### PR TITLE
Add dataset_version property to new session endpoint

### DIFF
--- a/servers/jak/shared/common/main/java/com/couchbase/lite/mobiletest/TestApp.java
+++ b/servers/jak/shared/common/main/java/com/couchbase/lite/mobiletest/TestApp.java
@@ -155,9 +155,9 @@ public abstract class TestApp {
     }
 
     @NonNull
-    public final TestContext newSession(@NonNull String client) {
+    public final TestContext newSession(@NonNull String client, @Nullable String datasetVersion) {
         final TestContext ctxt = session;
-        session = new TestContext(client);
+        session = new TestContext(client, datasetVersion);
         if (ctxt != null) { ctxt.close(); }
         return session;
     }

--- a/servers/jak/shared/common/main/java/com/couchbase/lite/mobiletest/TestContext.java
+++ b/servers/jak/shared/common/main/java/com/couchbase/lite/mobiletest/TestContext.java
@@ -28,8 +28,13 @@ import com.couchbase.lite.mobiletest.util.FileUtils;
 public final class TestContext implements AutoCloseable {
     private static final String TAG = "CONTEXT";
 
+    private static final String DEFAULT_DATASET_VERSION = "3.2";
+
+
     @NonNull
     private final String client;
+    @NonNull
+    private final String datasetVersion;
     @Nullable
     private String testName;
     @Nullable
@@ -47,7 +52,11 @@ public final class TestContext implements AutoCloseable {
     @Nullable
     private Map<String, URLEndpointListener> openEndptListeners;
 
-    TestContext(@NonNull String client) { this.client = client; }
+    TestContext(@NonNull String client, @Nullable String datasetVersion) {
+        this.client = client;
+        // !!! Unimplemented: this is completely ignored
+        this.datasetVersion = (datasetVersion == null) ? DEFAULT_DATASET_VERSION : datasetVersion;
+    }
 
     @Override
     public void close() {
@@ -68,6 +77,9 @@ public final class TestContext implements AutoCloseable {
 
     @NonNull
     public String getClient() { return client; }
+
+    @NonNull
+    public String getDatasetVersion() { return datasetVersion; }
 
     public void setTestName(@Nullable String testName) { this.testName = testName; }
 

--- a/servers/jak/shared/common/main/java/com/couchbase/lite/mobiletest/endpoints/v1/Session.java
+++ b/servers/jak/shared/common/main/java/com/couchbase/lite/mobiletest/endpoints/v1/Session.java
@@ -43,14 +43,18 @@ public class Session {
     private static final String KEY_COLLECTIONS = "collections";
     private static final String KEY_DATASET = "dataset";
     private static final String KEY_ID = "id";
+    private static final String KEY_DATASET_VERSION = "dataset_version";
     private static final String KEY_LOGGING = "logging";
+
     private static final String KEY_URL = "url";
     private static final String KEY_TAG = "tag";
+
 
     private static final Set<String> LEGAL_SESSION_KEYS;
     static {
         final Set<String> l = new HashSet<>();
         l.add(KEY_ID);
+        l.add(KEY_DATASET_VERSION);
         l.add(KEY_LOGGING);
         LEGAL_SESSION_KEYS = Collections.unmodifiableSet(l);
     }
@@ -103,7 +107,7 @@ public class Session {
 
         endSession(app);
 
-        final TestContext newCtxt = app.newSession(sessionId);
+        final TestContext newCtxt = app.newSession(sessionId, req.getString(KEY_DATASET_VERSION));
         startSession(app, newCtxt);
 
         final TypedMap logConfig = req.getMap(KEY_LOGGING);
@@ -121,11 +125,15 @@ public class Session {
 
         final TestContext oldCtxt = app.getSession(client);
         String testName = oldCtxt.getTestName();
+
         if (testName != null) { Log.p(TAG, "<<<<< END TEST: " + testName); }
+
+        // preserve the dataset version across resets
+        final String datasetVersion = oldCtxt.getDatasetVersion();
 
         endSession(app);
 
-        final TestContext newCtxt = app.newSession(client);
+        final TestContext newCtxt = app.newSession(client, datasetVersion);
         final DatabaseService dbSvc = startSession(app, newCtxt);
         testName = req.getString(KEY_TEST_NAME);
         newCtxt.setTestName(testName);


### PR DESCRIPTION
dataset_version is *not* implemented.  It is merely recognized and recorded in the session.