### PR TITLE
Implement Multipeer Replicator Support in iOS (API 1.2.1)

### DIFF
--- a/servers/ios/TestServer.xcodeproj/project.pbxproj
+++ b/servers/ios/TestServer.xcodeproj/project.pbxproj
@@ -12,6 +12,12 @@
 		404619D22CB9A985003835C7 /* NewSessionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 404619D12CB9A985003835C7 /* NewSessionHandler.swift */; };
 		4055CAA02CDC33A400EDD0CB /* IPAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4055CA9F2CDC33A400EDD0CB /* IPAddress.swift */; };
 		409F45302DFA7BC900BB7851 /* FileDownloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 409F452F2DFA7BC900BB7851 /* FileDownloader.swift */; };
+		409F43F82DEA348500BB7851 /* StartMultipeerReplicatorRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 409F43F72DEA348500BB7851 /* StartMultipeerReplicatorRequest.swift */; };
+		409F43FC2DEA373E00BB7851 /* StartMultipeerReplicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 409F43FB2DEA373E00BB7851 /* StartMultipeerReplicator.swift */; };
+		409F44002DEA561A00BB7851 /* MultipeerReplicatorConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 409F43FF2DEA561A00BB7851 /* MultipeerReplicatorConfiguration.swift */; };
+		409F44022DEA823A00BB7851 /* StopMultipeerReplicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 409F44012DEA823A00BB7851 /* StopMultipeerReplicator.swift */; };
+		409F44172DEE187600BB7851 /* GetMultipeerReplicatorStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 409F44162DEE187600BB7851 /* GetMultipeerReplicatorStatus.swift */; };
+		409F442C2DEE228300BB7851 /* MultipeerReplicatorStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 409F442B2DEE228300BB7851 /* MultipeerReplicatorStatus.swift */; };
 		40AA34992CAF5D20004F4D08 /* StopReplicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40AA34982CAF5D20004F4D08 /* StopReplicator.swift */; };
 		40AA349D2CAF6755004F4D08 /* CollectionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40AA349C2CAF6755004F4D08 /* CollectionSpec.swift */; };
 		40AA34A12CAF6BE4004F4D08 /* ReplicationConflictResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40AA34A02CAF6BE4004F4D08 /* ReplicationConflictResolver.swift */; };
@@ -97,6 +103,12 @@
 		404619D12CB9A985003835C7 /* NewSessionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewSessionHandler.swift; sourceTree = "<group>"; };
 		4055CA9F2CDC33A400EDD0CB /* IPAddress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IPAddress.swift; sourceTree = "<group>"; };
 		409F452F2DFA7BC900BB7851 /* FileDownloader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileDownloader.swift; sourceTree = "<group>"; };
+		409F43F72DEA348500BB7851 /* StartMultipeerReplicatorRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartMultipeerReplicatorRequest.swift; sourceTree = "<group>"; };
+		409F43FB2DEA373E00BB7851 /* StartMultipeerReplicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartMultipeerReplicator.swift; sourceTree = "<group>"; };
+		409F43FF2DEA561A00BB7851 /* MultipeerReplicatorConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipeerReplicatorConfiguration.swift; sourceTree = "<group>"; };
+		409F44012DEA823A00BB7851 /* StopMultipeerReplicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StopMultipeerReplicator.swift; sourceTree = "<group>"; };
+		409F44162DEE187600BB7851 /* GetMultipeerReplicatorStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetMultipeerReplicatorStatus.swift; sourceTree = "<group>"; };
+		409F442B2DEE228300BB7851 /* MultipeerReplicatorStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipeerReplicatorStatus.swift; sourceTree = "<group>"; };
 		40A219D62CDC3E790038204C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		40AA34982CAF5D20004F4D08 /* StopReplicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StopReplicator.swift; sourceTree = "<group>"; };
 		40AA349C2CAF6755004F4D08 /* CollectionSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionSpec.swift; sourceTree = "<group>"; };
@@ -231,6 +243,7 @@
 			children = (
 				40BDA7F72AF1C13B008DB256 /* GetAllDocuments.swift */,
 				40AA34A42CAF94A4004F4D08 /* GetDocument.swift */,
+				409F44162DEE187600BB7851 /* GetMultipeerReplicatorStatus.swift */,
 				40BDA7F62AF1C13B008DB256 /* GetReplicatorStatus.swift */,
 				40BDA7F02AF1C13B008DB256 /* GetRootHandler.swift */,
 				40BDA7F32AF1C13B008DB256 /* Handler.swift */,
