### PR TITLE
Provide the ability to deploy logslurp to AWS backend

### DIFF
--- a/environment/aws/README.md
+++ b/environment/aws/README.md
@@ -17,6 +17,13 @@ Next, you will need to run `terraform init` inside of this folder in order to se
 
 Next, you need to make sure that the [python prerequisites](./requirements.txt) are installed in whatever environment you are using
 
+Next, you will need to add a section to your machine SSH config (`$HOME/.ssh/config`) to ensure that public keys from AWS are automatically added to the system known hosts.  This is because the hostname will be changing every time and docker remote deploy requires an unmolested SSH connection in order to function (without adding to known_hosts you will get an interactive prompt to add the remote host to the known hosts).  To accomplish this add the following section to your SSH config:
+
+```
+Host *.amazonaws.com
+    StrictHostKeyChecking accept-new
+```
+
 Finally, you will need to set up your Amazon AWS credentials so that terraform can use them.  As a Couchbase Employee the easiest way to do this is to set them up as described on the AWS SSO page that can be accessed via the Okta landing page.  The easiest result (option 2 on the resulting page) looks something like the following added to `$HOME/.aws/credentials`
 
 ```

--- a/environment/aws/logslurp_setup/configure-system.sh
+++ b/environment/aws/logslurp_setup/configure-system.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -x
+
+if ! command -v docker &> /dev/null; then
+  sudo yum install -y docker
+  sudo systemctl start docker
+fi
+
+if ! groups $USER | grep -q "\bdocker\b"; then
+  sudo usermod -aG docker $USER
+fi

--- a/environment/aws/logslurp_setup/setup_logslurp.py
+++ b/environment/aws/logslurp_setup/setup_logslurp.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+import subprocess
+from pathlib import Path
+from typing import Optional
+
+import paramiko
+from common.output import header
+from termcolor import colored
+from tqdm import tqdm
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+current_ssh = ""
+
+def sftp_progress_bar(sftp: paramiko.SFTP, local_path: Path, remote_path: str):
+    file_size = os.path.getsize(local_path)
+    with tqdm(total=file_size, unit="B", unit_scale=True, desc=local_path.name) as bar:
+
+        def callback(transferred, total):
+            bar.update(transferred - bar.n)
+
+        sftp.put(local_path, remote_path, callback=callback)
+
+
+def remote_exec(
+    ssh: paramiko.SSHClient, command: str, desc: str, fail_on_error: bool = True
+):
+    header(desc)
+
+    _, stdout, stderr = ssh.exec_command(command, get_pty=True)
+    for line in iter(stdout.readline, ""):
+        print(colored(f"[{current_ssh}] {line}", "light_grey"), end="")
+
+    exit_status = stdout.channel.recv_exit_status()
+    if fail_on_error and exit_status != 0:
+        print(stderr.read().decode())
+        raise Exception(f"Command '{command}' failed with exit status {exit_status}")
+
+    header("Done!")
+    print()
+
+def get_ec2_hostname(hostname: str) -> str:
+    if hostname.startswith("ec2-"):
+        return hostname
+    
+    components = hostname.split(".")
+    if len(components) != 4:
+        raise ValueError(f"Invalid hostname {hostname}")
+    
+    return f"ec2-{hostname.replace('.', '-')}.compute-1.amazonaws.com"
+
+def check_aws_key_checking() -> None:
+    ssh_config_path = Path.home() / ".ssh" / "config"
+    if not ssh_config_path.exists():
+        raise FileNotFoundError(f"SSH config file not found at {ssh_config_path}")
+
+    with ssh_config_path.open() as f:
+        lines = f.readlines()
+
+    host_found = False
+    for line in lines:
+        if line.strip() == "Host *.amazonaws.com":
+            host_found = True
+            continue
+
+        if host_found:
+            if line.strip().startswith("Host"):
+                raise Exception("No StrictHostKeyChecking line found for Host *.amazonaws.com, please modify your ssh config to set it to accept-new")
+            
+            if "StrictHostKeyChecking" in line:
+                if "accept-new" not in line:
+                    raise Exception("StrictHostKeyChecking is not set to accept-new for Host *.amazonaws.com, please modify your ssh config to set it to accept-new")
+
+                return
+
+    if host_found:
+        raise Exception("No StrictHostKeyChecking line found for Host *.amazonaws.com, please modify your ssh config to set it to accept-new")
+    else:
+        raise Exception("Host *.amazonaws.com not found in SSH config, please add it with StrictHostKeyChecking accept-new")
+
+
+def main(hostname: str, private_key: Optional[str] = None):
+    check_aws_key_checking()
+    ec2_hostname = get_ec2_hostname(hostname)
+    ssh = paramiko.SSHClient()
+    ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+    pkey: paramiko.Ed25519Key = (
+        paramiko.Ed25519Key.from_private_key_file(private_key)
+        if private_key
+        else None
+    )
+    ssh.connect(ec2_hostname, username="ec2-user", pkey=pkey)
+
+    global current_ssh
+    current_ssh = hostname
+    sftp = ssh.open_sftp()
+    sftp_progress_bar(
+        sftp, SCRIPT_DIR / "configure-system.sh", "/tmp/configure-system.sh"
+    )
+    remote_exec(ssh, "bash /tmp/configure-system.sh", "Setting up instance")
+    sftp.close()
+    ssh.close()
+
+    context_result = subprocess.run(["docker", "context", "ls", "--format", "{{.Name}}"], check=True, capture_output=True, text=True)
+    if "aws" in context_result.stdout:
+        header("Updating docker context")
+        subprocess.run(["docker", "context", "update", "aws", "--docker", f"host=ssh://ec2-user@{ec2_hostname}"])
+    else:
+        header("Creating docker context")
+        subprocess.run(["docker", "context", "create", "aws", "--docker", f"host=ssh://ec2-user@{ec2_hostname}"])
+
+    os.chdir(SCRIPT_DIR / ".." / "..")
+
+    header(f"Building and starting logslurp on {hostname}")
+    env = os.environ.copy()
+    env["DOCKER_CONTEXT"] = "aws"
+    subprocess.run(["docker", "compose", "up", "-d", "--build", "cbl-test-logslurp"], check=True, env=env)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Run a script over an SSH connection.")
+    parser.add_argument(
+        "hostname", help="The hostname or IP address of the server."
+    )
+    parser.add_argument(
+        "--private-key",
+        help="The private key to use for the SSH connection (if not default)",
+    )
+    args = parser.parse_args()
+
+    main(args.hostname, args.private_key)

--- a/environment/aws/main.tf
+++ b/environment/aws/main.tf
@@ -91,6 +91,13 @@ resource "aws_security_group" "main" {
         protocol    = "tcp"
         cidr_blocks = ["0.0.0.0/0"]
     }
+    
+    ingress {
+        from_port = 8180
+        to_port = 8180
+        protocol = "tcp"
+        cidr_blocks = ["0.0.0.0/0"]
+    }
 
     ingress {
         from_port   = 9876

--- a/environment/aws/start_backend.py
+++ b/environment/aws/start_backend.py
@@ -8,9 +8,9 @@ from time import sleep
 from typing import IO, List, cast
 
 from common.output import header
+from logslurp_setup.setup_logslurp import main as logslurp_main
 from server_setup.setup_server import main as server_main
 from sgw_setup.setup_sgw import main as sgw_main
-from logslurp_setup.setup_logslurp import main as logslurp_main
 
 
 def terraform_apply(public_key_name: str):

--- a/environment/aws/start_backend.py
+++ b/environment/aws/start_backend.py
@@ -10,6 +10,7 @@ from typing import IO, List, cast
 from common.output import header
 from server_setup.setup_server import main as server_main
 from sgw_setup.setup_sgw import main as sgw_main
+from logslurp_setup.setup_logslurp import main as logslurp_main
 
 
 def terraform_apply(public_key_name: str):
@@ -129,6 +130,7 @@ if __name__ == "__main__":
 
     server_main(cbs_ips, args.cbs_version, args.private_key)
     sgw_main(sgw_ips, args.sgw_url, args.private_key)
+    logslurp_main(cbs_ips[0], args.private_key)
     if args.tdk_config_out is not None:
         with open(args.tdk_config_out, "w") as fout:
             write_config(args.tdk_config_in, fout)

--- a/jenkins/pipelines/dotnet/config_aws.json
+++ b/jenkins/pipelines/dotnet/config_aws.json
@@ -4,6 +4,6 @@
     "sync-gateways": [{"hostname": "{{sgw-ip1}}", "tls": true}],
     "couchbase-servers": [{"hostname": "{{cbs-ip1}}"}],
     "api-version": 1,
-    "logslurp": "{{test-client-ip}}:8180",
+    "logslurp": "{{cbs-ip1}}:8180",
     "greenboard": {"hostname": "jenkins.mobiledev.couchbase.com", "username": "writer", "password": "couchbase2" }
 }


### PR DESCRIPTION
This eliminates any backend dependency on our lab machines.  However, it also means an additional setup step in order to reliably be able to deploy docker onto a remote host.