### PR TITLE
Make dataset_version mandatory for topology

### DIFF
--- a/environment/aws/topology_setup/build_test_server.py
+++ b/environment/aws/topology_setup/build_test_server.py
@@ -73,6 +73,7 @@ def main() -> None:
     parser = ArgumentParser("Builds a given test server")
     parser.add_argument("platform", type=str, help="The platform to build")
     parser.add_argument("version", type=str, help="The version of CBL to use")
+    parser.add_argument("dataset_version", type=str, help="The dataset version to use")
     parser.add_argument(
         "--upload",
         action="store_true",
@@ -85,7 +86,7 @@ def main() -> None:
     )
 
     args = parser.parse_args()
-    server = TestServer.create(args.platform, args.version)
+    server = TestServer.create(args.platform, args.version, args.dataset_version)
     if "-" not in args.version:
         raise ValueError(
             f"Invalid version {args.version}, must be in the form x.y.z-build"

--- a/environment/aws/topology_setup/setup_topology.py
+++ b/environment/aws/topology_setup/setup_topology.py
@@ -140,7 +140,7 @@ class TestServerInput:
     Attributes:
         location (str): The location of the test server.
         cbl_version (str): The version of Couchbase Lite to use.
-        dataset_version (Optional[str]): The version of the dataset to use.
+        dataset_version (str): The version of the dataset to use.
         platform (str): The platform of the test server.
         download (bool): Whether to download the test server package.
     """
@@ -154,7 +154,7 @@ class TestServerInput:
         return self.__cbl_version
 
     @property
-    def dataset_version(self) -> Optional[str]:
+    def dataset_version(self) -> str:
         return self.__dataset_version
 
     @property
@@ -169,7 +169,7 @@ class TestServerInput:
         self,
         location: str,
         cbl_version: str,
-        dataset_version: Optional[str],
+        dataset_version: str,
         platform: str,
         download: bool,
     ):
@@ -269,9 +269,7 @@ class TopologyConfig:
                         TestServerInput(
                             raw_server["location"],
                             raw_server["cbl_version"],
-                            raw_server["dataset_version"]
-                            if "dataset_version" in raw_server
-                            else None,
+                            raw_server["dataset_version"],
                             raw_server["platform"],
                             cast(bool, raw_server.get("download", False)),
                         )
@@ -383,7 +381,9 @@ class TopologyConfig:
         """
         for test_server_input in self.__test_server_inputs:
             test_server = TestServer.create(
-                test_server_input.platform, test_server_input.cbl_version
+                test_server_input.platform,
+                test_server_input.cbl_version,
+                test_server_input.dataset_version,
             )
             bridge = test_server.create_bridge()
             bridge.validate(test_server_input.location)
@@ -401,10 +401,11 @@ class TopologyConfig:
         """
         for test_server_input in self.__test_server_inputs:
             test_server = TestServer.create(
-                test_server_input.platform, test_server_input.cbl_version
+                test_server_input.platform,
+                test_server_input.cbl_version,
+                test_server_input.dataset_version,
             )
 
-            test_server.dataset_version = test_server_input.dataset_version
             if test_server_input.download:
                 test_server.download()
             else:
@@ -437,7 +438,9 @@ class TopologyConfig:
         TestServer.initialize()
         for test_server_input in self.__test_server_inputs:
             test_server = TestServer.create(
-                test_server_input.platform, test_server_input.cbl_version
+                test_server_input.platform,
+                test_server_input.cbl_version,
+                test_server_input.dataset_version,
             )
             bridge = test_server.create_bridge()
             bridge.stop(test_server_input.location)

--- a/environment/aws/topology_setup/test_server.py
+++ b/environment/aws/topology_setup/test_server.py
@@ -46,9 +46,9 @@ Functions:
 from __future__ import annotations
 
 import importlib
+import shutil
 from abc import ABC, abstractmethod
 from pathlib import Path
-import shutil
 from typing import Callable, Dict, Type
 
 import requests
@@ -284,24 +284,25 @@ class TestServer(ABC):
         """
         pass
 
+
 def copy_dataset(dest_dir: Path, version: str):
     header(f"Copying dataset resources v{version}")
     db_dir = TEST_SERVER_DIR.parent / "dataset" / "server" / "dbs" / version
     blob_dir = TEST_SERVER_DIR.parent / "dataset" / "server" / "blobs"
 
-    
     dest_db_dir = dest_dir / "dbs"
     shutil.rmtree(dest_db_dir, ignore_errors=True)
     dest_db_dir.mkdir(0o755)
     for db in db_dir.glob("*.zip"):
         print(f"Copying {db} -> {dest_db_dir / db.name}")
         shutil.copy2(db, dest_db_dir)
-    
+
     dest_blob_dir = dest_dir / "blobs"
     shutil.rmtree(dest_blob_dir, ignore_errors=True)
     dest_blob_dir.mkdir(0o755)
     for blob in blob_dir.iterdir():
         print(f"Copying {blob} -> {dest_blob_dir / blob.name}")
         shutil.copy2(blob, dest_blob_dir)
-            
+
+
 assert __name__ != "__main__", "This module is not meant to be run directly"

--- a/environment/aws/topology_setup/test_server.py
+++ b/environment/aws/topology_setup/test_server.py
@@ -109,7 +109,6 @@ class TestServer(ABC):
         self.__version = version
         self.__dataset_version = dataset_version
         self._downloaded = False
-        """If needed, the dataset version to use when building"""
 
     @classmethod
     def initialize(cls) -> None:

--- a/environment/aws/topology_setup/test_server.py
+++ b/environment/aws/topology_setup/test_server.py
@@ -48,6 +48,7 @@ from __future__ import annotations
 import importlib
 from abc import ABC, abstractmethod
 from pathlib import Path
+import shutil
 from typing import Callable, Dict, Type
 
 import requests
@@ -284,5 +285,24 @@ class TestServer(ABC):
         """
         pass
 
+def copy_dataset(dest_dir: Path, version: str):
+    header(f"Copying dataset resources v{version}")
+    db_dir = TEST_SERVER_DIR.parent / "dataset" / "server" / "dbs" / version
+    blob_dir = TEST_SERVER_DIR.parent / "dataset" / "server" / "blobs"
 
+    
+    dest_db_dir = dest_dir / "dbs"
+    shutil.rmtree(dest_db_dir, ignore_errors=True)
+    dest_db_dir.mkdir(0o755)
+    for db in db_dir.glob("*.zip"):
+        print(f"Copying {db} -> {dest_db_dir / db.name}")
+        shutil.copy2(db, dest_db_dir)
+    
+    dest_blob_dir = dest_dir / "blobs"
+    shutil.rmtree(dest_blob_dir, ignore_errors=True)
+    dest_blob_dir.mkdir(0o755)
+    for blob in blob_dir.iterdir():
+        print(f"Copying {blob} -> {dest_blob_dir / blob.name}")
+        shutil.copy2(blob, dest_blob_dir)
+            
 assert __name__ != "__main__", "This module is not meant to be run directly"

--- a/environment/aws/topology_setup/test_server.py
+++ b/environment/aws/topology_setup/test_server.py
@@ -48,7 +48,7 @@ from __future__ import annotations
 import importlib
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Callable, Dict, Optional, Type
+from typing import Callable, Dict, Type
 
 import requests
 
@@ -104,10 +104,10 @@ class TestServer(ABC):
 
     __registry: Dict[str, Type[TestServer]] = {}
 
-    def __init__(self, version: str):
+    def __init__(self, version: str, dataset_version: str) -> None:
         self.__version = version
+        self.__dataset_version = dataset_version
         self._downloaded = False
-        self.dataset_version: Optional[str] = None
         """If needed, the dataset version to use when building"""
 
     @classmethod
@@ -148,13 +148,14 @@ class TestServer(ABC):
         return decorator
 
     @classmethod
-    def create(cls, name: str, version: str) -> TestServer:
+    def create(cls, name: str, version: str, dataset_version: str) -> TestServer:
         """
         Create an instance of a registered test server subclass.
 
         Args:
             name (str): The name of the registered test server subclass.
             version (str): The version of the test server.
+            dataset_version (str): The dataset version to use when building.
 
         Returns:
             TestServer: An instance of the registered test server subclass.
@@ -167,7 +168,7 @@ class TestServer(ABC):
         if name not in cls.__registry:
             raise ValueError(f"Unknown test server type: {name}")
 
-        return cls.__registry[name](version)
+        return cls.__registry[name](version, dataset_version)
 
     @property
     def version(self) -> str:
@@ -178,6 +179,16 @@ class TestServer(ABC):
             str: The version of the test server.
         """
         return self.__version
+
+    @property
+    def dataset_version(self) -> str:
+        """
+        Get the dataset version of the test server.
+
+        Returns:
+            str: The dataset version of the test server.
+        """
+        return self.__dataset_version
 
     @property
     @abstractmethod

--- a/environment/aws/topology_setup/test_server_platforms/c_register.py
+++ b/environment/aws/topology_setup/test_server_platforms/c_register.py
@@ -37,7 +37,11 @@ from typing import cast
 from environment.aws.common.io import untar_directory, unzip_directory
 from environment.aws.common.output import header
 from environment.aws.topology_setup.cbl_library_downloader import CBLLibraryDownloader
-from environment.aws.topology_setup.test_server import TEST_SERVER_DIR, TestServer
+from environment.aws.topology_setup.test_server import (
+    TEST_SERVER_DIR,
+    TestServer,
+    copy_dataset,
+)
 
 from .android_bridge import AndroidBridge
 from .exe_bridge import ExeBridge
@@ -68,6 +72,9 @@ class CTestServer(TestServer):
     @abstractmethod
     def cbl_filename(self, version: str) -> str:
         pass
+
+    def _copy_dataset(self) -> None:
+        copy_dataset(C_TEST_SERVER_DIR / "assets", self.dataset_version)
 
     def _copy_with_symlink_preservation(self, src: Path, dest: Path) -> None:
         if src.is_symlink():
@@ -111,6 +118,7 @@ class CTestServer_Desktop(CTestServer):
         """
         Build the C test server.
         """
+        self._copy_dataset()
         shutil.rmtree(LIB_DIR, ignore_errors=True)
         self._download_cbl()
         header("Building C test server")
@@ -568,7 +576,7 @@ class CTestServer_Linux(CTestServer_Desktop):
         version (str): The version of the test server.
     """
 
-    def __init__(self, version: str, dataset_version: str):
+    def __init__(self, version: str, dataset_version: str, arch: str):
         super().__init__(version, dataset_version)
         self.__arch = arch
 
@@ -643,5 +651,5 @@ class CTestServer_Linux_x86_64(CTestServer_Linux):
         version (str): The version of the test server.
     """
 
-    def __init__(self, version: str):
-        super().__init__(version, "x86_64")
+    def __init__(self, version: str, dataset_version: str):
+        super().__init__(version, dataset_version, "x86_64")

--- a/environment/aws/topology_setup/test_server_platforms/c_register.py
+++ b/environment/aws/topology_setup/test_server_platforms/c_register.py
@@ -62,8 +62,8 @@ class CTestServer(TestServer):
         version (str): The version of the test server.
     """
 
-    def __init__(self, version: str):
-        super().__init__(version)
+    def __init__(self, version: str, dataset_version: str):
+        super().__init__(version, dataset_version)
 
     @abstractmethod
     def cbl_filename(self, version: str) -> str:
@@ -145,8 +145,8 @@ class CTestServer_iOS(CTestServer):
         version (str): The version of the test server.
     """
 
-    def __init__(self, version: str):
-        super().__init__(version)
+    def __init__(self, version: str, dataset_version: str):
+        super().__init__(version, dataset_version)
 
     @property
     def platform(self) -> str:
@@ -284,8 +284,8 @@ class CTestServer_Android(CTestServer):
         version (str): The version of the test server.
     """
 
-    def __init__(self, version: str):
-        super().__init__(version)
+    def __init__(self, version: str, dataset_version: str):
+        super().__init__(version, dataset_version)
 
     @property
     def platform(self) -> str:
@@ -414,8 +414,8 @@ class CTestServer_Windows(CTestServer_Desktop):
         version (str): The version of the test server.
     """
 
-    def __init__(self, version: str):
-        super().__init__(version)
+    def __init__(self, version: str, dataset_version: str):
+        super().__init__(version, dataset_version)
 
     @property
     def platform(self) -> str:
@@ -490,8 +490,8 @@ class CTestServer_macOS(CTestServer_Desktop):
         version (str): The version of the test server.
     """
 
-    def __init__(self, version: str):
-        super().__init__(version)
+    def __init__(self, version: str, dataset_version: str):
+        super().__init__(version, dataset_version)
 
     def cbl_filename(self, version: str) -> str:
         return f"couchbase-lite-c-enterprise-{version}-macos.zip"
@@ -568,8 +568,8 @@ class CTestServer_Linux(CTestServer_Desktop):
         version (str): The version of the test server.
     """
 
-    def __init__(self, version: str, arch: str):
-        super().__init__(version)
+    def __init__(self, version: str, dataset_version: str):
+        super().__init__(version, dataset_version)
         self.__arch = arch
 
     @property

--- a/environment/aws/topology_setup/test_server_platforms/dotnet_register.py
+++ b/environment/aws/topology_setup/test_server_platforms/dotnet_register.py
@@ -39,7 +39,7 @@ from typing import List, Optional
 
 from environment.aws.common.io import unzip_directory, zip_directory
 from environment.aws.common.output import header
-from environment.aws.topology_setup.test_server import TEST_SERVER_DIR, TestServer
+from environment.aws.topology_setup.test_server import TEST_SERVER_DIR, TestServer, copy_dataset
 
 from .android_bridge import AndroidBridge
 from .exe_bridge import ExeBridge
@@ -54,23 +54,6 @@ if platform.system() == "Windows":
     DOTNET_PATH = Path(environ["LOCALAPPDATA"]) / "Microsoft" / "dotnet" / "dotnet.exe"
 else:
     DOTNET_PATH = Path.home() / ".dotnet" / "dotnet"
-
-def copy_dataset(dest_dir: Path, version: str):
-    header(f"Copying dataset resources v{version}")
-    db_dir = TEST_SERVER_DIR.parent / "dataset" / "server" / "dbs" / version
-    blob_dir = TEST_SERVER_DIR.parent / "dataset" / "server" / "blobs"
-
-    for db in db_dir.glob("*.zip"):
-        if not (dest_dir / db.name).exists():
-            print(f"Copying {db} -> {dest_dir / db.name}")
-            shutil.copy2(db, dest_dir)
-    
-    for blob in blob_dir.iterdir():
-        dest_blob_dir = dest_dir / "blobs"
-        dest_blob_dir.mkdir(0o755, exist_ok=True)
-        if not (dest_blob_dir / blob.name).exists():
-            print(f"Copying {blob} -> {dest_blob_dir / blob.name}")
-            shutil.copy2(blob, dest_blob_dir)
 
 class DotnetTestServer(TestServer):
     """

--- a/environment/aws/topology_setup/test_server_platforms/dotnet_register.py
+++ b/environment/aws/topology_setup/test_server_platforms/dotnet_register.py
@@ -64,8 +64,8 @@ class DotnetTestServer(TestServer):
         version (str): The version of the test server.
     """
 
-    def __init__(self, version: str):
-        super().__init__(version)
+    def __init__(self, version: str, dataset_version: str):
+        super().__init__(version, dataset_version)
 
     @property
     @abstractmethod
@@ -152,8 +152,8 @@ class DotnetTestServerCli(TestServer):
         version (str): The version of the test server.
     """
 
-    def __init__(self, version: str):
-        super().__init__(version)
+    def __init__(self, version: str, dataset_version: str):
+        super().__init__(version, dataset_version)
 
     @property
     @abstractmethod
@@ -219,8 +219,8 @@ class DotnetTestServer_iOS(DotnetTestServer):
         version (str): The version of the test server.
     """
 
-    def __init__(self, version: str):
-        super().__init__(version)
+    def __init__(self, version: str, dataset_version: str):
+        super().__init__(version, dataset_version)
 
     @property
     def platform(self) -> str:
@@ -336,8 +336,8 @@ class DotnetTestServer_Android(DotnetTestServer):
         version (str): The version of the test server.
     """
 
-    def __init__(self, version: str):
-        super().__init__(version)
+    def __init__(self, version: str, dataset_version: str):
+        super().__init__(version, dataset_version)
 
     @property
     def platform(self) -> str:
@@ -446,8 +446,8 @@ class DotnetTestServer_Windows(DotnetTestServerCli):
         version (str): The version of the test server.
     """
 
-    def __init__(self, version: str):
-        super().__init__(version)
+    def __init__(self, version: str, dataset_version: str):
+        super().__init__(version, dataset_version)
 
     @property
     def platform(self) -> str:
@@ -544,8 +544,8 @@ class DotnetTestServer_macOS(DotnetTestServer):
         version (str): The version of the test server.
     """
 
-    def __init__(self, version: str):
-        super().__init__(version)
+    def __init__(self, version: str, dataset_version: str):
+        super().__init__(version, dataset_version)
 
     @property
     def platform(self) -> str:

--- a/environment/aws/topology_setup/test_server_platforms/dotnet_register.py
+++ b/environment/aws/topology_setup/test_server_platforms/dotnet_register.py
@@ -39,7 +39,11 @@ from typing import List, Optional
 
 from environment.aws.common.io import unzip_directory, zip_directory
 from environment.aws.common.output import header
-from environment.aws.topology_setup.test_server import TEST_SERVER_DIR, TestServer, copy_dataset
+from environment.aws.topology_setup.test_server import (
+    TEST_SERVER_DIR,
+    TestServer,
+    copy_dataset,
+)
 
 from .android_bridge import AndroidBridge
 from .exe_bridge import ExeBridge
@@ -54,6 +58,7 @@ if platform.system() == "Windows":
     DOTNET_PATH = Path(environ["LOCALAPPDATA"]) / "Microsoft" / "dotnet" / "dotnet.exe"
 else:
     DOTNET_PATH = Path.home() / ".dotnet" / "dotnet"
+
 
 class DotnetTestServer(TestServer):
     """

--- a/environment/aws/topology_setup/test_server_platforms/dotnet_register.py
+++ b/environment/aws/topology_setup/test_server_platforms/dotnet_register.py
@@ -286,7 +286,7 @@ class DotnetTestServer_iOS(DotnetTestServer):
             str: The path for the latest builds.
         """
         version_parts = self.version.split("-")
-        return f"couchbase-lite-net/{version_parts[0]}/{version_parts[1]}/testserver_ios.zip"
+        return f"couchbase-lite-net/{version_parts[0]}/{version_parts[1]}/testserver_ios_{self.dataset_version}.zip"
 
     def create_bridge(self) -> PlatformBridge:
         """
@@ -393,7 +393,7 @@ class DotnetTestServer_Android(DotnetTestServer):
             str: The path for the latest builds.
         """
         version_parts = self.version.split("-")
-        return f"couchbase-lite-net/{version_parts[0]}/{version_parts[1]}/testserver_android.apk"
+        return f"couchbase-lite-net/{version_parts[0]}/{version_parts[1]}/testserver_android_{self.dataset_version}.apk"
 
     def create_bridge(self) -> PlatformBridge:
         """
@@ -493,7 +493,7 @@ class DotnetTestServer_Windows(DotnetTestServerCli):
             str: The path for the latest builds.
         """
         version_parts = self.version.split("-")
-        return f"couchbase-lite-net/{version_parts[0]}/{version_parts[1]}/testserver_windows.zip"
+        return f"couchbase-lite-net/{version_parts[0]}/{version_parts[1]}/testserver_windows_{self.dataset_version}.zip"
 
     def create_bridge(self) -> PlatformBridge:
         """
@@ -601,7 +601,7 @@ class DotnetTestServer_macOS(DotnetTestServer):
             str: The path for the latest builds.
         """
         version_parts = self.version.split("-")
-        return f"couchbase-lite-net/{version_parts[0]}/{version_parts[1]}/testserver_macos.zip"
+        return f"couchbase-lite-net/{version_parts[0]}/{version_parts[1]}/testserver_macos_{self.dataset_version}.zip"
 
     def create_bridge(self) -> PlatformBridge:
         """

--- a/environment/aws/topology_setup/test_server_platforms/java_register.py
+++ b/environment/aws/topology_setup/test_server_platforms/java_register.py
@@ -247,8 +247,8 @@ class JAKTestServer(TestServer):
     def test_server_path(self) -> str:
         pass
 
-    def __init__(self, version: str, gradle_target: str = "jar"):
-        super().__init__(version)
+    def __init__(self, version: str, dataset_version: str, gradle_target: str = "jar"):
+        super().__init__(version, dataset_version)
         self.__gradle_target = gradle_target
 
     def build(self) -> None:
@@ -283,8 +283,8 @@ class JAKTestServer_Android(JAKTestServer):
         version (str): The version of the test server.
     """
 
-    def __init__(self, version: str):
-        super().__init__(version, "assembleRelease")
+    def __init__(self, version: str, dataset_version: str):
+        super().__init__(version, dataset_version, "assembleRelease")
 
     @property
     def test_server_path(self) -> str:
@@ -364,8 +364,8 @@ class JAKTestServer_Android(JAKTestServer):
 
 
 class JAKTestServer_Desktop(JAKTestServer):
-    def __init__(self, version: str):
-        super().__init__(version)
+    def __init__(self, version: str, dataset_version: str):
+        super().__init__(version, dataset_version)
 
     @property
     def test_server_path(self) -> str:
@@ -376,8 +376,8 @@ class JAKTestServer_Desktop(JAKTestServer):
 
 
 class JAKTestServer_WebService(JAKTestServer):
-    def __init__(self, version: str):
-        super().__init__(version)
+    def __init__(self, version: str, dataset_version: str):
+        super().__init__(version, dataset_version)
 
     @property
     def test_server_path(self) -> str:
@@ -399,8 +399,8 @@ class JAKTestServer_WindowsDesktop(JAKTestServer_Desktop):
         version (str): The version of the test server.
     """
 
-    def __init__(self, version: str):
-        super().__init__(version)
+    def __init__(self, version: str, dataset_version: str):
+        super().__init__(version, dataset_version)
 
     @property
     def platform(self) -> str:
@@ -455,8 +455,8 @@ class JAKTestServer_WindowsWebService(JAKTestServer_WebService):
         version (str): The version of the test server.
     """
 
-    def __init__(self, version: str):
-        super().__init__(version)
+    def __init__(self, version: str, dataset_version: str):
+        super().__init__(version, dataset_version)
 
     @property
     def platform(self) -> str:
@@ -511,8 +511,8 @@ class JAKTestServer_macOSWebService(JAKTestServer_WebService):
         version (str): The version of the test server.
     """
 
-    def __init__(self, version: str):
-        super().__init__(version)
+    def __init__(self, version: str, dataset_version: str):
+        super().__init__(version, dataset_version)
 
     @property
     def platform(self) -> str:
@@ -567,8 +567,8 @@ class JAKTestServer_macOSDesktop(JAKTestServer_Desktop):
         version (str): The version of the test server.
     """
 
-    def __init__(self, version: str):
-        super().__init__(version)
+    def __init__(self, version: str, dataset_version: str):
+        super().__init__(version, dataset_version)
 
     @property
     def platform(self) -> str:
@@ -623,8 +623,8 @@ class JAKTestServer_LinuxDesktop(JAKTestServer_Desktop):
         version (str): The version of the test server.
     """
 
-    def __init__(self, version: str):
-        super().__init__(version)
+    def __init__(self, version: str, dataset_version: str):
+        super().__init__(version, dataset_version)
 
     @property
     def platform(self) -> str:
@@ -679,8 +679,8 @@ class JAKTestServer_LinuxWebService(JAKTestServer_WebService):
         version (str): The version of the test server.
     """
 
-    def __init__(self, version: str):
-        super().__init__(version)
+    def __init__(self, version: str, dataset_version: str):
+        super().__init__(version, dataset_version)
 
     @property
     def platform(self) -> str:

--- a/environment/aws/topology_setup/test_server_platforms/java_register.py
+++ b/environment/aws/topology_setup/test_server_platforms/java_register.py
@@ -255,9 +255,6 @@ class JAKTestServer(TestServer):
         """
         Build the JAK test server.
         """
-        if self.dataset_version is None:
-            raise RuntimeError("dataset_version must be set before building")
-
         gradle_path = JAK_TEST_SERVER_DIR / self.test_server_path / "gradlew"
         if platform.system() == "Windows":
             gradle_path = gradle_path.with_suffix(".bat")
@@ -384,9 +381,6 @@ class JAKTestServer_WebService(JAKTestServer):
         return "webservice"
 
     def create_bridge(self):
-        if self.dataset_version is None:
-            raise RuntimeError("dataset_version must be set before creating bridge")
-
         return JettyBridge(self.version, self.dataset_version)
 
 

--- a/environment/aws/topology_setup/test_server_platforms/java_register.py
+++ b/environment/aws/topology_setup/test_server_platforms/java_register.py
@@ -305,10 +305,8 @@ class JAKTestServer_Android(JAKTestServer):
         Returns:
             str: The path for the latest builds.
         """
-
-        # testserver_android.apk must match what is output in compress_package
         version_parts = self.version.split("-")
-        return f"couchbase-lite-android/{version_parts[0]}/{version_parts[1]}/testserver_android.apk"
+        return f"couchbase-lite-android/{version_parts[0]}/{version_parts[1]}/testserver_android_{self.dataset_version}.apk"
 
     def create_bridge(self) -> PlatformBridge:
         """
@@ -415,7 +413,7 @@ class JAKTestServer_WindowsDesktop(JAKTestServer_Desktop):
             str: The path for the latest builds.
         """
         version_parts = self.version.split("-")
-        return f"couchbase-lite-java/{version_parts[0]}/{version_parts[1]}/testserver_windows_desktop.zip"
+        return f"couchbase-lite-java/{version_parts[0]}/{version_parts[1]}/testserver_windows_desktop_{self.dataset_version}.zip"
 
     def compress_package(self) -> str:
         """
@@ -471,7 +469,7 @@ class JAKTestServer_WindowsWebService(JAKTestServer_WebService):
             str: The path for the latest builds.
         """
         version_parts = self.version.split("-")
-        return f"couchbase-lite-java/{version_parts[0]}/{version_parts[1]}/testserver_windows_webservice.zip"
+        return f"couchbase-lite-java/{version_parts[0]}/{version_parts[1]}/testserver_windows_webservice_{self.dataset_version}.zip"
 
     def compress_package(self) -> str:
         """
@@ -527,7 +525,7 @@ class JAKTestServer_macOSWebService(JAKTestServer_WebService):
             str: The path for the latest builds.
         """
         version_parts = self.version.split("-")
-        return f"couchbase-lite-java/{version_parts[0]}/{version_parts[1]}/testserver_macos_webservice.zip"
+        return f"couchbase-lite-java/{version_parts[0]}/{version_parts[1]}/testserver_macos_webservice_{self.dataset_version}.zip"
 
     def compress_package(self) -> str:
         """
@@ -583,7 +581,7 @@ class JAKTestServer_macOSDesktop(JAKTestServer_Desktop):
             str: The path for the latest builds.
         """
         version_parts = self.version.split("-")
-        return f"couchbase-lite-java/{version_parts[0]}/{version_parts[1]}/testserver_macos_desktop.zip"
+        return f"couchbase-lite-java/{version_parts[0]}/{version_parts[1]}/testserver_macos_desktop_{self.dataset_version}.zip"
 
     def compress_package(self) -> str:
         """
@@ -639,7 +637,7 @@ class JAKTestServer_LinuxDesktop(JAKTestServer_Desktop):
             str: The path for the latest builds.
         """
         version_parts = self.version.split("-")
-        return f"couchbase-lite-java/{version_parts[0]}/{version_parts[1]}/testserver_linux_desktop.tar.gz"
+        return f"couchbase-lite-java/{version_parts[0]}/{version_parts[1]}/testserver_linux_desktop_{self.dataset_version}.tar.gz"
 
     def compress_package(self) -> str:
         """
@@ -695,7 +693,7 @@ class JAKTestServer_LinuxWebService(JAKTestServer_WebService):
             str: The path for the latest builds.
         """
         version_parts = self.version.split("-")
-        return f"couchbase-lite-java/{version_parts[0]}/{version_parts[1]}/testserver_linux_webservice.tar.gz"
+        return f"couchbase-lite-java/{version_parts[0]}/{version_parts[1]}/testserver_linux_webservice_{self.dataset_version}.tar.gz"
 
     def compress_package(self) -> str:
         """

--- a/environment/aws/topology_setup/test_server_platforms/swift_register.py
+++ b/environment/aws/topology_setup/test_server_platforms/swift_register.py
@@ -123,10 +123,8 @@ class SwiftTestServer_iOS(SwiftTestServer):
         Returns:
             str: The path for the latest builds.
         """
-
-        # testserver_ios.zip must match what is output in compress_package
         version_parts = self.version.split("-")
-        return f"couchbase-lite-ios/{version_parts[0]}/{version_parts[1]}/testserver_ios.zip"
+        return f"couchbase-lite-ios/{version_parts[0]}/{version_parts[1]}/testserver_ios_{self.dataset_version}.zip"
 
     def build(self) -> None:
         self._copy_dataset()

--- a/environment/aws/topology_setup/test_server_platforms/swift_register.py
+++ b/environment/aws/topology_setup/test_server_platforms/swift_register.py
@@ -57,8 +57,8 @@ class SwiftTestServer(TestServer):
         version (str): The version of the test server.
     """
 
-    def __init__(self, version: str):
-        super().__init__(version)
+    def __init__(self, version: str, dataset_version: str):
+        super().__init__(version, dataset_version)
 
     def cbl_filename(self, version: str) -> str:
         return f"couchbase-lite-swift_xc_enterprise_{version}.zip"
@@ -94,8 +94,8 @@ class SwiftTestServer_iOS(SwiftTestServer):
         version (str): The version of the test server.
     """
 
-    def __init__(self, version: str):
-        super().__init__(version)
+    def __init__(self, version: str, dataset_version: str):
+        super().__init__(version, dataset_version)
 
     @property
     def platform(self) -> str:

--- a/environment/aws/topology_setup/test_server_platforms/swift_register.py
+++ b/environment/aws/topology_setup/test_server_platforms/swift_register.py
@@ -36,6 +36,7 @@ from environment.aws.topology_setup.test_server import (
     DOWNLOADED_TEST_SERVER_DIR,
     TEST_SERVER_DIR,
     TestServer,
+    copy_dataset,
 )
 
 from .ios_bridge import iOSBridge
@@ -84,6 +85,13 @@ class SwiftTestServer(TestServer):
         unzip_directory(download_file, FRAMEWORKS_DIR)
         download_file.unlink()
 
+    def _copy_dataset(self) -> None:
+        dest_dir = SWIFT_TEST_SERVER_DIR / "Assets"
+        copy_dataset(
+            dest_dir,
+            self.dataset_version,
+        )
+
 
 @TestServer.register("swift_ios")
 class SwiftTestServer_iOS(SwiftTestServer):
@@ -121,6 +129,7 @@ class SwiftTestServer_iOS(SwiftTestServer):
         return f"couchbase-lite-ios/{version_parts[0]}/{version_parts[1]}/testserver_ios.zip"
 
     def build(self) -> None:
+        self._copy_dataset()
         self._download_cbl()
         header("Building")
         env = os.environ.copy()

--- a/environment/aws/topology_setup/topology_schema.json
+++ b/environment/aws/topology_setup/topology_schema.json
@@ -69,7 +69,7 @@
                         "default": false
                     }
                 },
-                "required": ["location", "cbl_version", "platform"],
+                "required": ["location", "cbl_version", "platform", "dataset_version"],
                 "additionalProperties": false
             }
         },

--- a/jenkins/pipelines/dotnet/prepare_env.psm1
+++ b/jenkins/pipelines/dotnet/prepare_env.psm1
@@ -1,15 +1,2 @@
 Invoke-WebRequest https://raw.githubusercontent.com/couchbaselabs/couchbase-mobile-tools/refs/heads/master/dotnet_testing_env/prepare_dotnet.psm1 -OutFile $PSScriptRoot/prepare_dotnet.psm1
 Import-Module $PSScriptRoot/prepare_dotnet.psm1 -Force
-
-function Copy-Datasets {
-    param (
-        [Parameter(Mandatory=$true)][string]$Version
-    )
-    Banner -Text "Copying dataset resources v$Version"
-
-    New-Item -ItemType Directory -Path $PSScriptRoot/../../../servers/dotnet/testserver.cli/Resources -ErrorAction SilentlyContinue
-    Push-Location $PSScriptRoot/../../../servers/dotnet/testserver.cli/Resources
-    Copy-Item -Force $PSScriptRoot/../../../dataset/server/dbs/$Version/*.zip . -Verbose
-    Copy-Item -Recurse -Force $PSScriptRoot/../../../dataset/server/blobs . -Verbose
-    Pop-Location
-}

--- a/jenkins/pipelines/dotnet/prepare_env.sh
+++ b/jenkins/pipelines/dotnet/prepare_env.sh
@@ -12,18 +12,3 @@ if [ ! -f $PREPARE_DOTNET_SCRIPT ]; then
 fi
 
 source $PREPARE_DOTNET_SCRIPT
-
-function copy_datasets() {
-    if [ $# -ne 1 ]; then
-        echo "No version provided to copy_datasets!"
-        exit 1
-    fi
-
-    banner "Copying dataset resources v$1"
-
-    mkdir -p $SCRIPT_DIR/../../../servers/dotnet/testserver/Resources/Raw
-    pushd $SCRIPT_DIR/../../../servers/dotnet/testserver/Resources/Raw
-    cp -fv $SCRIPT_DIR/../../../dataset/server/dbs/$1/*.zip .
-    cp -Rfv $SCRIPT_DIR/../../../dataset/server/blobs .
-    popd
-}

--- a/jenkins/pipelines/dotnet/run_test.ps1
+++ b/jenkins/pipelines/dotnet/run_test.ps1
@@ -9,7 +9,6 @@ Import-Module $PSScriptRoot/prepare_env.psm1 -Force
 $ErrorActionPreference = "Stop" 
 
 Install-DotNet
-Copy-Datasets -Version $Dataset
 
 python -m venv venv
 .\venv\Scripts\activate

--- a/jenkins/pipelines/dotnet/run_test.sh
+++ b/jenkins/pipelines/dotnet/run_test.sh
@@ -18,7 +18,6 @@ function prepare_dotnet() {
     if [ "$platform" != "macos" ]; then
         install_xharness
     fi
-    copy_datasets $dataset_version
 }
 
 if [ $# -lt 4 ]; then

--- a/servers/dotnet/testserver.logic/ObjectManager.cs
+++ b/servers/dotnet/testserver.logic/ObjectManager.cs
@@ -95,7 +95,7 @@ namespace TestServer
 
             Stream asset;
             try {
-                asset = await _fileSystem.OpenAppPackageFileAsync($"{datasetName}.cblite2.zip");
+                asset = await _fileSystem.OpenAppPackageFileAsync($"dbs/{datasetName}.cblite2.zip");
             } catch (Exception ex) {
                 throw new ApplicationException($"Unable to open dataset '{datasetName}'", ex);
             }


### PR DESCRIPTION
It is now required in the build_test_server script, and topology.json.  

Modify the builds to copy the dataset

Put the dataset version into the latestbuilds path