@@ -239,7 +252,9 @@
 				40BDA7EE2AF1C13B008DB256 /* ResetHandler.swift */,
 				40C7A5622CA4AF5C0053ADCB /* RunQuery.swift */,
 				40BDA7F42AF1C13B008DB256 /* SnapshotDocuments.swift */,
+				409F43FB2DEA373E00BB7851 /* StartMultipeerReplicator.swift */,
 				40BDA7EF2AF1C13B008DB256 /* StartReplicator.swift */,
+				409F44012DEA823A00BB7851 /* StopMultipeerReplicator.swift */,
 				40AA34982CAF5D20004F4D08 /* StopReplicator.swift */,
 				40BDA7F22AF1C13B008DB256 /* UpdateDatabase.swift */,
 				40BDA7F12AF1C13B008DB256 /* VerifyDocuments.swift */,
@@ -296,6 +311,8 @@
 				40BDA8D92AF20AAB008DB256 /* DocumentID.swift */,
 				40BDA8D22AF20AAB008DB256 /* DocumentReplication.swift */,
 				40AA34A62CAF9BC8004F4D08 /* GetDocumentRequest.swift */,
+				409F43FF2DEA561A00BB7851 /* MultipeerReplicatorConfiguration.swift */,
+				409F442B2DEE228300BB7851 /* MultipeerReplicatorStatus.swift */,
 				404619CF2CB9A761003835C7 /* NewSession.swift */,
 				40BDA8D32AF20AAB008DB256 /* PerformMaintenanceConfiguration.swift */,
 				40C7A5662CA4B15B0053ADCB /* QueryResults.swift */,
@@ -311,6 +328,7 @@
 				40BDA8DC2AF20AAB008DB256 /* ServerInfo.swift */,
 				40BDA8CF2AF20AAB008DB256 /* SnapshotID.swift */,
 				40BDA8CC2AF20AAB008DB256 /* SnapshotRequest.swift */,
+				409F43F72DEA348500BB7851 /* StartMultipeerReplicatorRequest.swift */,
 				40BDA8CD2AF20AAB008DB256 /* StartReplicatorRequest.swift */,
 				40BDA8D72AF20AAB008DB256 /* TestServerError.swift */,
 				40BDA8DB2AF20AAB008DB256 /* UpdateRequest.swift */,
@@ -435,10 +453,13 @@
 				40BDA8132AF1C15C008DB256 /* ReplicationFilterFactory.swift in Sources */,
 				40BDA8EC2AF20AAB008DB256 /* VerifyRequest.swift in Sources */,
 				40BDA8062AF1C13B008DB256 /* TestServerMiddleware.swift in Sources */,
+				409F43F82DEA348500BB7851 /* StartMultipeerReplicatorRequest.swift in Sources */,
 				40BDA8F22AF20AAB008DB256 /* ServerInfo.swift in Sources */,
 				40BDA8F42AF20AAB008DB256 /* DatabaseUpdateItem.swift in Sources */,
 				40BDA8002AF1C13B008DB256 /* Handler.swift in Sources */,
+				409F44022DEA823A00BB7851 /* StopMultipeerReplicator.swift in Sources */,
 				40BDA7FC2AF1C13B008DB256 /* StartReplicator.swift in Sources */,
+				409F44172DEE187600BB7851 /* GetMultipeerReplicatorStatus.swift in Sources */,
 				40BDA7FE2AF1C13B008DB256 /* VerifyDocuments.swift in Sources */,
 				40BDA7FD2AF1C13B008DB256 /* GetRootHandler.swift in Sources */,
 				40BDA7FB2AF1C13B008DB256 /* ResetHandler.swift in Sources */,
@@ -455,6 +476,7 @@
 				40AA34A12CAF6BE4004F4D08 /* ReplicationConflictResolver.swift in Sources */,
 				40BDA8E72AF20AAB008DB256 /* CollectionDocuments.swift in Sources */,
 				40C7A5672CA4B15B0053ADCB /* QueryResults.swift in Sources */,
+				409F44002DEA561A00BB7851 /* MultipeerReplicatorConfiguration.swift in Sources */,
 				EACC964D2AF3F8B500999C70 /* CBLVersion.swift in Sources */,
 				40AA34992CAF5D20004F4D08 /* StopReplicator.swift in Sources */,
 				404619D22CB9A985003835C7 /* NewSessionHandler.swift in Sources */,
@@ -477,8 +499,10 @@
 				409F45302DFA7BC900BB7851 /* FileDownloader.swift in Sources */,
 				40BDA8ED2AF20AAB008DB256 /* TestServerError.swift in Sources */,
 				40BDA8142AF1C15C008DB256 /* KeyPathParser.swift in Sources */,
