### PR TITLE
Add test cases for replication filters

### DIFF
--- a/spec/api/api.yaml
+++ b/spec/api/api.yaml
@@ -99,6 +99,38 @@ paths:
           $ref: '#/components/responses/Error'
         '405':
           description: Operation Not Allowed
+  /updateDatabase:
+    post:
+      tags:
+        - API
+      summary: Update documents in the database.
+      description: |-
+        Perform document updates in batch, including save (create or update), delete and purge documents in the database.
+      operationId: updateDatabase
+      requestBody:
+        description: |-
+          The request object containing document update items that will be performed in batch.
+        content:
+          application/json:
+            schema:
+              type: object
+              required: ['database', 'updates']
+              properties:
+                database:
+                  type: string
+                  example: 'db1'
+                updates:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/DatabaseUpdateItem'
+        required: true
+      responses:
+        '200':
+          description: Success
+        '400':
+          $ref: '#/components/responses/Error'
+        '405':
+          description: Operation Not Allowed
   /startReplicator:
     post:
       tags:
@@ -184,6 +216,24 @@ components:
           type: string
       example: { 'catalog.cloths': ['c001', 'c002'], 
                  'catalog.shoes': ['s001', 's002', 's003']}
+    DatabaseUpdateItem:
+      type: object
+      required: ['type', 'collection', 'documentID']
+      properties:
+        type: 
+          type: string
+          enum: ['UPDATE', 'DELETE', 'PURGE']
+          example: 'UPDATE'
+        collection:
+          type: string
+          example: 'store.cloths'
+        documentID:
+          type: string
+          example: 'doc1'
+        properties:
+          type: object
+          additionalProperties: { }
+          example: {'name': 'Cool Sport Tech Fleece Shirt'}
     Error:
       type: object
       required: ['domain', 'code']
@@ -278,6 +328,19 @@ components:
           items:
             type: string
           example: ['doc1', 'doc2']
+        pushFilter:
+          $ref: '#/components/schemas/ReplicationFilter'
+    ReplicationFilter:
+      type: object
+      required: ['name']
+      properties:
+        name:
+          type: string
+          example: 'documentIDs'
+        params:
+          type: object
+          additionalProperties: { }
+          example: { 'documentIDs': ['doc1', 'doc2'] }
     ReplicatorStatus:
       type: object
       required: ['activity', 'progress']
@@ -287,10 +350,14 @@ components:
           enum: ['STOPPED', 'OFFLINE', 'CONNECTING', 'IDLE', 'BUSY']
         progress:
           type: object
+          required: ['complete', 'documentCount']
           properties:
             complete:
               type: number
-              format: document
+              format: double
+            documentCount:
+              type: number
+              format: int64
         error:
           $ref: '#/components/schemas/Error'
     ResetConfiguration:

--- a/spec/api/api.yaml
+++ b/spec/api/api.yaml
@@ -105,7 +105,8 @@ paths:
         - API
       summary: Update documents in the database.
       description: |-
-        Perform document updates in batch, including save (create or update), delete and purge documents in the database.
+        Perform document updates in batch. The request body contains an array of DatabaseUpdateItem object which describes how documents are updated, deleted or purged.
+        For updating a document, the changes to the document are specified as delta in updatedProperties and removedProperties key of the DatabaseUpdateItem.
       operationId: updateDatabase
       requestBody:
         description: |-
@@ -216,6 +217,24 @@ components:
           type: string
       example: { 'catalog.cloths': ['c001', 'c002'], 
                  'catalog.shoes': ['s001', 's002', 's003']}
+    DocumentReplication:
+      type: object
+      properties:
+        collection:
+          type: string
+          example: 'store.cloths'
+        documentID:
+          type: string
+          example: 'doc1'
+        isPush: 
+          type: boolean
+          example: true
+        flags: 
+          type: integer
+          format: int32
+          example: 2
+        error:
+          $ref: '#/components/schemas/Error'
     DatabaseUpdateItem:
       type: object
       required: ['type', 'collection', 'documentID']
@@ -230,10 +249,14 @@ components:
         documentID:
           type: string
           example: 'doc1'
-        properties:
+        updatedProperties:
           type: object
           additionalProperties: { }
           example: {'name': 'Cool Sport Tech Fleece Shirt'}
+        removedProperties:
+          type: object
+          additionalProperties: { }
+          example: {'vendor': {'info': null}}
     Error:
       type: object
       required: ['domain', 'code']
@@ -358,6 +381,10 @@ components:
             documentCount:
               type: number
               format: int64
+        documents:
+          type: array
+          items:
+            $ref: '#/components/schemas/DocumentReplication'
         error:
           $ref: '#/components/schemas/Error'
     ResetConfiguration:

--- a/spec/tests/000-dataset.md
+++ b/spec/tests/000-dataset.md
@@ -14,13 +14,13 @@
 
 ### SG Dataset
 
