### PR TITLE
RemoteLogger open and close are synchronous

### DIFF
--- a/environment/LogSlurp/ClientLogger/Program.cs
+++ b/environment/LogSlurp/ClientLogger/Program.cs
@@ -9,6 +9,8 @@ const int Port = 5186;
 using var httpClient = new HttpClient();
 var log_id = Guid.NewGuid().ToString();
 var response = await httpClient.PostAsync($"http://localhost:{Port}/startNewLog", JsonContent.Create(new { log_id }));
+Console.WriteLine();
+Console.WriteLine("Session ID: " + log_id);
 
 var ws = new ClientWebSocket();
 ws.Options.SetRequestHeader("CBL-Log-ID", log_id);

--- a/environment/LogSlurp/README.md
+++ b/environment/LogSlurp/README.md
@@ -106,3 +106,13 @@ quit<br />
 <br />
 ==== Retrieved ====<br />
 ClientLogger: 2024-08-12 23:33:34,147 hello
+
+The client logger can be used to test the implementation of a logger.  Do this:
+- Start the log slurper
+- Start the client logger.  It will print the id of the session it started with the slurper
+- When the client logger loops asking for log messages let it sit
+- Run your logger implementation. Use the session id from the client logger and an arbitrary "tag"
+- Log a few things from your implementation.  Maybe type a couple of log messages at the client logger as well
+- When you have enough logs to validate your implementation, type "quit" at the client logger
+- The client logger will display the contents of the session, including the log messages you typed at it, along with the ones sent from your logger implementation, interleaved approprately.
+

--- a/jenkins/pipelines/android/Jenkinsfile
+++ b/jenkins/pipelines/android/Jenkinsfile
@@ -6,7 +6,7 @@ pipeline {
         string(name: 'CBL_BUILD', defaultValue: '', description: 'Couchbase Lite Build Number')
         string(name: 'SGW_URL', defaultValue: '', description: "The url of Sync Gateway to download")
     }
-    options { timeout(time: 30, unit: 'MINUTES') }
+    options { timeout(time: 60, unit: 'MINUTES') }
     stages {
         stage('Init') {
             steps {

--- a/jenkins/pipelines/java/Jenkinsfile
+++ b/jenkins/pipelines/java/Jenkinsfile
@@ -6,7 +6,7 @@ pipeline {
         string(name: 'CBL_BUILD', defaultValue: '', description: 'Couchbase Lite Build Number')
         string(name: 'SGW_URL', defaultValue: '', description: "The url of Sync Gateway to download")
     }
-    options { timeout(time: 60, unit: 'MINUTES') }
+    options { timeout(time: 120, unit: 'MINUTES') }
     stages {
         stage('Init') {
             steps {

--- a/jenkins/pipelines/java/desktop/win_tests.ps1
+++ b/jenkins/pipelines/java/desktop/win_tests.ps1
@@ -3,7 +3,7 @@ param (
     [string]$version,
 
     [Parameter(Mandatory=$true)]
-    [string]$buildNumber
+    [string]$buildNumber,
 
     [Parameter(Mandatory=$false)]
     [string]$sgUrl,


### PR DESCRIPTION
Longer timeouts for test runs (runs are timing out while still successful)
ClientLogger more useful for testing