+				409F43FC2DEA373E00BB7851 /* StartMultipeerReplicator.swift in Sources */,
 				40C7A5652CA4AFB40053ADCB /* RunQueryConfiguration.swift in Sources */,
 				40C7A5632CA4AF5C0053ADCB /* RunQuery.swift in Sources */,
+				409F442C2DEE228300BB7851 /* MultipeerReplicatorStatus.swift in Sources */,
 				4055CAA02CDC33A400EDD0CB /* IPAddress.swift in Sources */,
 				40BDA8EE2AF20AAB008DB256 /* ResetConfiguration.swift in Sources */,
 				40BDA8EB2AF20AAB008DB256 /* ReplicatorConfiguration.swift in Sources */,

--- a/servers/ios/TestServer.xcodeproj/project.pbxproj
+++ b/servers/ios/TestServer.xcodeproj/project.pbxproj
@@ -18,6 +18,8 @@
 		409F44022DEA823A00BB7851 /* StopMultipeerReplicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 409F44012DEA823A00BB7851 /* StopMultipeerReplicator.swift */; };
 		409F44172DEE187600BB7851 /* GetMultipeerReplicatorStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 409F44162DEE187600BB7851 /* GetMultipeerReplicatorStatus.swift */; };
 		409F442C2DEE228300BB7851 /* MultipeerReplicatorStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 409F442B2DEE228300BB7851 /* MultipeerReplicatorStatus.swift */; };
+		409F443D2DF0EB3800BB7851 /* MultipeerReplicatorCAAuthenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 409F443C2DF0EB3800BB7851 /* MultipeerReplicatorCAAuthenticator.swift */; };
+		409F443F2DF1016C00BB7851 /* MultipeerReplicatorIdentity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 409F443E2DF1016C00BB7851 /* MultipeerReplicatorIdentity.swift */; };
 		40AA34992CAF5D20004F4D08 /* StopReplicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40AA34982CAF5D20004F4D08 /* StopReplicator.swift */; };
 		40AA349D2CAF6755004F4D08 /* CollectionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40AA349C2CAF6755004F4D08 /* CollectionSpec.swift */; };
 		40AA34A12CAF6BE4004F4D08 /* ReplicationConflictResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40AA34A02CAF6BE4004F4D08 /* ReplicationConflictResolver.swift */; };
@@ -109,6 +111,8 @@
 		409F44012DEA823A00BB7851 /* StopMultipeerReplicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StopMultipeerReplicator.swift; sourceTree = "<group>"; };
 		409F44162DEE187600BB7851 /* GetMultipeerReplicatorStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetMultipeerReplicatorStatus.swift; sourceTree = "<group>"; };
 		409F442B2DEE228300BB7851 /* MultipeerReplicatorStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipeerReplicatorStatus.swift; sourceTree = "<group>"; };
+		409F443C2DF0EB3800BB7851 /* MultipeerReplicatorCAAuthenticator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipeerReplicatorCAAuthenticator.swift; sourceTree = "<group>"; };
+		409F443E2DF1016C00BB7851 /* MultipeerReplicatorIdentity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipeerReplicatorIdentity.swift; sourceTree = "<group>"; };
 		40A219D62CDC3E790038204C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		40AA34982CAF5D20004F4D08 /* StopReplicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StopReplicator.swift; sourceTree = "<group>"; };
 		40AA349C2CAF6755004F4D08 /* CollectionSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionSpec.swift; sourceTree = "<group>"; };
@@ -311,7 +315,9 @@
 				40BDA8D92AF20AAB008DB256 /* DocumentID.swift */,
 				40BDA8D22AF20AAB008DB256 /* DocumentReplication.swift */,
 				40AA34A62CAF9BC8004F4D08 /* GetDocumentRequest.swift */,
+				409F443C2DF0EB3800BB7851 /* MultipeerReplicatorCAAuthenticator.swift */,
 				409F43FF2DEA561A00BB7851 /* MultipeerReplicatorConfiguration.swift */,
+				409F443E2DF1016C00BB7851 /* MultipeerReplicatorIdentity.swift */,
 				409F442B2DEE228300BB7851 /* MultipeerReplicatorStatus.swift */,
 				404619CF2CB9A761003835C7 /* NewSession.swift */,
 				40BDA8D32AF20AAB008DB256 /* PerformMaintenanceConfiguration.swift */,
@@ -454,6 +460,7 @@
 				40BDA8EC2AF20AAB008DB256 /* VerifyRequest.swift in Sources */,
 				40BDA8062AF1C13B008DB256 /* TestServerMiddleware.swift in Sources */,
 				409F43F82DEA348500BB7851 /* StartMultipeerReplicatorRequest.swift in Sources */,