-| Collections         | #Docs       | #Size (bytes) |
-| :------------------ | ----------- | ------------- |
-| inventory.airline   | 0           | 0             |
-| inventory.route     | 0           | 0             |
-| inventory.airport   | 1960        | 455K          |
-| inventory.landmark  | 4490        | 2.86M         |
-| inventory.hotel     | 459         | TBD           |
+| Collections         | #Docs       | #Size (bytes) | Channels |
+| :------------------ | ----------- | ------------- |----------
+| inventory.airline   | 0           | 0             | country ("United States", "United Kingdom", "France") |
+| inventory.route     | 0           | 0             | 
+| inventory.airport   | 1960        | 455K          | country ("United States", "United Kingdom", "France") |
+| inventory.landmark  | 4490        | 2.86M         | country ("United States", "United Kingdom", "France") |
+| inventory.hotel     | 459         | TBD           | country ("United States", "United Kingdom", "France") |
 
 Note: the documents in the `inventory.hotel` collections of CBL and SG will have different document IDs.
 

--- a/spec/tests/002-replication-filter.md
+++ b/spec/tests/002-replication-filter.md
@@ -43,7 +43,7 @@ Test that the replicator will push only the docs specified in the document ids f
          * documentIDs : `route_10000`, `route_10001`
     * endpoint: `/travel-sample-inventory`
     * type: push
-    * continuos: false
+    * continuous: false
 3. Wait until the replicator is stopped.
 4. Check that only docs specified in the documentIDs filters are replicated except `inventory.airline`.`airline_1x`
 5. Update docs in the local database (NEED_API)
@@ -70,7 +70,7 @@ Test that the replicator will pull only the docs specified in the document ids f
          * documentIDs : `landmark_10019`, `landmark_10156`
     * endpoint: `/travel-sample-inventory`
     * type: pull
-    * continuos: false
+    * continuous: false
 3. Wait until the replicator is stopped.
 4. Check that only docs specified in the documentIDs filters are replicated except `inventory.airport`.`airport_1x`.
 5. Update docs on SG
@@ -97,7 +97,7 @@ Test that the replicator will pull only the docs specified in the channels filte
          * channels : `France`
     * endpoint: `/travel-sample-inventory`
     * type: pull
-    * continuos: false
+    * continuous: false
 3. Wait until the replicator is stopped.
 4. Check that only docs in the specified channels are pulled.
 5. Update docs on SG
@@ -121,14 +121,14 @@ Test that the replicator will push only the docs that are passed from the push f
       * `inventory.airline`
          * pushFilter:
             * name: `documentIDs`
-            * params: `{ "documentIDs": { "inventory.airline": "airline_10", "airline_22", "airline_1x"} }`
+            * params: `{ "documentIDs": ["airline_10", "airline_22", "airline_1x"] }`
       * `inventory.route`
          * pushFilter:  
             * name: `deletedDocumentsOnly`
             * params: `{}`
     * endpoint: `/travel-sample-inventory`
     * type: push
-    * continuos: false
+    * continuous: false
 3. Wait until the replicator is stopped.
 4. Check that only docs passed the push filters are replicated.
 5. Update docs in the local database (NEED_API)
@@ -152,14 +152,14 @@ Test that the replicator will pull only the docs that are passed from the pull f
       * `inventory.airport`
          * pullFilter:
             * name: `documentIDs`  
-            * params : `{ "documentIDs": {"inventory.airport": "airport_1254", "airport_1260", "airport_1x"} }`
+            * params : `{ "documentIDs": ["airport_1254", "airport_1260", "airport_1x"] }`
       * `inventory.landmark`
          * pullFilter:  
             * name: `deletedDocumentsOnly`
             * params: `{}`
     * endpoint: `/travel-sample-inventory`
     * type: pull
-    * continuos: false
+    * continuous: false
 3. Wait until the replicator is stopped.
 4. Check that only docs passed the pull filters are replicated.
 5. Update docs on SG

