### PR TITLE
Add devicectl support to iOS bridge

### DIFF
--- a/environment/aws/topology_setup/setup_topology.py
+++ b/environment/aws/topology_setup/setup_topology.py
@@ -411,6 +411,7 @@ class TopologyConfig:
                 test_server.build()
 
             bridge = test_server.create_bridge()
+            bridge.validate(test_server_input.location)
             bridge.install(test_server_input.location)
             bridge.run(test_server_input.location)
             port = 5555 if test_server_input.platform.startswith("dotnet") else 8080
@@ -440,6 +441,7 @@ class TopologyConfig:
                 test_server_input.platform, test_server_input.cbl_version
             )
             bridge = test_server.create_bridge()
+            bridge.validate(test_server_input.location)
             bridge.stop(test_server_input.location)
 
     def apply_sgw_hostnames(self, hostnames: List[str]):

--- a/environment/aws/topology_setup/test_server_platforms/c_register.py
+++ b/environment/aws/topology_setup/test_server_platforms/c_register.py
@@ -253,7 +253,7 @@ class CTestServer_iOS(CTestServer):
 
         return iOSBridge(
             str(path),
-            False,
+            "com.couchbase.CBLTestServer",
         )
 
     def compress_package(self) -> str:

--- a/environment/aws/topology_setup/test_server_platforms/dotnet_register.py
+++ b/environment/aws/topology_setup/test_server_platforms/dotnet_register.py
@@ -292,7 +292,7 @@ class DotnetTestServer_iOS(DotnetTestServer):
         )
         return iOSBridge(
             str(prefix / "testserver.app"),
-            False,
+            "com.couchbase.dotnet.testserver",
         )
 
     def compress_package(self) -> str:

--- a/environment/aws/topology_setup/test_server_platforms/swift_register.py
+++ b/environment/aws/topology_setup/test_server_platforms/swift_register.py
@@ -172,7 +172,7 @@ class SwiftTestServer_iOS(SwiftTestServer):
         path = location / "TestServer-iOS.app"
         return iOSBridge(
             str(path),
-            True,
+            "com.couchbase.ios.testserver",
         )
 
     def compress_package(self) -> str:


### PR DESCRIPTION
Now there is no toggle.  It will always try devicectl first and fallback to xharness if available