+				409F443D2DF0EB3800BB7851 /* MultipeerReplicatorCAAuthenticator.swift in Sources */,
 				40BDA8F22AF20AAB008DB256 /* ServerInfo.swift in Sources */,
 				40BDA8F42AF20AAB008DB256 /* DatabaseUpdateItem.swift in Sources */,
 				40BDA8002AF1C13B008DB256 /* Handler.swift in Sources */,
@@ -484,6 +491,7 @@
 				40BDA8022AF1C13B008DB256 /* PerformMaintenance.swift in Sources */,
 				40BDA8032AF1C13B008DB256 /* GetReplicatorStatus.swift in Sources */,
 				40BDA8012AF1C13B008DB256 /* SnapshotDocuments.swift in Sources */,
+				409F443F2DF1016C00BB7851 /* MultipeerReplicatorIdentity.swift in Sources */,
 				40BDA8E42AF20AAB008DB256 /* ContentTypes.swift in Sources */,
 				40BDA8152AF1C15C008DB256 /* AnyCodable.swift in Sources */,
 				40AA34A32CAF8C4C004F4D08 /* ReplicationConflictResolverFactory.swift in Sources */,

--- a/servers/ios/TestServer/ContentTypes/DocumentReplication.swift
+++ b/servers/ios/TestServer/ContentTypes/DocumentReplication.swift
@@ -6,6 +6,7 @@
 //
 
 import Vapor
+import CouchbaseLiteSwift
 
 //DocumentReplication:
 //      type: object
@@ -53,5 +54,19 @@ extension ContentTypes {
     enum DocumentReplicationFlags : String, Codable {
         case deleted = "deleted"
         case accessRemoved = "accessRemoved"
+    }
+}
+
+extension ContentTypes.DocumentReplication {
+    init(doc: CouchbaseLiteSwift.ReplicatedDocument, isPush: Bool) {
+        var flags: [ContentTypes.DocumentReplicationFlags] = []
+        if doc.flags.contains(.accessRemoved) { flags.append(.accessRemoved) }
+        if doc.flags.contains(.deleted) { flags.append(.deleted) }
+        
+        self.collection = "\(doc.scope).\(doc.collection)"
+        self.documentID = doc.id
+        self.isPush = isPush
+        self.flags = flags
+        self.error = doc.error.map(TestServerError.cblError)
     }
 }

--- a/servers/ios/TestServer/ContentTypes/MultipeerReplicatorCAAuthenticator.swift
+++ b/servers/ios/TestServer/ContentTypes/MultipeerReplicatorCAAuthenticator.swift
@@ -1,0 +1,20 @@
+//
+//  MultipeerReplicatorCAAuthenticator.swift
+//  TestServer
+//
+//  Created by Pasin Suriyentrakorn on 6/4/25.
+//
+
+import Vapor
+
+extension ContentTypes {
+    enum MultipeerReplicatorCAAuthenticatorType : String, Codable {
+        case CACERT = "CA-CERT"
+    }
+    
+    struct MultipeerReplicatorCAAuthenticator : Content {
+        let type: MultipeerReplicatorCAAuthenticatorType
+        let certificate: String
+    }
+}
+

--- a/servers/ios/TestServer/ContentTypes/MultipeerReplicatorConfiguration.swift
+++ b/servers/ios/TestServer/ContentTypes/MultipeerReplicatorConfiguration.swift
@@ -1,0 +1,18 @@
+//
+//  MultipeerReplicatorConfiguration.swift
+//  TestServer
+//
+//  Created by Pasin Suriyentrakorn on 5/30/25.
+//
+
+import Foundation
+
+import Vapor
+
+extension ContentTypes {
+    struct MultipeerReplicatorConfiguration : Content {
+        let peerGroupID: String
+        let database: String
+        let collections: [ReplicationCollection]
+    }
+}

--- a/servers/ios/TestServer/ContentTypes/MultipeerReplicatorConfiguration.swift
+++ b/servers/ios/TestServer/ContentTypes/MultipeerReplicatorConfiguration.swift
@@ -5,8 +5,6 @@
 //  Created by Pasin Suriyentrakorn on 5/30/25.
 //
 
-import Foundation
-
 import Vapor
 
 extension ContentTypes {
@@ -14,5 +12,7 @@ extension ContentTypes {
         let peerGroupID: String
         let database: String
         let collections: [ReplicationCollection]
+        let identity: MultipeerReplicatorIdentity
+        let authenticator: MultipeerReplicatorCAAuthenticator?
     }
 }

