### PR TITLE
Fix race when assigning roles in TestFest test

### DIFF
--- a/client/src/cbltest/api/cloud.py
+++ b/client/src/cbltest/api/cloud.py
@@ -37,23 +37,6 @@ class CouchbaseCloud:
     def _wait_for_all_indexed_removed(self, bucket: str) -> None:
         _try_n_times(10, 2, True, self._check_all_indexes_removed, type(None), bucket)
 
-    async def create_role(
-        self, db_name: str, role: str, collection_access: dict
-    ) -> None:
-        await self.__sync_gateway.add_role(db_name, role, collection_access)
-
-    async def add_user(
-        self,
-        db_name: str,
-        user: str,
-        password: Optional[str] = None,
-        collection_access: Optional[dict] = None,
-        admin_roles: Optional[List[str]] = None,
-    ) -> None:
-        await self.__sync_gateway.add_user(
-            db_name, user, password, collection_access, admin_roles
-        )
-
     async def configure_dataset(
         self,
         dataset_path: Path,

--- a/client/src/cbltest/api/cloud.py
+++ b/client/src/cbltest/api/cloud.py
@@ -42,6 +42,18 @@ class CouchbaseCloud:
     ) -> None:
         await self.__sync_gateway.add_role(db_name, role, collection_access)
 
+    async def add_user(
+        self,
+        db_name: str,
+        user: str,
+        password: Optional[str] = None,
+        collection_access: Optional[dict] = None,
+        admin_roles: Optional[List[str]] = None,
+    ) -> None:
+        await self.__sync_gateway.add_user(
+            db_name, user, password, collection_access, admin_roles
+        )
+
     async def configure_dataset(
         self,
         dataset_path: Path,

--- a/client/src/cbltest/api/syncgateway.py
+++ b/client/src/cbltest/api/syncgateway.py
@@ -517,12 +517,12 @@ class SyncGateway:
         self,
         db_name: str,
         name: str,
-        password: str,
-        collection_access: dict,
+        password: Optional[str] = None,
+        collection_access: Optional[dict] = None,
         admin_roles: Optional[List[str]] = None,
     ) -> None:
         """
-        Adds the specified user to a Sync Gateway database with the specified channel access
+        Adds or updates the specified user to a Sync Gateway database with the specified channel access
 
         :param db_name: The name of the Database to add the user to
         :param name: The username to add
@@ -530,15 +530,20 @@ class SyncGateway:
         :param collection_access: The collections that the user will have access to.  This needs to
             be formatted in the way Sync Gateway expects it, so if you are unsure use
             :func:`drop_bucket()<cbltest.api.syncgateway.SyncGateway.create_collection_access_dict>`
+        :param admin_roles: The admin roles
         """
         with self.__tracer.start_as_current_span(
             "add_user", attributes={"cbl.user.name": name}
         ):
-            body = {
+            body: Dict[str, Any] = {
                 "name": name,
-                "password": password,
-                "collection_access": collection_access,
             }
+
+            if password is not None:
+                body["password"] = password
+
+            if collection_access is not None:
+                body["collection_access"] = collection_access
 
             if admin_roles is not None:
                 body["admin_roles"] = admin_roles

--- a/dataset/sg/todo-sg-config.json
+++ b/dataset/sg/todo-sg-config.json
@@ -5,7 +5,7 @@
       "_default": {
         "collections": {
           "lists": {
-            "sync": "function foo(doc,oldDoc,meta){var owner=doc._deleted?oldDoc.owner:doc.owner;requireUser(owner);var listChannel='lists.'+owner+'.'+doc._id;var contributorRole='role:'+listChannel+'.contributor';role(owner,contributorRole);access(contributorRole,listChannel);channel(listChannel)}"
+            "sync": "function foo(doc,oldDoc,meta){var owner=doc._deleted?oldDoc.owner:doc.owner;requireUser(owner);var listChannel='lists.'+owner+'.'+doc._id;var contributorRoleName=listChannel+'.contributor';var contributorRole='role:'+contributorRoleName;requireRole(contributorRoleName);access(contributorRole,listChannel);channel(listChannel)}"
           },
           "tasks": {
             "sync": "function foo(doc,oldDoc,meta){var listId=doc._deleted?oldDoc.taskList.id:doc.taskList.id;var listOwner=doc._deleted?oldDoc.taskList.owner:doc.taskList.owner;var listChannel='lists.'+listOwner+'.'+listId;var contributorRoleName=listChannel+'.contributor';var contributorRole='role:'+contributorRoleName;requireRole(contributorRoleName);var tasksChannel=listChannel+'.tasks';access(contributorRole,tasksChannel);channel(tasksChannel)}"

--- a/tests/test_fest.py
+++ b/tests/test_fest.py
@@ -30,7 +30,7 @@ class TestFest(CBLTestClass):
                 f"Assign roles '{', '.join(user_roles)}' to the user '{user}'"
             )
             for role in user_roles:
-                await cloud.create_role(
+                await cblpytest.sync_gateways[0].add_role(
                     "todo",
                     role,
                     {
@@ -41,7 +41,9 @@ class TestFest(CBLTestClass):
                         }
                     },
                 )
-            await cloud.add_user("todo", user, admin_roles=user_roles)
+            await cblpytest.sync_gateways[0].add_user(
+                "todo", user, admin_roles=user_roles
+            )
 
         return cloud
 


### PR DESCRIPTION
* Assigned user roles using REST API instead of using sync function in the list collection as the user role is required when adding tasks in the tasks collection.

* Update todo's sync function.

* Changed syncgateway add_user to require only db_name and name so this function can be used for updating the user.

* Added add_user to cloud.py so that the function can be accessed from the test files.