### PR TITLE
C Server : Prepare for Android project

### DIFF
--- a/servers/c/src/CBLManager.h
+++ b/servers/c/src/CBLManager.h
@@ -2,7 +2,7 @@
 
 #include "CBLReplicationFilter.h"
 
-#include "CBLHeader.h"
+#include "support/CBLHeader.h"
 #include CBL_HEADER(CouchbaseLite.h)
 
 #include <mutex>

--- a/servers/c/src/CBLReplicationFilter.cpp
+++ b/servers/c/src/CBLReplicationFilter.cpp
@@ -2,7 +2,7 @@
 #include "support/Define.h"
 #include "support/JSON.h"
 
-#include "CBLHeader.h"
+#include "support/CBLHeader.h"
 #include CBL_HEADER(CouchbaseLite.h)
 
 #include <unordered_set>

--- a/servers/c/src/CollectionSpec.cpp
+++ b/servers/c/src/CollectionSpec.cpp
@@ -1,6 +1,6 @@
 #include "CollectionSpec.h"
 
-#include "CBLHeader.h"
+#include "support/CBLHeader.h"
 #include CBL_HEADER(CouchbaseLite.h)
 
 #include "support/Define.h"

--- a/servers/c/src/Dispatcher.cpp
+++ b/servers/c/src/Dispatcher.cpp
@@ -9,7 +9,7 @@ using namespace ts_support::exception;
 
 Dispatcher::Dispatcher(const TestServer *testServer) {
     _testServer = testServer;
-    _cblManager = make_unique<CBLManager>(_testServer->context()->databaseDir, _testServer->context()->assetDir);
+    _cblManager = make_unique<CBLManager>(_testServer->context().databaseDir, _testServer->context().assetsDir);
 
     addRule({"GET", "/", HANDLER(handleGETRoot)});
     addRule({"POST", "/reset", HANDLER(handlePOSTReset)});

--- a/servers/c/src/TestServer.cpp
+++ b/servers/c/src/TestServer.cpp
@@ -1,21 +1,48 @@
 #include "TestServer.h"
 #include <civetweb.h>
 #include <string>
+
+#ifdef __ANDROID__
+#include "support/Android.h"
+#endif
+
+#include "support/Exception.h"
+#include "support/Files.h"
 #include "support/UUID.h"
 
 using namespace std;
+using namespace ts_support;
+using namespace ts_support::exception;
+using namespace ts_support::files;
+
+#ifdef __ANDROID__
+using namespace ts_support::android;
+#endif
+
+TestServer::TestServer() {
+#ifdef __ANDROID__
+    CheckNotNull(androidContext(), "Android Context is not initialized");
+#endif
+    _context = {filesDir("CBL-C-TestServer", true), assetsDir()};
+    _dispatcher = new Dispatcher(this);
+}
+
+TestServer::~TestServer() {
+    stop();
+    delete _dispatcher;
+}
 
 void TestServer::start() {
     if (_server) {
         return;
     }
-    
+
     _uuid = ts_support::key::generateUUID();
 
     string port_str = to_string(PORT);
     const char *options[3] = {"listening_ports", port_str.c_str(), nullptr};
-
     _server = mg_start(nullptr, nullptr, options);
+    CheckNotNull(_server, "Cannot start server");
 
     mg_set_request_handler(_server, "/*", [](mg_connection *conn, void *context) -> int {
         auto server = static_cast<TestServer *>(context);
@@ -26,9 +53,10 @@ void TestServer::start() {
 void TestServer::stop() {
     if (_server) {
         mg_stop(_server);
+        _server = nullptr;
     }
 }
 
 int TestServer::handleRequest(mg_connection *conn) {
-    return _dispatcher.handle(conn);
+    return _dispatcher->handle(conn);
 }

--- a/servers/c/src/TestServer.h
+++ b/servers/c/src/TestServer.h
@@ -14,12 +14,18 @@ public:
 
     struct Context {
         std::string databaseDir;
-        std::string assetDir;
+        std::string assetsDir;
     };
 
-    explicit TestServer(Context context) : _context(std::move(context)), _dispatcher(this) {}
+    explicit TestServer();
 
-    [[nodiscard]] const Context *context() const { return &_context; }
+    ~TestServer();
+
+    TestServer(const TestServer &server) = delete;
+
+    TestServer &operator=(const TestServer &server) = delete;
+
+    [[nodiscard]] const Context &context() const { return _context; }
 
     [[nodiscard]] std::string serverUUID() const { return _uuid; }
 
@@ -31,7 +37,7 @@ private:
     int handleRequest(mg_connection *conn);
 
     Context _context;
+    Dispatcher *_dispatcher{nullptr};
     mg_context *_server{nullptr};
-    Dispatcher _dispatcher;
     std::string _uuid;
 };

--- a/servers/c/src/main.cpp
+++ b/servers/c/src/main.cpp
@@ -11,18 +11,24 @@ using namespace std;
 using namespace ts_support::files;
 
 int main() {
-    mg_init_library(0);
-    TestServer::Context context = {tempDir("CBL-C-TestServer", true), assetDir()};
-    TestServer server = TestServer(context);
-    server.start();
-    cout << "Using CBL C version " << CBLITE_VERSION << "-" << CBLITE_BUILD_NUMBER;
-#ifdef COUCHBASE_ENTERPRISE
-    cout << " (Enterprise)";
-#endif
-    cout << endl;
-    cout << "Listening on port " << TestServer::PORT << "..." << endl;
+    try {
+        mg_init_library(0);
 
-    while (true) {
-        std::this_thread::sleep_for(1s);
+        TestServer server = TestServer();
+        server.start();
+
+        cout << "Using CBL C version " << CBLITE_VERSION << "-" << CBLITE_BUILD_NUMBER;
+#ifdef COUCHBASE_ENTERPRISE
+        cout << " (Enterprise)";
+#endif
+        cout << endl;
+        cout << "Listening on port " << TestServer::PORT << "..." << endl;
+
+        while (true) {
+            std::this_thread::sleep_for(1s);
+        }
+    } catch (const exception &e) {
+        cerr << "Error: " << e.what() << endl;
+        return -1;
     }
 }

--- a/servers/c/src/support/Android.cpp
+++ b/servers/c/src/support/Android.cpp
@@ -1,0 +1,38 @@
+#ifdef __ANDROID__
+
+#include "Android.h"
+#include "Exception.h"
+
+#include "CBLHeader.h"
+#include CBL_HEADER(CouchbaseLite.h)
+
+#include <assert.h>
+
+using namespace ts_support::android;
+
+static AndroidContext sContext;
+
+void ts_support::android::initAndroidContext(const AndroidContext &context) {
+    assert(!context.filesDir.empty());
+    assert(!context.tempDir.empty());
+    assert(!context.assetsDir.empty());
+
+    sContext = context;
+
+    CBLInitContext init{
+            .filesDir = sContext.filesDir.c_str(),
+            .tempDir = sContext.tempDir.c_str()
+    };
+    CBLError err{};
+    CBL_Init(init, &err);
+    CheckError(err);
+}
+
+const AndroidContext *ts_support::android::androidContext() {
+    if (sContext.filesDir.empty()) {
+        return nullptr;
+    }
+    return &sContext;
+}
+
+#endif

--- a/servers/c/src/support/Android.h
+++ b/servers/c/src/support/Android.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#ifdef __ANDROID__
+
+#include <string>
+
+namespace ts_support::android {
+    struct AndroidContext {
+        std::string filesDir;
+        std::string tempDir;
+        std::string assetsDir;
+    };
+
+    void initAndroidContext(const AndroidContext &context);
+
+    const AndroidContext *androidContext();
+}
+
+#endif

--- a/servers/c/src/support/CBLHeader.h
+++ b/servers/c/src/support/CBLHeader.h
@@ -3,11 +3,10 @@
 #define STRINGIFY(X) STRINGIFY_(X)
 #define STRINGIFY_(X) #X
 
-// Thanks Apple, this sorcery is needed to use frameworks include paths
-// (i.e. CouchbaseLite/<path>) work as well as normal include paths
-// (i.e. cbl/<path> or fleece/<path>)
 #ifdef __APPLE__
+
 #include <TargetConditionals.h>
+
 #if !TARGET_OS_OSX
 #define CBL_HEADER(X) STRINGIFY(CouchbaseLite/X)
 #define FLEECE_HEADER(X) STRINGIFY(CouchbaseLite/X)

--- a/servers/c/src/support/Exception.h
+++ b/servers/c/src/support/Exception.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "../CBLHeader.h"
+#include "CBLHeader.h"
 #include CBL_HEADER(CBLBase.h)
 
 #include <exception>
@@ -30,6 +30,6 @@ static inline void CheckError(CBLError &error) {
     if (error.code > 0) { throw ts_support::exception::CBLException(error); }
 }
 
-static inline void CheckNotNull(void *obj, const string &message) {
+static inline void CheckNotNull(const void *obj, const string &message) {
     if (!obj) { throw runtime_error(message); }
 }

--- a/servers/c/src/support/Files+Apple.mm
+++ b/servers/c/src/support/Files+Apple.mm
@@ -7,7 +7,7 @@
 
 using namespace std;
 
-string ts_support::files::tempDir(const string &subdir, bool create) {
+string ts_support::files::filesDir(const std::string &subdir, bool create) {
     NSString *tempDir = NSTemporaryDirectory();
     if (!subdir.empty()) {
         NSString *sub = [NSString stringWithCString:subdir.c_str() encoding:NSUTF8StringEncoding];
@@ -19,7 +19,7 @@ string ts_support::files::tempDir(const string &subdir, bool create) {
     return tempDir.UTF8String;
 }
 
-string ts_support::files::assetDir() {
+string ts_support::files::assetsDir() {
     // TODO: The identifier should be passed into the function instead of hard coding the value here.
     auto bundle = CFBundleGetBundleWithIdentifier(CFSTR("com.couchbase.CBLTestServer"));
     if (bundle) {

--- a/servers/c/src/support/Files.cpp
+++ b/servers/c/src/support/Files.cpp
@@ -1,20 +1,27 @@
 #include "Files.h"
 
+#ifdef __ANDROID__
+#include "Android.h"
+#endif
+
 #include <string>
 #include <filesystem>
 
 using namespace std;
 
-string ts_support::files::tempDir(const string &subdir, bool create) {
 #ifdef __ANDROID__
-    // TODO:
-    return "";
+using namespace ts_support::android;
 #endif
 
+string ts_support::files::filesDir(const string &subdir, bool create) {
 #ifdef WIN32
     string dir = subdir.empty() ? "C:\\tmp" : "C:\\tmp\\" + subdir;
 #else
+#ifdef __ANDROID__
+    string dir = subdir.empty() ? androidContext()->filesDir : androidContext()->filesDir + "/" + subdir;
+#else
     string dir = subdir.empty() ? "/tmp" : "/tmp/" + subdir;
+#endif
 #endif
 
     if (create) {
@@ -23,10 +30,9 @@ string ts_support::files::tempDir(const string &subdir, bool create) {
     return dir;
 }
 
-string ts_support::files::assetDir() {
+string ts_support::files::assetsDir() {
 #ifdef __ANDROID__
-    // TODO:
-    return "";
+    return androidContext()->assetsDir;
 #endif
     auto current = filesystem::current_path() / "assets";
     return current.generic_string();

--- a/servers/c/src/support/Files.h
+++ b/servers/c/src/support/Files.h
@@ -3,7 +3,7 @@
 #include <string>
 
 namespace ts_support::files {
-    std::string tempDir(const std::string &dir, bool create);
+    std::string filesDir(const std::string &subdir, bool create);
 
-    std::string assetDir();
+    std::string assetsDir();
 }

--- a/servers/c/src/support/Fleece.h
+++ b/servers/c/src/support/Fleece.h
@@ -1,15 +1,7 @@
 #pragma once
 
-#ifdef __APPLE__
-#include <TargetConditionals.h>
-#if !TARGET_OS_OSX
-#include "CouchbaseLite/Fleece.h"
-#else
-#include "fleece/Fleece.h"
-#endif
-#else
-#include "fleece/Fleece.h"
-#endif
+#include "CBLHeader.h"
+#include FLEECE_HEADER(Fleece.h)
 
 #include <nlohmann/json.hpp>
 


### PR DESCRIPTION
* Moved CBLHeader.h to support folder
* Added Android.h and cpp for setting Android Context and initializing CBL for Android
* Changed TestServer constructor to accept no parameters : the database and assets directory will be automatically determined.
* Supported Android in support/Files .
* Threw exception with cannot start civetweb server.
* Made TestServer non-copyable as it shouldn’t and no need to copy.