--- a/servers/ios/TestServer/ContentTypes/MultipeerReplicatorIdentity.swift
+++ b/servers/ios/TestServer/ContentTypes/MultipeerReplicatorIdentity.swift
@@ -1,0 +1,20 @@
+//
+//  MultipeerReplicatorIdentity.swift
+//  TestServer
+//
+//  Created by Pasin Suriyentrakorn on 6/4/25.
+//
+
+import Vapor
+
+extension ContentTypes {
+    enum IdentityDataEncoding : String, Codable {
+        case PKCS12 = "PKCS12"
+    }
+    
+    struct MultipeerReplicatorIdentity : Content {
+        let encoding: IdentityDataEncoding
+        let data: String
+        let password: String?
+    }
+}

--- a/servers/ios/TestServer/ContentTypes/MultipeerReplicatorStatus.swift
+++ b/servers/ios/TestServer/ContentTypes/MultipeerReplicatorStatus.swift
@@ -1,0 +1,19 @@
+//
+//  MultipeerReplicatorStatus.swift
+//  TestServer
+//
+//  Created by Pasin Suriyentrakorn on 6/2/25.
+//
+
+import Vapor
+
+extension ContentTypes {
+    struct PeerReplicatorStatus : Content {
+        let peerID: String
+        let status: ReplicatorStatus
+    }
+    
+    struct MultipeerReplicatorStatus : Content {
+        let replicators: [PeerReplicatorStatus]
+    }
+}

--- a/servers/ios/TestServer/ContentTypes/StartMultipeerReplicatorRequest.swift
+++ b/servers/ios/TestServer/ContentTypes/StartMultipeerReplicatorRequest.swift
@@ -12,5 +12,7 @@ extension ContentTypes {
         let peerGroupID: String
         let database: String
         let collections: [ReplicationCollection]
+        let identity: MultipeerReplicatorIdentity
+        let authenticator: MultipeerReplicatorCAAuthenticator?
     }
 }

--- a/servers/ios/TestServer/ContentTypes/StartMultipeerReplicatorRequest.swift
+++ b/servers/ios/TestServer/ContentTypes/StartMultipeerReplicatorRequest.swift
@@ -1,0 +1,16 @@
+//
+//  StartMultipeerReplicatorRequest.swift
+//  TestServer
+//
+//  Created by Pasin Suriyentrakorn on 5/30/25.
+//
+
+import Vapor
+
+extension ContentTypes {
+    struct StartMultipeerReplicatorRequest : Content {
+        let peerGroupID: String
+        let database: String
+        let collections: [ReplicationCollection]
+    }
+}

--- a/servers/ios/TestServer/ContentTypes/TestServerError.swift
+++ b/servers/ios/TestServer/ContentTypes/TestServerError.swift
@@ -51,7 +51,13 @@ struct TestServerError : Error, Codable {
         if let error = error as NSError? {
             return TestServerError(domain: .TESTSERVER, code: error.code, message: error.localizedDescription)
         }
+        
         return badRequest(error.localizedDescription)
+    }
+
+    static func cblError(_ error: Error) -> TestServerError {
+        let err = error as NSError
+        return TestServerError(domain: .CBL, code: err.code, message: err.localizedDescription)
     }
     
     static let cblDBNotOpen = TestServerError(domain: .CBL, code: CBLError.notOpen, message: "Database is not open.")

