### PR TITLE
Use xcrun devicectl to manage iOS test app

### DIFF
--- a/jenkins/pipelines/ios/teardown.sh
+++ b/jenkins/pipelines/ios/teardown.sh
@@ -1,10 +1,13 @@
 #!/bin/bash -e
 
-echo "Shutdown Test Server"
-if [ -d "servers/ios/build" ]; then
-    pushd servers/ios/build > /dev/null
-    ios kill com.couchbase.CBLTestServer-iOS || true
-    popd > /dev/null
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+SHARED_DIR="${SCRIPT_DIR}/../shared"
+
+DEVICE_UDID="$("${SHARED_DIR}/ios_device.sh")"
+if [[ -n "${DEVICE_UDID}" ]]; then
+    echo "Device Found: ${DEVICE_UDID}"
+    echo "Shutdown Test Server"
+    "${SHARED_DIR}/ios_app.sh" stop "${DEVICE_UDID}" "com.couchbase.CBLTestServer-iOS"
 fi
 
 echo "Shutdown Environment"

--- a/jenkins/pipelines/ios/test.sh
+++ b/jenkins/pipelines/ios/test.sh
@@ -15,7 +15,7 @@ DEVICE_UDID="$("${SHARED_DIR}/ios_device.sh")"
 if [[ -z "${DEVICE_UDID}" ]]; then
     echo "No connected device found." && exit 1
 else
-    echo "Device Found: ${DEVICE_UDID}"
+    echo "Connected device found: ${DEVICE_UDID}"
 fi
 
 # Build Test Server App:

--- a/jenkins/pipelines/shared/ios_app.sh
+++ b/jenkins/pipelines/shared/ios_app.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+if [ "$#" -lt 3 ]; then
+    echo "Usage: $0 <ACTION>  <DEVICE_UDID> <APP_PATH_OR_BUNDLE_ID>"
+    echo "Actions:" 
+    echo "  start <DEVICE_UDID> <APP-PATH> : Install and launch the app"
+    echo "  stop <DEVICE_UDID> <APP-BUNDLE-ID>  : Terminate the app"
+    exit 1
+fi
+
+ACTION=${1}
+UDID=${2}
+APP_OR_BUNDLE_ID=${3}
+
+# Function to get the app's executable path based on the bundle ID
+get_exe_path() {
+    local DEVICE_UDID=${1}
+    local BUNDLE_ID=${2}
+    APP_PATH_OUTPUT=$(xcrun devicectl device info apps --device "${DEVICE_UDID}" --bundle-id "${BUNDLE_ID}" --hide-headers --hide-default-columns --columns path)
+
+    # Extract the line after "Apps installed:"
+    local EXE_PATH
+    EXE_PATH=$(echo "${APP_PATH_OUTPUT}" | awk '/Apps installed:/{getline; print}')
+    echo "${EXE_PATH}"
+}
+
+# Function to get the PID of the running app based on the app path
+get_pid() {
+    local DEVICE_UDID=${1}
+    local APP_PATH=${2}
+    local PID
+    PID=$(xcrun devicectl device info processes --device "${DEVICE_UDID}" | grep "${APP_PATH}" | awk '{print $1}')
+    echo "${PID}"
+}
+
+# Start action: install and launch the app
+if [ "${ACTION}" == "start" ]; then
+    # The second parameter is the app path
+    APP_PATH=${APP_OR_BUNDLE_ID}
+
+    # Get the absolute path of APP_PATH
+    APP_PATH=$(realpath "${APP_PATH}")
+
+    # Get the app's bundle identifier
+    BUNDLE_ID=$(defaults read "${APP_PATH}/Info.plist" CFBundleIdentifier)
+    if [ -z "${BUNDLE_ID}" ]; then
+        echo "Failed to read CFBundleIdentifier from ${APP_PATH}."
+        exit 1
+    fi
+
+    # Install the app on the connected device
+    echo "Installing the app..."
+    xcrun devicectl device install app --device "${UDID}" "${APP_PATH}"
+
+    # Launch the app
+    echo "Launching the app with bundle ID: ${BUNDLE_ID}..."
+    xcrun devicectl device process launch --device "${UDID}" "${BUNDLE_ID}"
+
+# Stop action: terminate the app
+elif [ "${ACTION}" == "stop" ]; then
+    # The second parameter is the app bundle ID
+    BUNDLE_ID=${APP_OR_BUNDLE_ID}
+
+    # Get the app's path to find its PID
+    EXE_PATH=$(get_exe_path "${UDID}" "${BUNDLE_ID}")
+    if [ -z "${EXE_PATH}" ]; then
+        echo "App is not installed on the device. Nothing to terminate"
+        exit 0
+    fi
+
+    # Terminate the app if it's running
+    PID=$(get_pid "${UDID}" "${EXE_PATH}")
+    if [ -n "${PID}" ]; then
+        echo "Terminating the app with PID: ${PID}..."
+        xcrun devicectl device process terminate --device "${UDID}" --pid "${PID}"
+    else
+        echo "App is not running. Nothing to terminate."
+    fi
+
+else
+    echo "Invalid action."
+    exit 1
+fi

--- a/jenkins/pipelines/shared/ios_device.sh
+++ b/jenkins/pipelines/shared/ios_device.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Check for the optional 'all' argument
+output_all=false
+if [[ "$1" == "all" ]]; then
+    output_all=true
+fi
+
+# Get the list of connected devices
+device_list=$(xcrun devicectl list devices --hide-default-columns --hide-headers --columns state udid | grep 'connected')
+
+# Check if there are any connected devices
+if [[ -z "$device_list" ]]; then
+    exit 0
+fi
+
+# Output based on whether 'all' option is provided
+if $output_all; then
+    # Print all connected UDIDs
+    echo "$device_list" | awk '{print $2}'
+else
+    # Print only the first connected UDID
+    first_connected_udid=$(echo "$device_list" | head -n 1 | awk '{print $2}')
+    echo "$first_connected_udid"
+fi


### PR DESCRIPTION
* Added `ios_app.sh` for starting and stopping iOS Test Server in the shared pipeline folder.
* Added `ios_device.sh` for getting a connected iOS device's UDID in the shared pipeline folder.
* Updated iOS pipeline use the scripts. 