### PR TITLE
Various fixes for three CBL tickets

### DIFF
--- a/.github/workflows/verify_python.sh
+++ b/.github/workflows/verify_python.sh
@@ -5,6 +5,7 @@ source venv/bin/activate
 pip install mypy
 pip install pytest
 pip install types-requests
+pip install types-Deprecated
 pip install ./client
 echo "Checking tests files..."
 python -m mypy tests --exclude=venv --ignore-missing-imports

--- a/client/src/cbltest/api/syncgateway.py
+++ b/client/src/cbltest/api/syncgateway.py
@@ -400,7 +400,7 @@ class SyncGateway:
         :param db_name: The name of the Database to delete
         """
         with self.__tracer.start_as_current_span("delete_database", attributes={"cbl.database.name": db_name}):
-            await self._send_request("delete", f"/{db_name}")
+            await self._send_request("delete", f"/{db_name}/")
 
     def create_collection_access_dict(self, input: Dict[str, List[str]]) -> dict:
         """

--- a/client/src/cbltest/utils.py
+++ b/client/src/cbltest/utils.py
@@ -1,5 +1,5 @@
 import time
-from typing import Any, Callable, Dict, TypeVar, Type, Union
+from typing import Any, Callable, Dict, TypeVar, Type, Union, Optional, cast
 
 from .api.error import CblTimeoutError
 
@@ -27,3 +27,7 @@ def _try_n_times(num_times: int,
                 print(f"Trying {func.__name__} failed (reason='{e}')")
 
     raise CblTimeoutError(f"Failed to call {func.__name__} after {num_times} attempts!")
+
+def assert_not_null(input: Optional[T], msg: str) -> T:
+    assert input is not None, msg
+    return cast(T, input)

--- a/environment/sg/Dockerfile
+++ b/environment/sg/Dockerfile
@@ -4,9 +4,6 @@ SHELL ["/bin/bash", "-c"]
 RUN apt -yqq update 
 RUN apt -yqq install curl systemctl
 RUN mkdir -p /opt/sg
-COPY cert /opt/sg/cert
-COPY config /opt/sg/config
-COPY start-sgw.sh /opt/sg
 
 ARG SG_DEB
 RUN [ -z "$SG_DEB" ] && echo "SG_DEB is required" && exit 1 || true
@@ -20,9 +17,12 @@ RUN ARCHITECTURE="$(dpkg --print-architecture)" && \
         exit 1; \
     fi
 
-WORKDIR /opt/sg
-RUN dpkg -i ./couchbase-sync-gateway.deb
+RUN dpkg -i /opt/sg/couchbase-sync-gateway.deb
+COPY cert /opt/sg/cert
+COPY config /opt/sg/config
+COPY start-sgw.sh /opt/sg
 
+WORKDIR /opt/sg
 EXPOSE 4984
 EXPOSE 4985
 

--- a/environment/sg/config/bootstrap-nonssl.json
+++ b/environment/sg/config/bootstrap-nonssl.json
@@ -15,6 +15,14 @@
       "enabled": true,
       "log_level": "info",
       "log_keys": ["*"]
+    },
+    "log_file_path": "/opt/sg/log",
+    "debug": {
+      "enabled": true,
+      "rotation": {
+        "max_size": 512,
+        "rotated_logs_size_limit": 1024
+      }
     }
   } 
 }

--- a/environment/sg/config/bootstrap.json
+++ b/environment/sg/config/bootstrap.json
@@ -19,6 +19,14 @@
       "enabled": true,
       "log_level": "info",
       "log_keys": ["*"]
+    },
+    "log_file_path": "/opt/sg/log",
+    "debug": {
+      "enabled": true,
+      "rotation": {
+        "max_size": 512,
+        "rotated_logs_size_limit": 1024
+      }
     }
   } 
 }

--- a/servers/dotnet/testserver.logic/Handlers/NewSessionHandler.cs
+++ b/servers/dotnet/testserver.logic/Handlers/NewSessionHandler.cs
@@ -91,6 +91,7 @@ internal static partial class HandlerList
         }
 
         Log.Logger = new LoggerConfiguration()
