### PR TITLE
CBL-4977 : Wait for all indexes removed before recreating SG database

### DIFF
--- a/client/src/cbltest/utils.py
+++ b/client/src/cbltest/utils.py
@@ -1,0 +1,27 @@
+import time
+from typing import Any, Callable, Dict, Type, TypeVar, Union, cast
+
+from .api.error import CblTimeoutError
+
+T = TypeVar("T")
+
+def _try_n_times(num_times: int,
+                 seconds_between: Union[int, float],
+                 wait_before_first_try: bool,
+                 func: Callable,
+                 ret_type: Type[T],
+                 *args: Any,
+                 **kwargs: Dict[str, Any]) -> T:
+    for i in range(num_times):
+        try:
+            if i == 0 and wait_before_first_try:
+                time.sleep(seconds_between)
+            return cast(ret_type, func(*args, **kwargs))
+        except Exception as e:
+            if i < num_times - 1:
+                print(f"Trying {func.__name__} failed (reason='{e}'), retry in {seconds_between} seconds ...")
+                time.sleep(seconds_between)
+            else:
+                print(f"Trying {func.__name__} failed (reason='{e}')")
+
+    raise CblTimeoutError(f"Failed to call {func.__name__} after {num_times} attempts!")


### PR DESCRIPTION
The bucket's indexes will be deleted asynchronously after the bucket is dropped. When recreating the sg database, sg may wrongly detect that the indexes already exist, but later when trying to use the indexes for querying, the index-not-available error occurs as the index has already been deleted by that time.

Wait until all indexes are removed will help prevent the issue. It's important to wait after the bucket and its collections are created, otherwise, QueryIndexManager will not be able to return the pending-to-removed indexes created for the collections.