### PR TITLE
Add in functionality to setup_test for dynamic patch versions

### DIFF
--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 ]
 description = "A client for consuming the Couchbase Lite functional testing REST API"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = {text ="Apache-2.0"}
 classifiers = [
     "Programming Language :: Python :: 3 :: Only",
@@ -22,12 +22,46 @@ classifiers = [
     "Environment :: Console"
 ]
 dependencies = [
-    "aiohttp",
-    "opentelemetry-api",
-    "couchbase",
-    "websocket-client",
-    "requests",
-    "typing_extensions; python_version < '3.10'"
+    "aiohappyeyeballs==2.4.4",
+    "aiohttp==3.11.11",
+    "aiosignal==1.3.2",
+    "async-timeout==5.0.1",
+    "attrs==24.3.0",
+    "certifi==2024.12.14",
+    "charset-normalizer==3.4.1",
+    "colorama==0.4.6",
+    "couchbase==4.3.4",
+    "Deprecated==1.2.15",
+    "exceptiongroup==1.2.2",
+    "executing==2.1.0",
+    "frozenlist==1.5.0",
+    "googleapis-common-protos==1.66.0",
+    "grpcio==1.69.0",
+    "idna==3.10",
+    "importlib_metadata==8.5.0",
+    "iniconfig==2.0.0",
+    "multidict==6.1.0",
+    "opentelemetry-api==1.29.0",
+    "opentelemetry-exporter-otlp-proto-common==1.29.0",
+    "opentelemetry-exporter-otlp-proto-grpc==1.29.0",
+    "opentelemetry-proto==1.29.0",
+    "opentelemetry-sdk==1.29.0",
+    "opentelemetry-semantic-conventions==0.50b0",
+    "packaging==24.2",
+    "pluggy==1.5.0",
+    "propcache==0.2.1",
+    "protobuf==5.29.3",
+    "pytest==8.3.4",
+    "pytest-asyncio==0.25.2",
+    "requests==2.32.3",
+    "tomli==2.2.1",
+    "types-Deprecated==1.2.15.20241117",
+    "types-requests==2.32.0.20241016",
+    "urllib3==2.3.0",
+    "websocket-client==1.8.0",
+    "wrapt==1.17.2",
+    "yarl==1.18.3",
+    "zipp==3.21.0",
 ]
 
 [project.urls]

--- a/client/requirements.txt
+++ b/client/requirements.txt
@@ -18,8 +18,6 @@ idna==3.10
 importlib_metadata==8.5.0
 iniconfig==2.0.0
 multidict==6.1.0
-mypy==1.14.1
-mypy-extensions==1.0.0
 opentelemetry-api==1.29.0
 opentelemetry-exporter-otlp-proto-common==1.29.0
 opentelemetry-exporter-otlp-proto-grpc==1.29.0
@@ -33,11 +31,9 @@ protobuf==5.29.3
 pytest==8.3.4
 pytest-asyncio==0.25.2
 requests==2.32.3
-ruff==0.9.2
 tomli==2.2.1
 types-Deprecated==1.2.15.20241117
 types-requests==2.32.0.20241016
-typing_extensions==4.12.2; python_version < '3.10'
 urllib3==2.3.0
 websocket-client==1.8.0
 wrapt==1.17.2

--- a/client/src/cbltest/jsonhelper.py
+++ b/client/src/cbltest/jsonhelper.py
@@ -1,11 +1,5 @@
 import json
-import sys
-from typing import Any, List, Optional, Type, TypeVar, cast
-
-if sys.version_info >= (3, 10):
-    from typing import get_origin
-else:
-    from typing_extensions import get_origin
+from typing import Any, List, Optional, Type, TypeVar, cast, get_origin
 
 from .logging import cbl_info, cbl_warning
 

--- a/jenkins/pipelines/dotnet/setup_test.py
+++ b/jenkins/pipelines/dotnet/setup_test.py
@@ -24,6 +24,11 @@ from jenkins.pipelines.shared.setup_test import setup_test
 @click.argument("dataset_version")
 @click.argument("sgw_version")
 @click.option(
+    "--cbs_version",
+    default="7.6",
+    help="The Couchbase Server version to use for the test (default: 7.6.x)",
+)
+@click.option(
     "--private_key",
     help="The private key to use for the SSH connection (if not default)",
 )
@@ -33,6 +38,7 @@ def cli_entry(
     dataset_version: str,
     sgw_version: str,
     private_key: Optional[str],
+    cbs_version: str,
 ) -> None:
     setup_test(
         cbl_version,
@@ -42,6 +48,7 @@ def cli_entry(
         SCRIPT_DIR / "config_aws.json",
         f"dotnet_{platform}",
         private_key,
+        cbs_version,
     )
 
 


### PR DESCRIPTION
If you pass in a two digit version for SGW or CBS python will look up the latest released patch for you.

Bump minimum python to 3.10 so that I can get rid of some cruft.  Fix up the dependencies section to mirror the frozen requirements.txt.