+            .MinimumLevel.Verbose()
             .WriteTo.Logger(Original)
             .WriteTo.LogSlurp(newSessionBody.logging.url, newSessionBody.id, newSessionBody.logging.tag)
             .CreateLogger();

--- a/servers/dotnet/testserver/MauiProgram.cs
+++ b/servers/dotnet/testserver/MauiProgram.cs
@@ -29,7 +29,7 @@ public static class MauiProgram
 
 		LogFilePath = $"{Path.GetTempFileName()}.txt";
 		var logConfig = new LoggerConfiguration()
-			.MinimumLevel.Debug()
+			.MinimumLevel.Verbose()
 			.WriteTo.File(LogFilePath)
 			.WriteTo.Console(restrictedToMinimumLevel: LogEventLevel.Warning);
 

--- a/servers/dotnet/testserver/testserver.csproj
+++ b/servers/dotnet/testserver/testserver.csproj
@@ -42,6 +42,8 @@
 		<UseInterpreter Condition="$(TargetFramework.Contains('-ios'))">true</UseInterpreter>
 		<RuntimeIdentifiers Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">android-arm64;android-arm</RuntimeIdentifiers>
 		<RuntimeIdentifier Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">maccatalyst-x64</RuntimeIdentifier>
+
+        <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/tests/test_basic_replication.py
+++ b/tests/test_basic_replication.py
@@ -325,7 +325,7 @@ class TestBasicReplication(CBLTestClass):
         hotels_all_docs = await cblpytest.sync_gateways[0].get_all_documents("travel", "travel", "hotels")
         for doc in hotels_all_docs.rows:
             if doc.id == "hotel_400" or doc.id == "hotel_500":