--- a/spec/tests/002-replication-filter.md
+++ b/spec/tests/002-replication-filter.md
@@ -1,0 +1,170 @@
+# Custom Filters
+
+{Need API Update}
+
+These are the list of the predefined custom push/pull filters used in the test cases.
+
+### documentIDs
+
+The filter that only allows the specified document IDs the to pass.
+
+**name** : `documentIDs`
+
+**params** :
+
+| Key        | Value       |
+| :--------- | ----------- |
+| documentIDs| `{ <collection-name> : [Array of document-ids>]` |
+
+## deletedDocumentsOnly
+
+The filter that only allows only deleted documents to pass.
+
+**name** : `deletedDocumentsOnly`
+
+**params** : `None`
+
+# Test Cases
+
+## test_push_document_ids_filter
+
+### Description
+
+Test that the replicator will push only the docs specified in the document ids filter.
+
+### Steps
+
+1. Load `travel-sample` dataset into a database.
+2. Start a replicator: 
+    * collections : 
+      * `inventory.airline`
+         * documentIDs : `airline_10`, `airline_22`, `airline_1x`
+      * `inventory.route`
+         * documentIDs : `route_10000`, `route_10001`
+    * endpoint: `/travel-sample-inventory`
+    * type: push
+    * continuos: false
+3. Wait until the replicator is stopped.
+4. Check that only docs specified in the documentIDs filters are replicated except `inventory.airline`.`airline_1x`
+5. Update docs in the local database (NEED_API)
+   * Add `airline_1x` and `airline_2x` in `inventory.airline`
+   * Update `airline_10`, `airline_22`, `airline_210` in `inventory.airline`
+   * Remove `route_10000`, `route_10001`, and `route_10010` in `inventory.route`
+6. Start the replicator with the same config as the step 2.
+7. Check that only docs specified in the documentIDs filters are replicated.
+
+## test_pull_document_ids_filter
+
+### Description
+
+Test that the replicator will pull only the docs specified in the document ids filter.
+
+### Steps
+
+1. Load `travel-sample` dataset into a database.
+2. Start a replicator: 
+    * collections : 
+      * `inventory.airport`
+         * documentIDs : `airport_1254`, `airport_1260`, `airport_1x`
+      * `inventory.landmark`
+         * documentIDs : `landmark_10019`, `landmark_10156`
+    * endpoint: `/travel-sample-inventory`
+    * type: pull
+    * continuos: false
+3. Wait until the replicator is stopped.
+4. Check that only docs specified in the documentIDs filters are replicated except `inventory.airport`.`airport_1x`.
+5. Update docs on SG
+   * Add `airport_1x` and `airport_2x` in `inventory.airport`
+   * Update `airport_1254`, `airport_1260`, `airport_1280` in `inventory.airport`
+   * Remove `landmark_10019`, `landmark_10156`, and `landmark_10622` in `inventory.landmark`
+6. Start the replicator with the same config as the step 2.
+7. Check that only docs specified in the documentIDs filters are replicated.
+
+## test_pull_channels_filter
+
+### Description
+
+Test that the replicator will pull only the docs specified in the channels filter.
+
+### Steps
+
+1. Load `travel-sample` dataset into a database.
+2. Start a replicator: 
+    * collections : 
+      * `inventory.airport`
+         * channels : `United States`, `France`
+      * `inventory.landmark`
+         * channels : `France`
+    * endpoint: `/travel-sample-inventory`
+    * type: pull
+    * continuos: false
+3. Wait until the replicator is stopped.
+4. Check that only docs in the specified channels are pulled.
+5. Update docs on SG
+   * Add `airport_1x` (United States), `airport_2x` (France) and `airport_3x` (United Kingdom) in `inventory.airport`
+   * Update `airport_3411` (United States), `airport_1254` (France), `airport_4346` (United Kingdom) in `inventory.airport`
+   * Remove `landmark_10144` (United States), `landmark_1006` (France) in `inventory.landmark`
+6. Start the replicator with the same config as the step 2.
+7. Check that only docs in the channels filters are replicated.
+
+## test_custom_push_filter
+
+### Description
+
+Test that the replicator will push only the docs that are passed from the push filter function.
+
+### Steps
+
+1. Load `travel-sample` dataset into a database.
+2. Start a replicator: 
+    * collections : 
+      * `inventory.airline`
+         * pushFilter:
+            * name: `documentIDs`
+            * params: `{ "documentIDs": { "inventory.airline": "airline_10", "airline_22", "airline_1x"} }`
+      * `inventory.route`
+         * pushFilter:  
+            * name: `deletedDocumentsOnly`
+            * params: `{}`
+    * endpoint: `/travel-sample-inventory`
+    * type: push
+    * continuos: false
+3. Wait until the replicator is stopped.
+4. Check that only docs passed the push filters are replicated.
+5. Update docs in the local database (NEED_API)
+   * Add `airline_1x` and `airline_2x` in `inventory.airline`
+   * Update `airline_10`, `airline_22`, `airline_210` in `inventory.airline`
+   * Remove `route_10000`, `route_10001`, and `route_10010` in `inventory.route`
+6. Start the replicator with the same config as the step 2.
+7. Check that only changes passed the push filters are replicated.
+
+## test_custom_pull_filter
+
+### Description
+
+Test that the replicator will pull only the docs that are passed from the pull filter function.
+
+### Steps
+
+1. Load `travel-sample` dataset into a database.
+2. Start a replicator: 
+    * collections : 
+      * `inventory.airport`
+         * pullFilter:
+            * name: `documentIDs`  
+            * params : `{ "documentIDs": {"inventory.airport": "airport_1254", "airport_1260", "airport_1x"} }`
+      * `inventory.landmark`
+         * pullFilter:  
+            * name: `deletedDocumentsOnly`
+            * params: `{}`
+    * endpoint: `/travel-sample-inventory`
+    * type: pull
+    * continuos: false
+3. Wait until the replicator is stopped.
+4. Check that only docs passed the pull filters are replicated.
+5. Update docs on SG
+   * Add `airport_1x` and `airport_2x` in `inventory.airport`
+   * Update `airport_1254`, `airport_1260`, `airport_1280` in `inventory.airport`
+   * Remove `landmark_10019`, `landmark_10156`, and `landmark_10622` in `inventory.landmark`
+6. Start the replicator with the same config as the step 2.
+7. Check that only changes passed the pull filters are replicated.


### PR DESCRIPTION
* Added replication-filter test cases for documentIDs, channels, pushFilter, and pullFilter.
* Updated travel-sample dataset to include info about channels 