### PR TITLE
Move env vars out out scripts and into Jenkinsfile for .NET

### DIFF
--- a/jenkins/pipelines/dotnet/Jenkinsfile
+++ b/jenkins/pipelines/dotnet/Jenkinsfile
@@ -26,6 +26,9 @@ pipeline {
             parallel {
                 stage("Windows") {
                     agent { label 'mob-e2e-win-01' }
+                    options {
+                        lock('mob-e2e-win-01')
+                    }
                     steps {
                         pwsh "jenkins\\pipelines\\dotnet\\test_winui.ps1 -Edition ${params.CBL_EDITION} -Version ${params.CBL_VERSION} -Build ${params.CBL_BUILD} -SgwUrl ${params.SGW_URL}"
                     }
@@ -37,12 +40,21 @@ pipeline {
                 }
                 stage("Mac Catalyst") {
                     agent { label 'mob-e2e-mac-01' }
+                    options {
+                        lock('mob-e2e-mac-01')
+                    }
+                    environment {
+                        KEYCHAIN_PASSWORD = credentials('mob-e2e-mac-01-keychain-password') 
+                        DEVELOPER_DIR="/Applications/Xcode-16.1.0.app"
+                        MD_APPLE_SDK_ROOT="/Applications/Xcode-16.1.0.app"
+                    }
                     steps {
-                        shell "jenkins\\pipelines\\dotnet\\test_mac.sh ${params.CBL_EDITION} ${params.CBL_VERSION} ${params.CBL_BUILD} ${params.SGW_URL}"
+                        sh 'security unlock-keychain -p ${KEYCHAIN_PASSWORD} ~/Library/Keychains/login.keychain-db'
+                        sh "jenkins\\pipelines\\dotnet\\test_mac.sh ${params.CBL_EDITION} ${params.CBL_VERSION} ${params.CBL_BUILD} ${params.SGW_URL}"
                     }
                     post { 
                         always { 
-                            shell 'jenkins\\pipelines\\dotnet\\teardown_mac.sh'
+                            sh 'jenkins\\pipelines\\dotnet\\teardown_mac.sh'
                         }
                     }
                 }
@@ -50,33 +62,36 @@ pipeline {
         }
         stage('iOS') {
             options {
-                lock("mob-e2e-iphone-01")
+                lock("mob-e2e-mac-01")
             }
             environment { 
                 KEYCHAIN_PASSWORD = credentials('mob-e2e-mac-01-keychain-password') 
                 IOS_TEST_SERVER_IP = "10.100.150.123"
+                DEVELOPER_DIR="/Applications/Xcode-16.1.0.app"
+                MD_APPLE_SDK_ROOT="/Applications/Xcode-16.1.0.app"
             }
             agent { label 'mob-e2e-mac-01' }
             steps {
-                shell "jenkins\\pipelines\\dotnet\\test_ios.sh ${params.CBL_EDITION} ${params.CBL_VERSION} ${params.CBL_BUILD} ${params.SGW_URL}"
+                sh 'security unlock-keychain -p ${KEYCHAIN_PASSWORD} ~/Library/Keychains/login.keychain-db'
+                sh "jenkins\\pipelines\\dotnet\\test_ios.sh ${params.CBL_EDITION} ${params.CBL_VERSION} ${params.CBL_BUILD} ${params.SGW_URL}"
             }
             post {
                 always {
-                    shell 'jenkins\\pipelines\\dotnet\\teardown_ios.sh'
+                    sh 'jenkins\\pipelines\\dotnet\\teardown_ios.sh'
                 }
             }
         }
         stage('Android') {
             options {
-                lock("mob-e2e-android-01")
+                lock("mob-e2e-mac-01")
             }
             agent { label 'mob-e2e-mac-01' }
             steps {
-                shell "jenkins\\pipelines\\dotnet\\test_android.sh ${params.CBL_EDITION} ${params.CBL_VERSION} ${params.CBL_BUILD} ${params.SGW_URL}"
+                sh "jenkins\\pipelines\\dotnet\\test_android.sh ${params.CBL_EDITION} ${params.CBL_VERSION} ${params.CBL_BUILD} ${params.SGW_URL}"
             }
             post {
                 always {
-                    shell 'jenkins\\pipelines\\dotnet\\teardown_android.sh'
+                    sh 'jenkins\\pipelines\\dotnet\\teardown_android.sh'
                 }
             }
         }

--- a/jenkins/pipelines/dotnet/build_ios.sh
+++ b/jenkins/pipelines/dotnet/build_ios.sh
@@ -5,8 +5,5 @@ source $SCRIPT_DIR/prepare_env.sh
 
 banner "Executing build for .NET $DOTNET_VERSION iOS"
 
-export DEVELOPER_DIR="/Applications/Xcode-16.1.0.app/"
-export MD_APPLE_SDK_ROOT=$DEVELOPER_DIR
 pushd $SCRIPT_DIR/../../../servers/dotnet/testserver
-security unlock-keychain -p $KEYCHAIN_PASSWORD
 $HOME/.dotnet/dotnet build -f net$DOTNET_VERSION-ios -c Release -p:RuntimeIdentifier=ios-arm64 -v n

--- a/jenkins/pipelines/dotnet/build_mac.sh
+++ b/jenkins/pipelines/dotnet/build_mac.sh
@@ -5,6 +5,5 @@ source $SCRIPT_DIR/prepare_env.sh
 
 banner "Executing build for .NET $DOTNET_VERSION Mac Catalyst"
 
-export DEVELOPER_DIR="/Applications/Xcode-16.0.0/"
 pushd $SCRIPT_DIR/../../../servers/dotnet/testserver
 $HOME/.dotnet/dotnet build -f net$DOTNET_VERSION-maccatalyst -c Release -v n


### PR DESCRIPTION
This makes them easier to centralize.  Also change shell to sh and put the Jenkins job in charge of unlocking the keychain since it's only relevant over SSH.