### PR TITLE
Restructure dbs dataset and add 4.0 dataset

### DIFF
--- a/dataset/server/dbs/3.2/names.cblite2.zip
+++ b/dataset/server/dbs/3.2/names.cblite2.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:858d2a1a0811e7f741a26f7f2454b1722659e7277ae8f2c8be8b34832affc419
+size 21508

--- a/dataset/server/dbs/3.2/posts.cblite2.zip
+++ b/dataset/server/dbs/3.2/posts.cblite2.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:013596c302b6c7b1bf611357317abd0e150ec7ebe0b6ab0d472abaf0404e2299
+size 1398

--- a/dataset/server/dbs/3.2/todo.cblite2.zip
+++ b/dataset/server/dbs/3.2/todo.cblite2.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bd37bc4ad89f0299bc898951eae2738bde5b548480ecd64ceb76d9f33cc6763b
+size 1757

--- a/dataset/server/dbs/3.2/travel.cblite2.zip
+++ b/dataset/server/dbs/3.2/travel.cblite2.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0f03f8a9ec5279b95e27d063cb3a993b2f0fba8966898e93bb0593edb46508b9
+size 1678226

--- a/dataset/server/dbs/4.0/names.cblite2.zip
+++ b/dataset/server/dbs/4.0/names.cblite2.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d35d0201b44ea8f37c8dfa42ab55fadcaa9350d97051287973b2eeb0ba01ced2
+size 17942

--- a/dataset/server/dbs/4.0/posts.cblite2.zip
+++ b/dataset/server/dbs/4.0/posts.cblite2.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96f682c8171d3999c28021980f7eeb13000cc1b26683363129b7b5cb6e93ca7f
+size 1482

--- a/dataset/server/dbs/4.0/todo.cblite2.zip
+++ b/dataset/server/dbs/4.0/todo.cblite2.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7a8aff7a215ce8fb7806516982b35e760f9174abe3de8c7f9973d42dc8606491
+size 1815

--- a/dataset/server/dbs/4.0/travel.cblite2.zip
+++ b/dataset/server/dbs/4.0/travel.cblite2.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7536b1f49ead24d65f629a8f8ebde83b4fd9f2371c5a197d22213441ade030bf
+size 1514058


### PR DESCRIPTION
* Restructure dataset/server/dbs to have 3.2 and 4.0 dataset in its own folder.
* Keep the original zip files until all platforms make changes to support the new structure.