### PR TITLE
Implement a fallback IP mechanism in topology JSON

### DIFF
--- a/environment/aws/topology_setup/setup_topology.py
+++ b/environment/aws/topology_setup/setup_topology.py
@@ -336,6 +336,10 @@ class TestServerInput:
     def download(self) -> bool:
         return self.__download
 
+    @property
+    def ip_hint(self) -> str | None:
+        return self.__ip_hint
+
     def __init__(
         self,
         location: str,
@@ -343,12 +347,15 @@ class TestServerInput:
         dataset_version: str,
         platform: str,
         download: bool,
+        *,
+        ip_hint: str | None = None,
     ):
         self.__location = location
         self.__cbl_version = cbl_version
         self.__dataset_version = dataset_version
         self.__platform = platform
         self.__download = download
+        self.__ip_hint = ip_hint
 
 
 class TestServerConfig:
@@ -476,6 +483,7 @@ class TopologyConfig:
                             raw_server["dataset_version"],
                             raw_server["platform"],
                             cast(bool, raw_server.get("download", False)),
+                            ip_hint=raw_server.get("ip_hint"),
                         )
                     )
 
@@ -648,7 +656,9 @@ class TopologyConfig:
             bridge.validate(test_server_input.location)
             self.__test_servers.append(
                 TestServerConfig(
-                    bridge.get_ip(test_server_input.location),
+                    bridge.get_ip(
+                        test_server_input.location, fallback=test_server_input.ip_hint
+                    ),
                     test_server_input.cbl_version,
                     test_server_input.dataset_version,
                     test_server_input.platform,
@@ -674,7 +684,9 @@ class TopologyConfig:
             bridge.install(test_server_input.location)
             bridge.run(test_server_input.location)
             port = 5555 if test_server_input.platform.startswith("dotnet") else 8080
-            ip = bridge.get_ip(test_server_input.location)
+            ip = bridge.get_ip(
+                test_server_input.location, fallback=test_server_input.ip_hint
+            )
 
             success = False
             for _ in range(0, 30):

--- a/environment/aws/topology_setup/test_server_platforms/android_bridge.py
+++ b/environment/aws/topology_setup/test_server_platforms/android_bridge.py
@@ -176,7 +176,7 @@ class AndroidBridge(PlatformBridge):
             capture_output=False,
         )
 
-    def get_ip(self, location: str) -> str:
+    def _get_ip(self, location: str) -> str | None:
         """
         Retrieve the IP address of the specified device.
 
@@ -211,4 +211,4 @@ class AndroidBridge(PlatformBridge):
             if "inet" in line:
                 return line.lstrip().split(" ")[1].split("/")[0]
 
-        raise RuntimeError(f"Could not determine IP address of '{location}'")
+        return None

--- a/environment/aws/topology_setup/test_server_platforms/exe_bridge.py
+++ b/environment/aws/topology_setup/test_server_platforms/exe_bridge.py
@@ -136,7 +136,7 @@ class ExeBridge(PlatformBridge):
         """
         click.echo("No action needed for uninstalling executable")
 
-    def get_ip(self, location: str) -> str:
+    def _get_ip(self, location: str) -> str | None:
         """
         Retrieve the IP address of the specified location.
 

--- a/environment/aws/topology_setup/test_server_platforms/ios_bridge.py
+++ b/environment/aws/topology_setup/test_server_platforms/ios_bridge.py
@@ -374,7 +374,7 @@ class iOSBridge(PlatformBridge):
                         fg="yellow",
                     )
 
-    def get_ip(self, location: str) -> str:
+    def _get_ip(self, location: str) -> str | None:
         """
         Retrieve the IP address of the specified device.
 
@@ -414,4 +414,4 @@ class iOSBridge(PlatformBridge):
             if mac_address in line:
                 return line.split(" ")[1].strip("()")
 
-        raise RuntimeError(f"Could not determine IP address of '{location}'")
+        return None

--- a/environment/aws/topology_setup/test_server_platforms/java_register.py
+++ b/environment/aws/topology_setup/test_server_platforms/java_register.py
@@ -119,7 +119,7 @@ class JarBridge(JavaBridge):
     def uninstall(self, location: str) -> None:
         pass
 
-    def get_ip(self, location):
+    def _get_ip(self, location) -> str | None:
         if location != "localhost":
             raise ValueError("JarBridge only supports running on localhost")
 
@@ -179,7 +179,7 @@ class JettyBridge(JavaBridge):
     def uninstall(self, location: str) -> None:
         pass
 
-    def get_ip(self, location):
+    def _get_ip(self, location) -> str | None:
         if location != "localhost":
             raise ValueError("JettyBridge only supports running on localhost")
 

--- a/environment/aws/topology_setup/test_server_platforms/macos_bridge.py
+++ b/environment/aws/topology_setup/test_server_platforms/macos_bridge.py
@@ -107,7 +107,7 @@ class macOSBridge(PlatformBridge):
         self.validate(location)
         click.echo("No action needed for uninstalling macOS app")
 
-    def get_ip(self, location: str) -> str:
+    def _get_ip(self, location: str) -> str | None:
         """
         Retrieve the IP address of the specified location.
 

--- a/environment/aws/topology_setup/test_server_platforms/platform_bridge.py
+++ b/environment/aws/topology_setup/test_server_platforms/platform_bridge.py
@@ -27,6 +27,8 @@ Functions:
 
 from abc import ABC, abstractmethod
 
+import click
+
 
 class PlatformBridge(ABC):
     """
@@ -102,8 +104,34 @@ class PlatformBridge(ABC):
         """
         pass
 
+    def get_ip(self, location: str, *, fallback: str | None = None) -> str:
+        """
+        Retrieve the IP address of the specified location.
+
+        Args:
+            location (str): The location of the application (e.g., device serial number).
+            fallback (str | None): An optional fallback IP address if the retrieval fails.
+
+        Returns:
+            str: The IP address of the location, or the fallback if specified.
+        """
+        attempt = self._get_ip(location)
+        if attempt is not None:
+            return attempt
+
+        if fallback is not None:
+            click.secho(
+                f"Failed to retrieve IP address for {location}, using fallback: {fallback}.",
+                fg="yellow",
+            )
+            return fallback
+
+        raise RuntimeError(
+            f"Failed to retrieve IP address for {location} and no fallback provided."
+        )
+
     @abstractmethod
-    def get_ip(self, location: str) -> str:
+    def _get_ip(self, location: str) -> str | None:
         """
         Retrieve the IP address of the specified location.
 

--- a/environment/aws/topology_setup/topology_schema.json
+++ b/environment/aws/topology_setup/topology_schema.json
@@ -115,6 +115,10 @@
                     "download": {
                         "type": "boolean",
                         "default": false
+                    },
+                    "ip_hint": {
+                        "type": "string",
+                        "default": ""
                     }
                 },
                 "required": ["location", "cbl_version", "platform", "dataset_version"],


### PR DESCRIPTION
This way if for some reason the IP auto detection doesn't work locally a quick way to resolve it is present. This should NOT be used for a permanent solution on Jenkins infrastructure, though.