### PR TITLE
Correct the path for C /getDocument

### DIFF
--- a/servers/c/src/Dispatcher.cpp
+++ b/servers/c/src/Dispatcher.cpp
@@ -26,7 +26,7 @@ namespace ts {
         addRule({"POST", "/newSession", HANDLER(handlePOSTNewSession)});
         addRule({"POST", "/reset", HANDLER(handlePOSTReset)});
         addRule({"POST", "/getAllDocuments", HANDLER(handlePOSTGetAllDocuments)});
-        addRule({"POST", "/test/getDocument", HANDLER(handlePOSTGetDocument)});
+        addRule({"POST", "/getDocument", HANDLER(handlePOSTGetDocument)});
         addRule({"POST", "/updateDatabase", HANDLER(handlePOSTUpdateDatabase)});
         addRule({"POST", "/startReplicator", HANDLER(handlePOSTStartReplicator)});
         addRule({"POST", "/startListener", HANDLER(handlePOSTStartListener)});


### PR DESCRIPTION
* Fixed the path for /getDocument. 
* This will fix test_pull_after_restore_access failure.