-                await cblpytest.sync_gateways[0].delete_document(doc.id, doc.revision, "travel", "travel", "hotels")
+                await cblpytest.sync_gateways[0].delete_document(doc.id, doc.revid, "travel", "travel", "hotels")
 
         self.mark_test_step("Wait until receiving all document replication events")
         await replicator.wait_for_all_doc_events({
@@ -459,7 +459,7 @@ class TestBasicReplication(CBLTestClass):
         hotels_all_docs = await cblpytest.sync_gateways[0].get_all_documents("travel", "travel", "hotels")
         for doc in hotels_all_docs.rows:
             if doc.id == "hotel_400" or doc.id == "hotel_500":
-                await cblpytest.sync_gateways[0].delete_document(doc.id, doc.revision, "travel", "travel", "hotels")
+                await cblpytest.sync_gateways[0].delete_document(doc.id, doc.revid, "travel", "travel", "hotels")
 
         self.mark_test_step("Wait until receiving all document replication events")
         await replicator.wait_for_all_doc_events({

--- a/tests/test_basic_replication.py
+++ b/tests/test_basic_replication.py
@@ -12,6 +12,7 @@ from cbltest.api.replicator import Replicator, ReplicatorType, ReplicatorCollect
 from cbltest.api.replicator_types import ReplicatorBasicAuthenticator, ReplicatorDocumentFlags
 from cbltest.api.syncgateway import DocumentUpdateEntry
 from cbltest.api.test_functions import compare_local_and_remote
+from cbltest.utils import assert_not_null
 
 
 class TestBasicReplication(CBLTestClass):
@@ -325,7 +326,8 @@ class TestBasicReplication(CBLTestClass):
         hotels_all_docs = await cblpytest.sync_gateways[0].get_all_documents("travel", "travel", "hotels")
         for doc in hotels_all_docs.rows:
             if doc.id == "hotel_400" or doc.id == "hotel_500":
-                await cblpytest.sync_gateways[0].delete_document(doc.id, doc.revid, "travel", "travel", "hotels")
+                revid = assert_not_null(doc.revid, f"Missing revid on {doc.id}")
+                await cblpytest.sync_gateways[0].delete_document(doc.id, revid, "travel", "travel", "hotels")
 
         self.mark_test_step("Wait until receiving all document replication events")
         await replicator.wait_for_all_doc_events({
@@ -459,7 +461,8 @@ class TestBasicReplication(CBLTestClass):
         hotels_all_docs = await cblpytest.sync_gateways[0].get_all_documents("travel", "travel", "hotels")
         for doc in hotels_all_docs.rows:
             if doc.id == "hotel_400" or doc.id == "hotel_500":
-                await cblpytest.sync_gateways[0].delete_document(doc.id, doc.revid, "travel", "travel", "hotels")
+                revid = assert_not_null(doc.revid, f"Missing revid on {doc.id}")
+                await cblpytest.sync_gateways[0].delete_document(doc.id, revid, "travel", "travel", "hotels")
 
         self.mark_test_step("Wait until receiving all document replication events")
         await replicator.wait_for_all_doc_events({

--- a/tests/test_replication_behavior.py
+++ b/tests/test_replication_behavior.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from cbltest import CBLPyTest
+from cbltest.utils import assert_not_null
 from cbltest.api.cloud import CouchbaseCloud
 from cbltest.api.replicator import Replicator
 from cbltest.api.replicator_types import ReplicatorCollectionEntry, ReplicatorType, \
@@ -19,7 +20,8 @@ class TestReplicationBehavior(CBLTestClass):
         for row in all_docs.rows:
             name_number = int(row.id[-3:])
             if name_number <= 150:
-                await cblpytest.sync_gateways[0].delete_document(row.id, row.revid, "names")
+                revid = assert_not_null(row.revid, f"Missing revid on {row.id}")
+                await cblpytest.sync_gateways[0].delete_document(row.id, revid, "names")
 
         self.mark_test_step("Reset local database, and load `empty` dataset")
         dbs = await cblpytest.test_servers[0].create_and_reset_db(["db1"])

--- a/tests/test_replication_behavior.py
+++ b/tests/test_replication_behavior.py
@@ -19,7 +19,7 @@ class TestReplicationBehavior(CBLTestClass):
         for row in all_docs.rows:
             name_number = int(row.id[-3:])
             if name_number <= 150:
-                await cblpytest.sync_gateways[0].delete_document(row.id, row.revision, "names")
+                await cblpytest.sync_gateways[0].delete_document(row.id, row.revid, "names")
 
         self.mark_test_step("Reset local database, and load `empty` dataset")
         dbs = await cblpytest.test_servers[0].create_and_reset_db(["db1"])

--- a/tests/test_replication_blob.py
+++ b/tests/test_replication_blob.py
@@ -2,12 +2,13 @@ from pathlib import Path
 from typing import List
 import pytest
 from cbltest import CBLPyTest
+from cbltest.utils import assert_not_null
 from cbltest.api.cloud import CouchbaseCloud
 from cbltest.api.database import SnapshotUpdater
 from cbltest.api.database_types import MaintenanceType, DocumentEntry
 from cbltest.api.replicator import Replicator, ReplicatorType, ReplicatorCollectionEntry, ReplicatorActivityLevel
 from cbltest.api.replicator_types import ReplicatorBasicAuthenticator
-from cbltest.api.syncgateway import DocumentUpdateEntry
+from cbltest.api.syncgateway import DocumentUpdateEntry, RemoteDocument
 from cbltest.api.test_functions import compare_local_and_remote
 from cbltest.api.cbltestclass import CBLTestClass
 
@@ -49,7 +50,8 @@ class TestReplicationBlob(CBLTestClass):
                                  ["travel.hotels"])
         
         self.mark_test_step("Update hotel_1 on SG without changing the image key.")
-        hotel_1 = await cblpytest.sync_gateways[0].get_document("travel", "hotel_1", "travel", "hotels")
+        hotel_1 = assert_not_null(await cblpytest.sync_gateways[0].get_document("travel", "hotel_1", "travel", "hotels"),
+                                  "hotel_1 vanished from SGW")
         hotels_updates: List[DocumentUpdateEntry] = []
         hotels_updates.append(DocumentUpdateEntry("hotel_1", hotel_1.revision, body={
             "_attachments": {
@@ -86,7 +88,8 @@ class TestReplicationBlob(CBLTestClass):
                                        ["travel.hotels"])
         
         self.mark_test_step("Update hotel_1 on SG again without changing the image key.")
-        hotel_1 = await cblpytest.sync_gateways[0].get_document("travel", "hotel_1", "travel", "hotels")
+        hotel_1 = assert_not_null(await cblpytest.sync_gateways[0].get_document("travel", "hotel_1", "travel", "hotels"),
+                                  "hotel_1 vanished from SGW")
         hotels_updates = []
         hotels_updates.append(DocumentUpdateEntry("hotel_1", hotel_1.revision, body={
             "_attachments": {

--- a/tests/test_replication_blob.py
+++ b/tests/test_replication_blob.py
@@ -14,6 +14,7 @@ from cbltest.api.cbltestclass import CBLTestClass
 class TestReplicationBlob(CBLTestClass):
     @pytest.mark.cbse(14861)
     @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.skip(reason="CBG-4389")
     async def test_pull_non_blob_changes_with_delta_sync_and_compact(self, cblpytest: CBLPyTest, dataset_path: Path):
         self.mark_test_step("Reset SG and load `travel` dataset with delta sync enabled.")
         cloud = CouchbaseCloud(cblpytest.sync_gateways[0], cblpytest.couchbase_servers[0])
@@ -48,8 +49,9 @@ class TestReplicationBlob(CBLTestClass):
                                  ["travel.hotels"])
         
         self.mark_test_step("Update hotel_1 on SG without changing the image key.")
+        hotel_1 = await cblpytest.sync_gateways[0].get_document("travel", "hotel_1", "travel", "hotels")
         hotels_updates: List[DocumentUpdateEntry] = []
-        hotels_updates.append(DocumentUpdateEntry("hotel_1", "1-2888d379591e42370912510ae8e8a976e1bf6436", body={
+        hotels_updates.append(DocumentUpdateEntry("hotel_1", hotel_1.revision, body={
             "_attachments": {
                 "blob_/image": {
                     "content_type": "image/png",
@@ -84,8 +86,9 @@ class TestReplicationBlob(CBLTestClass):
                                        ["travel.hotels"])
         
         self.mark_test_step("Update hotel_1 on SG again without changing the image key.")
+        hotel_1 = await cblpytest.sync_gateways[0].get_document("travel", "hotel_1", "travel", "hotels")
         hotels_updates = []
-        hotels_updates.append(DocumentUpdateEntry("hotel_1", "2-9a718e02f5e5aa1aa90bdbb25072d258", body={
+        hotels_updates.append(DocumentUpdateEntry("hotel_1", hotel_1.revision, body={
             "_attachments": {
                 "blob_/image": {
                     "content_type": "image/png",

--- a/tests/test_replication_filter.py
+++ b/tests/test_replication_filter.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from typing import List, Set
 from cbltest import CBLPyTest
+from cbltest.utils import assert_not_null
 from cbltest.api.replicator import Replicator
 from cbltest.api.replicator_types import (ReplicatorCollectionEntry, ReplicatorBasicAuthenticator, ReplicatorType, 
                                           ReplicatorActivityLevel, ReplicatorDocumentEntry, ReplicatorFilter)
@@ -130,13 +131,14 @@ class TestReplicationFilter(CBLTestClass):
 
         remote_landmark_10 = await cblpytest.sync_gateways[0].get_document("travel", "landmark_10", "travel", "landmarks")
         assert remote_landmark_10 is not None, "Missing landmark_10 from sync gateway"
+        landmark_10_revid = assert_not_null(remote_landmark_10.revid, "Missing landmark_10 revid")
         
         updates = [
             DocumentUpdateEntry("airport_1000", None, {"answer": 42}),
             DocumentUpdateEntry("airport_10", remote_airport_10.revid, {"answer": 42})
         ]
         await cblpytest.sync_gateways[0].update_documents("travel", updates, "travel", "airports")
-        await cblpytest.sync_gateways[0].delete_document("landmark_10", remote_landmark_10.revid, "travel", "travel", "landmarks")
+        await cblpytest.sync_gateways[0].delete_document("landmark_10", landmark_10_revid, "travel", "travel", "landmarks")
 
         self.mark_test_step("Start the replicator with the same config as the step 3.")
         replicator.clear_document_updates()
@@ -207,9 +209,11 @@ class TestReplicationFilter(CBLTestClass):
 
         remote_landmark_1 = await cblpytest.sync_gateways[0].get_document("travel", "landmark_1", "travel", "landmarks")
         assert remote_landmark_1 is not None, "Missing landmark_1 from sync gateway"
+        landmark_1_revid = assert_not_null(remote_landmark_1.revid, "Missing landmark_1 revid")
 
         remote_landmark_601 = await cblpytest.sync_gateways[0].get_document("travel", "landmark_601", "travel", "landmarks")
         assert remote_landmark_601 is not None, "Missing landmark_601 from sync gateway"
+        landmark_601_revid = assert_not_null(remote_landmark_601.revid, "Missing landmark_601 revid")
 
         updates = [
             DocumentUpdateEntry("airport_1000", None, {"answer": 42, "channels": ["United Kingdom"]}),
@@ -221,8 +225,8 @@ class TestReplicationFilter(CBLTestClass):
         ]
 
         await cblpytest.sync_gateways[0].update_documents("travel", updates, "travel", "airports")
-        await cblpytest.sync_gateways[0].delete_document("landmark_1", remote_landmark_1.revid, "travel", "travel", "landmarks")
-        await cblpytest.sync_gateways[0].delete_document("landmark_601", remote_landmark_601.revid, "travel", "travel", "landmarks")
+        await cblpytest.sync_gateways[0].delete_document("landmark_1", landmark_1_revid, "travel", "travel", "landmarks")
+        await cblpytest.sync_gateways[0].delete_document("landmark_601", landmark_601_revid, "travel", "travel", "landmarks")
 
         self.mark_test_step("Start the replicator with the same config as the step 3.")
         replicator.clear_document_updates()
@@ -426,13 +430,15 @@ class TestReplicationFilter(CBLTestClass):
 
         remote_name_10 = await cblpytest.sync_gateways[0].get_document("names", "name_105")
         assert remote_name_10 is not None, "Missing name_105 from sync gateway"
+        name_10_revid = assert_not_null(remote_name_10.revid, "Missing name_105 revid")
 
         remote_name_20 = await cblpytest.sync_gateways[0].get_document("names", "name_193")
         assert remote_name_20 is not None, "Missing name_193 from sync gateway"
+        name_20_revid = assert_not_null(remote_name_20.revid, "Missing name_193 revid")
 
         await cblpytest.sync_gateways[0].update_documents("names", updates)
-        await cblpytest.sync_gateways[0].delete_document("name_105", remote_name_10.revid, "names")
-        await cblpytest.sync_gateways[0].delete_document("name_193", remote_name_20.revid, "names")
+        await cblpytest.sync_gateways[0].delete_document("name_105", name_10_revid, "names")
+        await cblpytest.sync_gateways[0].delete_document("name_193", name_20_revid, "names")
 
         self.mark_test_step("Start a replicator with the same config as in step 3.")
         await replicator.start()


### PR DESCRIPTION
As well as other things that came up during making the fixes or otherwise:

- Add trailing slash to a few SGW endpoints so it doesn't require a needless HTTP redirect
- Fix the Windows .NET test server from having issues with install by not having external dependencies in the packaging process
- Skip a failing test pending a CBG issue outcome
- Fix .NET server not sending verbose logs anywhere
- Turn on Sync Gateway file logging
- Optimize Sync Gateway Dockerfile so that the deb is downloaded as one of the first steps.  This makes config changes much faster since the download will have been cached as a previous step