--- a/servers/ios/TestServer/Handlers/GetMultipeerReplicatorStatus.swift
+++ b/servers/ios/TestServer/Handlers/GetMultipeerReplicatorStatus.swift
@@ -12,7 +12,7 @@ extension Handlers {
         guard let repl = try? req.content.decode(ContentTypes.Replicator.self) else {
             throw TestServerError.badRequest("Request body does not match the 'Replicator' schema.") }
         
-        let dbManager = req.application.databaseManager
+        let dbManager = req.databaseManager
         guard let status = dbManager.multipeerReplicatorStatus(forID: repl.id) else {
             throw TestServerError.badRequest("MultipeerReplicator with ID '\(repl.id)' does not exist.")
         }

--- a/servers/ios/TestServer/Handlers/GetMultipeerReplicatorStatus.swift
+++ b/servers/ios/TestServer/Handlers/GetMultipeerReplicatorStatus.swift
@@ -1,0 +1,21 @@
+//
+//  GetMultipeerReplicatorStatus.swift
+//  TestServer
+//
+//  Created by Pasin Suriyentrakorn on 6/2/25.
+//
+
+import Foundation
+
+extension Handlers {
+    static let getMultipperReplicatorStatus : EndpointHandler<ContentTypes.MultipeerReplicatorStatus> = { req throws in
+        guard let repl = try? req.content.decode(ContentTypes.Replicator.self) else {
+            throw TestServerError.badRequest("Request body does not match the 'Replicator' schema.") }
+        
+        let dbManager = req.application.databaseManager
+        guard let status = dbManager.multipeerReplicatorStatus(forID: repl.id) else {
+            throw TestServerError.badRequest("MultipeerReplicator with ID '\(repl.id)' does not exist.")
+        }
+        return status
+    }
+}

--- a/servers/ios/TestServer/Handlers/StartMultipeerReplicator.swift
+++ b/servers/ios/TestServer/Handlers/StartMultipeerReplicator.swift
@@ -1,0 +1,27 @@
+//
+//  StartMultipeerReplicator.swift
+//  TestServer
+//
+//  Created by Pasin Suriyentrakorn on 5/30/25.
+//
+
+import Foundation
+
+extension Handlers {
+    static let startMultipeerReplicator: EndpointHandler<ContentTypes.Replicator> = { req throws in
+        guard let request = try? req.content.decode(ContentTypes.StartMultipeerReplicatorRequest.self) else {
+            throw TestServerError.badRequest("Request body is not a valid startMultipeerReplicator Request.")
+        }
+        
+        let dbManager = req.application.databaseManager
+        
+        var config = ContentTypes.MultipeerReplicatorConfiguration(
+            peerGroupID: request.peerGroupID,
+            database: request.database,
+            collections: request.collections)
+        
+        let id = try dbManager.startMultipeerReplicator(config: config)
+        
+        return ContentTypes.Replicator(id: id)
+    }
+}

--- a/servers/ios/TestServer/Handlers/StartMultipeerReplicator.swift
+++ b/servers/ios/TestServer/Handlers/StartMultipeerReplicator.swift
@@ -13,7 +13,7 @@ extension Handlers {
             throw TestServerError.badRequest("Request body is not a valid startMultipeerReplicator Request.")
         }
         
-        let dbManager = req.application.databaseManager
+        let dbManager = req.databaseManager
         
         var config = ContentTypes.MultipeerReplicatorConfiguration(
             peerGroupID: request.peerGroupID,

--- a/servers/ios/TestServer/Handlers/StartMultipeerReplicator.swift
+++ b/servers/ios/TestServer/Handlers/StartMultipeerReplicator.swift
@@ -18,7 +18,9 @@ extension Handlers {
         var config = ContentTypes.MultipeerReplicatorConfiguration(
             peerGroupID: request.peerGroupID,
             database: request.database,
-            collections: request.collections)
+            collections: request.collections,
+            identity: request.identity,
+            authenticator: request.authenticator)
         
         let id = try dbManager.startMultipeerReplicator(config: config)
         

--- a/servers/ios/TestServer/Handlers/StopMultipeerReplicator.swift
+++ b/servers/ios/TestServer/Handlers/StopMultipeerReplicator.swift
@@ -1,0 +1,20 @@
+//
+//  StopMultipeerReplicator.swift
+//  TestServer
+//
+//  Created by Pasin Suriyentrakorn on 5/30/25.
+//
+
+import Vapor
+
+extension Handlers {
+    static let stopMultipeerReplicator: EndpointHandlerEmptyResponse = { req throws in
+        guard let requestedReplicator = try? req.content.decode(ContentTypes.Replicator.self) else {
+            throw TestServerError.badRequest("Request body does not match the 'Replicator' schema.")
+        }
+        
+        let dbManager = req.application.databaseManager
+        try dbManager.stopMultipeerReplicator(forID: requestedReplicator.id)
+        return Response(status: .ok)
+    }
+}

--- a/servers/ios/TestServer/Handlers/StopMultipeerReplicator.swift
+++ b/servers/ios/TestServer/Handlers/StopMultipeerReplicator.swift
@@ -13,7 +13,7 @@ extension Handlers {
             throw TestServerError.badRequest("Request body does not match the 'Replicator' schema.")
         }
         
-        let dbManager = req.application.databaseManager
+        let dbManager = req.databaseManager
         try dbManager.stopMultipeerReplicator(forID: requestedReplicator.id)
         return Response(status: .ok)
     }

--- a/servers/ios/TestServer/Server/TestServer.swift
+++ b/servers/ios/TestServer/Server/TestServer.swift
@@ -54,7 +54,7 @@ class TestServer : ObservableObject {
         setupRoutes()
     }
     
-    /// Implement API v1.2.0 (No support for start/stop listener - 1.1.0, and dynamic dataset - 1.1.1 yet)
+    /// Implement API v1.2.1 (No support for start/stop listener - 1.1.0, and dynamic dataset - 1.1.1 yet)
     private func setupRoutes() {
         app.get("", use: Handlers.getRoot)
         app.post("newSession", use: Handlers.newSession)

--- a/servers/ios/TestServer/Server/TestServer.swift
+++ b/servers/ios/TestServer/Server/TestServer.swift
@@ -54,7 +54,7 @@ class TestServer : ObservableObject {
         setupRoutes()
     }
     
-    /// Implement API v1.0.0
+    /// Implement API v1.2.0 (No support for start/stop listener - 1.1.0, and dynamic dataset - 1.1.1 yet)
     private func setupRoutes() {
         app.get("", use: Handlers.getRoot)
         app.post("newSession", use: Handlers.newSession)
@@ -66,7 +66,10 @@ class TestServer : ObservableObject {
         app.post("verifyDocuments", use: Handlers.verifyDocuments)
         app.post("startReplicator", use: Handlers.startReplicator)
         app.post("getReplicatorStatus", use: Handlers.getReplicatorStatus)
+        app.post("startMultipeerReplicator", use: Handlers.startMultipeerReplicator)
+        app.post("stopMultipeerReplicator", use: Handlers.stopMultipeerReplicator)
         app.post("performMaintenance", use: Handlers.performMaintenance)
+        app.post("getMultipeerReplicatorStatus", use: Handlers.getMultipperReplicatorStatus)
         app.post("runQuery", use: Handlers.runQuery)
         
         Log.log(level: .debug, message: "Server configured with the following routes: \n\(app.routes.description)")

--- a/servers/ios/TestServer/Utils/DatabaseManager.swift
+++ b/servers/ios/TestServer/Utils/DatabaseManager.swift
@@ -239,11 +239,9 @@ class DatabaseManager {
     public func startMultipeerReplicator(config: ContentTypes.MultipeerReplicatorConfiguration) throws -> UUID {
         Log.log(level: .debug, message: "Starting Multipeer Replicator")
         
-        let identity = try DatabaseManager.identity(for: config)
+        let identity = try DatabaseManager.multipeerReplicatorIdentity(for: config)
         
-        let authenticator = MultipeerCertificateAuthenticator { peer, certs in
-            return true
-        }
+        let authenticator = try DatabaseManager.multipeerAuthenticator(for: config.authenticator)
         
         var collectionConfigs: [MultipeerCollectionConfiguration] = []
         for replColl in config.collections {
@@ -621,34 +619,40 @@ class DatabaseManager {
         }
     }
     
-    private static func identity(for config: ContentTypes.MultipeerReplicatorConfiguration) throws -> TLSIdentity {
-        var allCollections: [String] = []
-        for collection in config.collections {
-            collection.names.forEach { allCollections.append($0) }
+    private static func multipeerReplicatorIdentity(for config: ContentTypes.MultipeerReplicatorConfiguration) throws -> TLSIdentity {
+        let label = "ios-multipeer-\(config.peerGroupID)"
+        
+        guard let data = Data(base64Encoded: config.identity.data) else {
+            throw TestServerError.badRequest("Invalid multipeer replictor's identity data")
         }
         
-        let input = "multipeer-\(config.peerGroupID)-\(config.database)-\(allCollections.joined(separator: ","))"
-        let data = Data(input.utf8)
-        let digest = Insecure.SHA1.hash(data: data)
-        let label = digest.map { String(format: "%02x", $0) }.joined()
-        
-        if let identity = try TLSIdentity.identity(withLabel: label) {
-            if identity.expiration > Date().addingTimeInterval(60 * 60 * 1 /* 60 Mins */) {
-                return identity
-            } else {
-                try TLSIdentity.deleteIdentity(withLabel: label)
+        try TLSIdentity.deleteIdentity(withLabel: label)
+        return try TLSIdentity.importIdentity(withData: data, password: config.identity.password, label: label)
+    }
+    
+    private static func multipeerAuthenticator(for config: ContentTypes.MultipeerReplicatorCAAuthenticator?) throws -> MultipeerCertificateAuthenticator {
+        guard let auth = config else {
+            return MultipeerCertificateAuthenticator { peer, certs in
+                return true
             }
         }
         
-        let keyUsages: KeyUsages = [.clientAuth, .serverAuth]
-        let attrs = [
-            certAttrCommonName: "CBLiteTests-\(label)"
-        ]
-        let expiration = Date().addingTimeInterval(60 * 60 * 2 /* 120 Mins */)
-        return try TLSIdentity.createIdentity(
-            for: keyUsages,
-            attributes: attrs,
-            expiration: expiration,
-            label: label)
+        var lines = auth.certificate
+            .components(separatedBy: .newlines)
+            .filter { !$0.contains("-----BEGIN CERTIFICATE-----") &&
+                      !$0.contains("-----END CERTIFICATE-----") &&
+                      !$0.isEmpty }
+        
+        let certData = lines.joined()
+
+        guard let derData = Data(base64Encoded: certData) else {
+            throw TestServerError.badRequest("Failed to convert multipeer authenticator's root certificate from PEM to DER")
+        }
+        
+        guard let rootCert = SecCertificateCreateWithData(nil, derData as CFData) else {
+            throw TestServerError.badRequest("Invalid multipeer authenticator's root certificate")
+        }
+        
+        return MultipeerCertificateAuthenticator(rootCerts: [rootCert])
     }
 }

--- a/servers/ios/TestServer/Utils/ReplicationFilterFactory.swift
+++ b/servers/ios/TestServer/Utils/ReplicationFilterFactory.swift
@@ -8,24 +8,42 @@
 import Foundation
 import CouchbaseLiteSwift
 
+struct AnyReplicationFilter {
+    private let block: (PeerID?, Document, DocumentFlags) -> Bool
+
+    init(_ block: @escaping (PeerID?, Document, DocumentFlags) -> Bool) {
+        self.block = block
+    }
+
+    func toReplicationFilter() -> ReplicationFilter {
+        return { doc, flags in self.block(nil, doc, flags) }
+    }
+
+    func toMultipeerReplicationFilter() -> MultipeerReplicationFilter {
+        return { peerID, doc, flags in self.block(peerID, doc, flags) }
+    }
+}
+
 struct ReplicationFilterFactory {
-    static func documentIDs(params: Dictionary<String, AnyCodable>?) throws -> ReplicationFilter {
-        guard let docIDsWrapped = params?["documentIDs"]
-        else { throw TestServerError.badRequest("Could not find key 'documentIDs' in params.") }
+    static func documentIDs(params: Dictionary<String, AnyCodable>?) throws -> AnyReplicationFilter {
+        guard let docIDsWrapped = params?["documentIDs"] else {
+            throw TestServerError.badRequest("Could not find key 'documentIDs' in params.")
+        }
         
         // docIDs should be a dictionary of collection name to array of docID
-        guard let validDocIDs = docIDsWrapped.value as? [String : [String]]
-        else { throw TestServerError.badRequest("documentIDs should be a Dict<String, Arr<String>>.") }
-        
-        return { document, _ in
-            return validDocIDs.contains(where: { (_, docIDs) in docIDs.contains(document.id) })
+        guard let validDocIDs = docIDsWrapped.value as? [String : [String]] else {
+            throw TestServerError.badRequest("documentIDs should be a Dict<String, Arr<String>>.")
         }
+        
+        return AnyReplicationFilter({ _, document, _ in
+            return validDocIDs.contains(where: { (_, docIDs) in docIDs.contains(document.id) })
+        })
     }
     
-    static func deletedDocumentsOnly() throws -> ReplicationFilter {
-        return { _, docFlags in
+    static func deletedDocumentsOnly() throws -> AnyReplicationFilter {
+        return AnyReplicationFilter({ _, _, docFlags in
             return docFlags == .deleted
-        }
+        })
     }
     
     private enum availableFilters : String {
@@ -33,9 +51,10 @@ struct ReplicationFilterFactory {
         case deletedDocumentsOnly = "deletedDocumentsOnly"
     }
     
-    static func getFilter(withName name: String, params: Dictionary<String, AnyCodable>? = nil) throws -> ReplicationFilter {
-        guard let filter = availableFilters(rawValue: name)
-        else { throw TestServerError.badRequest("Could not find filter with name '\(name)'") }
+    static func getFilter(withName name: String, params: Dictionary<String, AnyCodable>? = nil) throws -> AnyReplicationFilter {
+        guard let filter = availableFilters(rawValue: name) else {
+            throw TestServerError.badRequest("Could not find filter with name '\(name)'")
+        }
         
         switch filter {
         case .documentIDs:


### PR DESCRIPTION
* Implemented Multipeer Replicator Support in iOS per API 1.2.0.
* Shared the push/pull filter and conflict resolver with the regular replicator
* No support for start / stop URLEndpointListener (1.1.0) and dynamic dataset (1.1.1) yet.
* Note: Cannot merge into the main branch until branching for `release/3.2` is done, otherwise the TestServer iOS cannot be built with the binary < 3.3.0 anymore.