### PR TITLE
Refactor now that nameof is gone from varname

### DIFF
--- a/.github/workflows/verify_python.sh
+++ b/.github/workflows/verify_python.sh
@@ -5,7 +5,6 @@ source ./venv/bin/activate
 pip install mypy
 pip install pytest pytest-asyncio
 pip install types-requests types-Deprecated
-pip install varname
 pip install ./client
 echo "Checking tests files..."
 python -m mypy tests --exclude=venv

--- a/client/src/cbltest/__init__.py
+++ b/client/src/cbltest/__init__.py
@@ -2,8 +2,6 @@ from json import dumps
 from sys import version_info
 from typing import Dict, List, Optional
 
-from varname import nameof
-
 from .api.couchbaseserver import CouchbaseServer
 from .api.syncgateway import SyncGateway
 from .api.testserver import TestServer
@@ -17,6 +15,7 @@ from .configparser import (
 from .extrapropsparser import _parse_extra_props
 from .logging import LogLevel, cbl_log_init, cbl_setLogLevel
 from .requests import RequestFactory
+from .utils import nameof
 
 if version_info < (3, 9):
     raise RuntimeError("Python must be at least v3.9!")

--- a/client/src/cbltest/api/cloud.py
+++ b/client/src/cbltest/api/cloud.py
@@ -3,14 +3,13 @@ from pathlib import Path
 from typing import List, Optional, cast
 
 from opentelemetry.trace import get_tracer
-from varname import nameof
 
 from cbltest.api.couchbaseserver import CouchbaseServer
 from cbltest.api.error import CblSyncGatewayBadResponseError, CblTestError
 from cbltest.api.syncgateway import PutDatabasePayload, SyncGateway
 from cbltest.assertions import _assert_not_null
 from cbltest.jsonhelper import _get_typed_required
-from cbltest.utils import _try_n_times
+from cbltest.utils import _try_n_times, nameof
 from cbltest.version import VERSION
 
 

--- a/client/src/cbltest/api/replicator_types.py
+++ b/client/src/cbltest/api/replicator_types.py
@@ -4,12 +4,11 @@ from abc import abstractmethod
 from enum import Enum, Flag, auto
 from typing import Any, Dict, Final, List, Optional, cast
 
-from varname import nameof
-
 from cbltest.api.jsonserializable import JSONSerializable
 from cbltest.assertions import _assert_not_empty
 from cbltest.jsonhelper import _get_typed_required
 from cbltest.responses import ErrorResponseBody
+from cbltest.utils import nameof
 
 
 class ReplicatorFilter(JSONSerializable):

--- a/client/src/cbltest/api/syncgateway.py
+++ b/client/src/cbltest/api/syncgateway.py
@@ -8,7 +8,6 @@ from urllib.parse import urljoin
 from aiohttp import BasicAuth, ClientSession, TCPConnector
 from deprecated import deprecated
 from opentelemetry.trace import get_tracer
-from varname import nameof
 
 from cbltest.api.error import CblSyncGatewayBadResponseError
 from cbltest.api.jsonserializable import JSONDictionary, JSONSerializable
@@ -16,7 +15,7 @@ from cbltest.assertions import _assert_not_null
 from cbltest.httplog import get_next_writer
 from cbltest.jsonhelper import _get_typed_required
 from cbltest.logging import cbl_info, cbl_warning
-from cbltest.utils import assert_not_null
+from cbltest.utils import assert_not_null, nameof
 from cbltest.version import VERSION
 
 

--- a/client/src/cbltest/utils.py
+++ b/client/src/cbltest/utils.py
@@ -1,6 +1,8 @@
 import time
 from typing import Any, Callable, Dict, Optional, Type, TypeVar, Union, cast
 
+from varname import argname
+
 from .api.error import CblTimeoutError
 
 T = TypeVar("T")
@@ -36,3 +38,7 @@ def _try_n_times(
 def assert_not_null(input: Optional[T], msg: str) -> T:
     assert input is not None, msg
     return cast(T, input)
+
+
+def nameof(*args):
+    return argname("*args")

--- a/client/src/cbltest/v1/requests.py
+++ b/client/src/cbltest/v1/requests.py
@@ -2,8 +2,6 @@ from enum import Enum
 from typing import Any, Dict, List, Optional, cast
 from uuid import UUID
 
-from varname import nameof
-
 from cbltest.api.database_types import DocumentEntry
 from cbltest.api.jsonserializable import JSONSerializable
 from cbltest.api.replicator_types import (
@@ -14,6 +12,7 @@ from cbltest.api.replicator_types import (
 from cbltest.assertions import _assert_not_null
 from cbltest.logging import cbl_warning
 from cbltest.requests import TestServerRequest, TestServerRequestBody
+from cbltest.utils import nameof
 
 # Some conventions that are followed in this file are that all request classes that
 # will be sent to the test server are classes that end in 'Request'.  Their bodies


### PR DESCRIPTION
The issues on the repo indicate to re-implement the method in terms of another one of the methods inside the package (as I did in utils.py)