### PR TITLE
Support downloading datasets in the C test server

### DIFF
--- a/servers/c/CMakeLists.txt
+++ b/servers/c/CMakeLists.txt
@@ -69,12 +69,14 @@ if(APPLE)
             testserver PRIVATE
             src/support/Device+Apple.mm
             src/support/Files+Apple.mm
+            src/support/FileDownloader+Apple.mm
     )
 else()
     target_sources(
             testserver PRIVATE
             src/support/Device.cpp
             src/support/Files.cpp
+            src/support/FileDownloader.cpp
     )
 endif()
 
@@ -86,6 +88,15 @@ target_link_libraries(
         zip
         ixwebsocket
 )
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    # For FileDownloader on linux platform
+    find_package(OpenSSL REQUIRED)
+    target_link_libraries(
+            testserver PRIVATE
+            OpenSSL::SSL
+            OpenSSL::Crypto)
+endif()
 
 target_include_directories(
         testserver PRIVATE
@@ -143,5 +154,3 @@ install(
         PATTERN "*"
         PATTERN ".gitkeep" EXCLUDE
 )
-
-

--- a/servers/c/platforms/android/app/src/main/cpp/CMakeLists.txt
+++ b/servers/c/platforms/android/app/src/main/cpp/CMakeLists.txt
@@ -65,6 +65,7 @@ set(SHARED_SRC
         ${SHARED_SRC_DIR}/log/RemoteLogger.cpp
         ${SHARED_SRC_DIR}/support/Android.cpp
         ${SHARED_SRC_DIR}/support/Device.cpp
+        ${SHARED_SRC_DIR}/support/FileDownloader.cpp
         ${SHARED_SRC_DIR}/support/Error.cpp
         ${SHARED_SRC_DIR}/support/Files.cpp
         ${SHARED_SRC_DIR}/support/StringUtil.cpp
@@ -73,6 +74,7 @@ set(SHARED_SRC
 
 set(LIB_SRC
         ${SHARED_SRC}
+        JNIUtil.cpp
         testserver.cpp)
 
 # Creates and names a library, sets it as either STATIC
@@ -82,12 +84,15 @@ set(LIB_SRC
 
 add_library(testserver SHARED ${LIB_SRC})
 
-if(NOT DEFINED CBL_VERSION)
-    message(FATAL_ERROR "Please set CBL_VERSION to the version of Couchbase Lite you are using.")
-endif()
+#if(NOT DEFINED CBL_VERSION)
+#    message(FATAL_ERROR "Please set CBL_VERSION to the version of Couchbase Lite you are using.")
+#endif()
 
 set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE NEVER)
-find_package(CouchbaseLite ${CBL_VERSION} REQUIRED PATHS ${PROJECT_SOURCE_DIR}/lib/libcblite-${CBL_VERSION})
+#find_package(CouchbaseLite ${CBL_VERSION} REQUIRED PATHS ${PROJECT_SOURCE_DIR}/lib/libcblite-${CBL_VERSION})
+
+find_package(CouchbaseLite 3.2.1 REQUIRED PATHS ${PROJECT_SOURCE_DIR}/lib/libcblite-3.2.1)
+
 set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
 
 add_subdirectory(vendor)
@@ -105,6 +110,7 @@ target_link_libraries(testserver
 
 target_include_directories(
         testserver PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}
         ${SHARED_SRC_DIR}
         ${SHARED_SRC_DIR}/cbl
         ${SHARED_SRC_DIR}/dispatcher

--- a/servers/c/platforms/android/app/src/main/cpp/JNIUtil.cpp
+++ b/servers/c/platforms/android/app/src/main/cpp/JNIUtil.cpp
@@ -1,0 +1,90 @@
+#include "JNIUtil.h"
+#include <stdexcept>
+
+namespace ts::jni {
+    static JavaVM* g_JavaVM;
+    static jclass g_FileDownloaderClass;
+    static jmethodID g_DownloadMethod;
+
+    JNIEnv* getJNIEnv(bool* didAttach) {
+        if (!g_JavaVM) {
+            return nullptr;
+        }
+
+        JNIEnv* env = nullptr;
+        jint result = g_JavaVM->GetEnv(reinterpret_cast<void**>(&env), JNI_VERSION_1_6);
+
+        if (result == JNI_OK) {
+            if (didAttach) *didAttach = false;
+            return env;
+        }
+
+        if (result == JNI_EDETACHED) {
+            if (g_JavaVM->AttachCurrentThread(&env, nullptr) == 0) {
+                if (didAttach) *didAttach = true;
+                return env;
+            }
+        }
+        return nullptr;
+    }
+
+    void detachCurrentThread() {
+        if (g_JavaVM) {
+            g_JavaVM->DetachCurrentThread();
+        }
+    }
+
+    jclass fileDownloaderClass() {
+        return g_FileDownloaderClass;
+    }
+
+    jmethodID fileDownloaderDownloadMethod() {
+        return g_DownloadMethod;
+    }
+
+    bool init(JNIEnv* env) {
+        jclass localClass = env->FindClass("com/couchbase/lite/testserver/util/FileDownloader");
+        if (!localClass) {
+            return false;
+        }
+
+        g_FileDownloaderClass = reinterpret_cast<jclass>(env->NewGlobalRef(localClass));
+        env->DeleteLocalRef(localClass);
+        if (!g_FileDownloaderClass) {
+            return false;
+        }
+
+        g_DownloadMethod = env->GetStaticMethodID(g_FileDownloaderClass, "download", "(Ljava/lang/String;Ljava/lang/String;)V");
+        return (g_DownloadMethod != nullptr);
+    }
+
+    void cleanup() {
+        JNIEnv* env = getJNIEnv();
+        if (env && g_FileDownloaderClass) {
+            env->DeleteGlobalRef(g_FileDownloaderClass);
+        }
+        g_FileDownloaderClass = nullptr;
+        g_DownloadMethod = nullptr;
+    }
+}
+
+extern "C"
+JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void*) {
+    ts::jni::g_JavaVM = vm;
+
+    JNIEnv* env = ts::jni::getJNIEnv();
+    if (!env) {
+        return JNI_ERR;
+    }
+
+    if (!ts::jni::init(env)) {
+        return JNI_ERR;
+    }
+
+    return JNI_VERSION_1_6;
+}
+
+extern "C"
+JNIEXPORT void JNICALL JNI_OnUnload(JavaVM*, void*) {
+    ts::jni::cleanup();
+}

--- a/servers/c/platforms/android/app/src/main/cpp/JNIUtil.h
+++ b/servers/c/platforms/android/app/src/main/cpp/JNIUtil.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <jni.h>
+
+namespace ts::jni {
+    JNIEnv* getJNIEnv(bool* didAttach = nullptr);
+    void detachCurrentThread();
+
+    jclass fileDownloaderClass();
+    jmethodID fileDownloaderDownloadMethod();
+}

--- a/servers/c/platforms/android/app/src/main/java/com/couchbase/lite/testserver/util/FileDownloader.java
+++ b/servers/c/platforms/android/app/src/main/java/com/couchbase/lite/testserver/util/FileDownloader.java
@@ -1,0 +1,35 @@
+package com.couchbase.lite.testserver.util;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+public class FileDownloader {
+    public static void download(String url, String destinationPath) throws IOException {
+        HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection();
+        connection.setConnectTimeout(60_000);
+        connection.setReadTimeout(60_000);
+        connection.setRequestMethod("GET");
+
+        int responseCode = connection.getResponseCode();
+        if (responseCode != HttpURLConnection.HTTP_OK) {
+            throw new IOException("Failed to download file from URL '" + url + "' : " +
+                    responseCode + " " + connection.getResponseMessage());
+        }
+
+        File file = new File(destinationPath);
+        try (InputStream input = connection.getInputStream();
+             FileOutputStream output = new FileOutputStream(file)) {
+            byte[] buffer = new byte[8192];
+            int len;
+            while ((len = input.read(buffer)) != -1) {
+                output.write(buffer, 0, len);
+            }
+        } finally {
+            connection.disconnect();
+        }
+    }
+}

--- a/servers/c/src/SessionManager.cpp
+++ b/servers/c/src/SessionManager.cpp
@@ -1,8 +1,10 @@
 #include "SessionManager.h"
+#include "CBLManager.h"
+#include "TestServer.h"
 
 namespace ts {
-
-    std::shared_ptr<Session> SessionManager::createSession(const std::string &id) {
+    std::shared_ptr<Session> SessionManager::createSession(const std::string &id,
+                                                           const std::string &datasetVersion) {
         std::lock_guard<std::mutex> lock(_mutex);
         if (_sessions.find(id) != _sessions.end()) {
             throw support::error::RequestError("Session with given ID already exists");
@@ -11,16 +13,22 @@ namespace ts {
         // Only have one session at least for now
         _sessions.clear();
 
-        auto session = std::make_shared<Session>(id, _cblManager);
+        // Create CBLManager per session:
+        auto context = _testServer->context();
+        auto cblManager = std::make_unique<cbl::CBLManager>(
+            context.databaseDir, context.assetsDir, datasetVersion);
+
+        // Create session:
+        auto session = std::make_shared<Session>(id, std::move(cblManager));
         _sessions.emplace(id, session);
         return session;
     }
 
     std::shared_ptr<Session> SessionManager::createTempSession() {
-        return std::make_shared<Session>(support::key::generateUUID(), _cblManager);
+        return std::make_shared<Session>(support::key::generateUUID(), nullptr);
     }
 
-    std::shared_ptr<Session> SessionManager::getSession(const std::string &id) {
+    std::shared_ptr<Session> SessionManager::getSession(const std::string &id) const {
         std::lock_guard<std::mutex> lock(_mutex);
         auto it = _sessions.find(id);
         if (it == _sessions.end()) {

--- a/servers/c/src/SessionManager.cpp
+++ b/servers/c/src/SessionManager.cpp
@@ -1,26 +1,60 @@
 #include "SessionManager.h"
+
 #include "CBLManager.h"
+#include "Log.h"
 #include "TestServer.h"
 
+#include <filesystem>
+
+namespace fs = std::filesystem;
+
+using namespace ts::log;
+
 namespace ts {
+    std::string SessionManager::sessionsRootDirectory() const {
+        return fs::path(_testServer->context().filesDir) / "sessions";
+    }
+
+    void SessionManager::init() {
+        auto sessionsRootDir = sessionsRootDirectory();
+        if (fs::exists(sessionsRootDir)) {
+            fs::remove_all(sessionsRootDir);
+        }
+        fs::create_directories(sessionsRootDir);
+    }
+
+    std::string SessionManager::createSessionDirectory(const std::string &id) {
+        auto sessionDir = fs::path(sessionsRootDirectory()) / id;
+        if (!fs::create_directories(sessionDir)) {
+            throw std::runtime_error("Failed to create session directory '" + sessionDir.string() + "'");
+        }
+        Log::log(LogLevel::info, "Session directory created at '%s'", sessionDir.string().c_str());
+        return sessionDir;
+    }
+
     std::shared_ptr<Session> SessionManager::createSession(const std::string &id,
                                                            const std::string &datasetVersion) {
         std::lock_guard<std::mutex> lock(_mutex);
         if (_sessions.find(id) != _sessions.end()) {
-            throw support::error::RequestError("Session with given ID already exists");
+            throw support::error::RequestError("Session with ID '" + id + "' already exists");
         }
+
+        Log::log(LogLevel::info, "Creating session with ID '%s' and dataset version '%s'",
+                 id.c_str(), datasetVersion.c_str());
 
         // Only have one session at least for now
         _sessions.clear();
 
         // Create CBLManager per session:
         auto context = _testServer->context();
+        auto sessionDir = createSessionDirectory(id);
         auto cblManager = std::make_unique<cbl::CBLManager>(
-            context.databaseDir, context.assetsDir, datasetVersion);
+            sessionDir, context.assetsDir, datasetVersion);
 
         // Create session:
         auto session = std::make_shared<Session>(id, std::move(cblManager));
         _sessions.emplace(id, session);
+        Log::log(LogLevel::info, "Session '%s' created successfully", id.c_str());
         return session;
     }
 

--- a/servers/c/src/SessionManager.h
+++ b/servers/c/src/SessionManager.h
@@ -13,35 +13,41 @@
 #include <utility>
 
 namespace ts {
+    class TestServer;
+
     class Session {
     public:
-        Session(std::string id, cbl::CBLManager *cblManager)
-            : _id(std::move(id)), _cblManager(cblManager) {}
+        Session(std::string  id, std::unique_ptr<ts::cbl::CBLManager> cblManager)
+        : _id(std::move(id))
+        , _cblManager(std::move(cblManager))
+        { }
 
         [[nodiscard]]
         const std::string &id() const { return _id; }
 
         [[nodiscard]]
-        ts::cbl::CBLManager *cblManager() const { return _cblManager; }
+        ts::cbl::CBLManager *cblManager() const { return _cblManager.get(); }
 
     private:
         std::string _id;
-        cbl::CBLManager *_cblManager;
+        std::unique_ptr<ts::cbl::CBLManager> _cblManager;
     };
 
     class SessionManager {
     public:
-        explicit SessionManager(cbl::CBLManager *cblManager) : _cblManager(cblManager) {}
+        explicit SessionManager(const TestServer* testServer)
+        : _testServer(testServer)
+        { }
 
-        std::shared_ptr<Session> createSession(const std::string &id);
+        std::shared_ptr<Session> createSession(const std::string &id, const std::string &datasetVersion);
 
         std::shared_ptr<Session> createTempSession();
 
-        std::shared_ptr<Session> getSession(const std::string &id);
+        std::shared_ptr<Session> getSession(const std::string &id) const;
 
     private:
         mutable std::mutex _mutex;
-        cbl::CBLManager *_cblManager;
+        const TestServer *_testServer{nullptr};
         std::unordered_map<std::string, std::shared_ptr<Session>> _sessions;
     };
 }

--- a/servers/c/src/SessionManager.h
+++ b/servers/c/src/SessionManager.h
@@ -1,11 +1,9 @@
 #pragma once
 
-// cbl
 #include "CBLManager.h"
 #include "Error.h"
 #include "UUID.h"
 
-// lib
 #include <string>
 #include <memory>
 #include <mutex>
@@ -37,7 +35,9 @@ namespace ts {
     public:
         explicit SessionManager(const TestServer* testServer)
         : _testServer(testServer)
-        { }
+        {
+            init();
+        }
 
         std::shared_ptr<Session> createSession(const std::string &id, const std::string &datasetVersion);
 
@@ -46,6 +46,11 @@ namespace ts {
         std::shared_ptr<Session> getSession(const std::string &id) const;
 
     private:
+        void init();
+
+        std::string sessionsRootDirectory() const;
+        std::string createSessionDirectory(const std::string &id);
+
         mutable std::mutex _mutex;
         const TestServer *_testServer{nullptr};
         std::unordered_map<std::string, std::shared_ptr<Session>> _sessions;

--- a/servers/c/src/TestServer.cpp
+++ b/servers/c/src/TestServer.cpp
@@ -43,8 +43,7 @@ namespace ts {
 #endif
         _context = {filesDir("CBL-C-TestServer", true), assetsDir()};
         _dispatcher = std::make_unique<Dispatcher>(this);
-        _cblManager = std::make_unique<cbl::CBLManager>(_context.databaseDir, _context.assetsDir);
-        _sessionManager = std::make_unique<SessionManager>(_cblManager.get());
+        _sessionManager = std::make_unique<SessionManager>(this);
     }
 
     TestServer::~TestServer() {

--- a/servers/c/src/TestServer.h
+++ b/servers/c/src/TestServer.h
@@ -38,8 +38,6 @@ namespace ts {
 
         SessionManager *sessionManager() const { return _sessionManager.get(); }
 
-        cbl::CBLManager *cblManager() const { return _cblManager.get(); }
-
         void start();
 
         void stop();
@@ -51,7 +49,6 @@ namespace ts {
 
         std::unique_ptr<ts::Dispatcher> _dispatcher;
         std::unique_ptr<ts::SessionManager> _sessionManager;
-        std::unique_ptr<ts::cbl::CBLManager> _cblManager;
 
         mg_context *_server{nullptr};
         std::string _uuid;

--- a/servers/c/src/TestServer.h
+++ b/servers/c/src/TestServer.h
@@ -18,7 +18,7 @@ namespace ts {
         static constexpr unsigned short PORT = 8080;
 
         struct Context {
-            std::string databaseDir;
+            std::string filesDir;
             std::string assetsDir;
         };
 

--- a/servers/c/src/cbl/CBLManager.cpp
+++ b/servers/c/src/cbl/CBLManager.cpp
@@ -5,6 +5,7 @@
 #include "Defer.h"
 #include "Define.h"
 #include "Error.h"
+#include "FileDownloader.h"
 #include "Precondition.h"
 #include "StringUtil.h"
 #include "ZipUtil.h"
@@ -15,17 +16,15 @@
 #include <utility>
 
 using namespace std;
-using namespace filesystem;
-
 using namespace ts::support;
 using namespace ts::support::precond;
 using namespace ts::support::error;
 
-#define DB_FILE_EXT ".cblite2"
-#define DB_FILE_ZIP_EXT ".cblite2.zip"
-#define DB_FILE_ZIP_EXTRACTED_DIR "extracted"
-#define ASSET_DBS_DIR "dbs"
-#define ASSET_BLOBS_DIR "blobs"
+namespace fs = std::filesystem;
+
+#define DATASET_BASE_URL "https://media.githubusercontent.com/media/couchbaselabs/couchbase-lite-tests/refs/heads/main/dataset/server/"
+#define DATASET_DOWNLOAD_DIR "download"
+#define DATASET_EXTRACTED_DIR "extracted"
 
 namespace ts::cbl {
     static FLSliceResult xor_cipher(FLSlice input) {
@@ -43,18 +42,22 @@ namespace ts::cbl {
         return xor_cipher(input);
     }
 
-
     static FLSliceResult xor_decryptor(void* context, FLString scope, FLString collection, 
         FLString documentID, FLDict properties, FLString keyPath, FLSlice input, FLString algorithm, 
         FLString keyID, CBLError* error) {
         return xor_cipher(input);
     }
 
-    /// Constructor
+    /// Constructor & Destructor
 
-    CBLManager::CBLManager(const string &databaseDir, const string &assetDir) {
+    CBLManager::CBLManager(const string &databaseDir, const string &assetDir, const std::string& datasetVersion) {
         _databaseDir = databaseDir;
         _assetDir = assetDir;
+        _datasetVersion = datasetVersion;
+    }
+
+    CBLManager::~CBLManager() {
+        reset();
     }
 
     /// Database
@@ -104,19 +107,23 @@ namespace ts::cbl {
         }
 
         string fromDbPath;
-        auto dbAssetPath = path(_assetDir).append(ASSET_DBS_DIR);
-        auto zipFilePath = path(dbAssetPath).append(datasetName + DB_FILE_ZIP_EXT);
-        if (filesystem::exists(zipFilePath)) {
-            if (auto it = _extDatasetPaths.find(datasetName); it != _extDatasetPaths.end()) {
-                fromDbPath = it->second;
-            } else {
-                auto extDirPath = path(_databaseDir).append(DB_FILE_ZIP_EXTRACTED_DIR);
-                zip::extractZip(zipFilePath.string(), extDirPath.string());
-                fromDbPath = extDirPath.append(datasetName + DB_FILE_EXT).string();
-                _extDatasetPaths[datasetName] = fromDbPath;
-            }
+        if (auto it = _extDatasetPaths.find(datasetName); it != _extDatasetPaths.end()) {
+            fromDbPath = it->second;
         } else {
-            fromDbPath = dbAssetPath.append(datasetName + DB_FILE_EXT).string();
+            auto relativeZipPath = fs::path("dbs") / _datasetVersion / (datasetName + ".cblite2.zip");
+            auto datasetZipFile = downloadDatasetFileIfNecessary(relativeZipPath.string());
+
+            if (!fs::exists(datasetZipFile)) {
+                throw std::logic_error("Dataset not found: " + datasetZipFile);
+            }
+
+            fs::path extDirPath = fs::path(_databaseDir) / DATASET_EXTRACTED_DIR;
+            zip::extractZip(datasetZipFile, extDirPath.string());
+
+            fs::path extractedDbPath = extDirPath / (datasetName + ".cblite2");
+            fromDbPath = extractedDbPath.string();
+
+            _extDatasetPaths[datasetName] = fromDbPath;
         }
 
         CBLError error{};
@@ -130,12 +137,11 @@ namespace ts::cbl {
         }
 
         // Copy:
-        if (!fromDbPath.empty()) {
-            if (!CBL_CopyDatabase(FLS(fromDbPath), FLS(dbName), &config, &error)) {
-                throw CBLException(error);
-            }
+        if (!CBL_CopyDatabase(FLS(fromDbPath), FLS(dbName), &config, &error)) {
+            throw CBLException(error);
         }
 
+        // Open:
         CBLDatabase *db = CBLDatabase_Open(FLS(dbName), &config, &error);
         if (!db) {
             throw CBLException(error);
@@ -213,6 +219,24 @@ namespace ts::cbl {
         return doc;
     }
 
+    /// Dataset
+
+    string CBLManager::downloadDatasetFileIfNecessary(const string &relativePath) {
+        auto datasetPath = fs::path(_databaseDir).append(DATASET_DOWNLOAD_DIR).append(relativePath);
+        if (fs::exists(datasetPath)) {
+            return datasetPath;
+        }
+
+        auto datasetDir = datasetPath.parent_path();
+        if (!fs::exists(datasetDir)) {
+            fs::create_directories(datasetDir);
+        }
+
+        auto datasetURL = string(DATASET_BASE_URL) + relativePath;
+        FileDownloader::download(datasetURL, datasetPath);
+        return datasetPath;
+    }
+
     /// Blob
 
     bool CBLManager::blobExists(const CBLDatabase *db, FLDict blobDict) {
@@ -233,8 +257,8 @@ namespace ts::cbl {
     }
 
     CBLBlob *CBLManager::blob(const string &name, CBLDatabase *db) {
-        auto blobPath = path(_assetDir).append(ASSET_BLOBS_DIR).append(name);
-        ifstream ifs(blobPath.string(), ios::in | ios::binary);
+        auto blobPath = downloadDatasetFileIfNecessary("blobs/" + name);
+        ifstream ifs(blobPath, ios::in | ios::binary);
         if (!ifs.is_open()) {
             throw logic_error("Blob '" + name + "' not found in dataset");
         }

--- a/servers/c/src/cbl/CBLManager.h
+++ b/servers/c/src/cbl/CBLManager.h
@@ -23,9 +23,11 @@ struct CBLDatabase;
 namespace ts::cbl {
     class CBLManager {
     public:
-        /// Constructor
+        /// Constructor & Destructor
 
-        CBLManager(const std::string &databaseDir, const std::string &assetDir);
+        CBLManager(const std::string &databaseDir, const std::string &assetDir, const std::string& datasetVersion);
+
+        ~CBLManager();
 
         /// Database
 
@@ -90,7 +92,7 @@ namespace ts::cbl {
     private:
         CBLDatabase *databaseUnlocked(const std::string &name);
 
-        FLSliceResult getServerCert();
+        std::string downloadDatasetFileIfNecessary(const std::string &relativePath);
 
         void
         addDocumentReplication(const std::string &id, const std::vector<ReplicatedDocument> &docs);
@@ -100,6 +102,7 @@ namespace ts::cbl {
 
         std::string _databaseDir;
         std::string _assetDir;
+        std::string _datasetVersion;
 
         /** Map of dataset name and extracted dataset path */
         std::unordered_map<std::string, std::string> _extDatasetPaths;

--- a/servers/c/src/dispatcher/PostNewSession.cpp
+++ b/servers/c/src/dispatcher/PostNewSession.cpp
@@ -9,11 +9,15 @@ int Dispatcher::handlePOSTNewSession(Request &request, Session *session) {
     json body = request.jsonBody();
     CheckBody(body);
 
-    // Session:
+    // Session Parameters:
     auto id = GetValue<string>(body, "id");
+    auto datasetVersion = GetValue<string>(body, "dataset_version");
+
+    // Create Session:
     auto sessionManager = request.dispatcher()->sessionManager();
-    auto newSession = sessionManager->createSession(id);
-    Log::logToConsole(LogLevel::info, "Start new session with id : %s", id.c_str());
+    auto newSession = sessionManager->createSession(id, datasetVersion);
+    Log::logToConsole(LogLevel::info, "Start new session with id '%s' and dataset version '%s'",
+                      id.c_str(), datasetVersion.c_str());
 
     // Logging:
     auto logging = GetOptValue<json>(body, "logging");

--- a/servers/c/src/support/FileDownloader+Apple.mm
+++ b/servers/c/src/support/FileDownloader+Apple.mm
@@ -1,0 +1,46 @@
+#include "FileDownloader.h"
+
+#import <Foundation/Foundation.h>
+#import <Foundation/NSURLSession.h>
+#import <stdexcept>
+#import <string>
+
+namespace ts::support {
+    void FileDownloader::download(const std::string &url, const std::string &destinationPath) {
+        @autoreleasepool {
+            NSURL* nsUrl = [NSURL URLWithString: [NSString stringWithUTF8String: url.c_str()]];
+            if (!nsUrl) {
+                throw std::invalid_argument("Invalid URL: " + url);
+            }
+
+            NSURL* destUrl = [NSURL fileURLWithPath: [NSString stringWithUTF8String: destinationPath.c_str()]];
+            if (!destUrl) {
+                throw std::invalid_argument("Invalid destination path: " + destinationPath);
+            }
+
+            dispatch_semaphore_t sema = dispatch_semaphore_create(0);
+
+            __block NSError* error = nil;
+            NSURLSessionConfiguration* config = [NSURLSessionConfiguration ephemeralSessionConfiguration];
+            NSURLSession* session = [NSURLSession sessionWithConfiguration: config];
+            NSURLSessionDownloadTask* task = [session downloadTaskWithURL: nsUrl completionHandler:
+                                              ^(NSURL *location, NSURLResponse* response, NSError* err) {
+                if (err) {
+                    error = err;
+                } else {
+                    NSFileManager* fileManager = [NSFileManager defaultManager];
+                    [fileManager moveItemAtURL: location toURL: destUrl error: &error];
+                }
+                dispatch_semaphore_signal(sema);
+            }];
+            [task resume];
+            dispatch_semaphore_wait(sema, DISPATCH_TIME_FOREVER);
+
+            [session finishTasksAndInvalidate];
+
+            if (error) {
+                throw std::runtime_error([error.localizedDescription UTF8String]);
+            }
+        }
+    }
+}

--- a/servers/c/src/support/FileDownloader.cpp
+++ b/servers/c/src/support/FileDownloader.cpp
@@ -1,0 +1,76 @@
+#include "FileDownloader.h"
+
+#if defined(_WIN32)
+#include <urlmon.h>
+#pragma comment(lib, "urlmon.lib")
+#elif defined(__ANDROID__)
+#include <JNIUtil.h>
+#elif defined(__linux__)
+#include <fstream>
+#include <ixwebsocket/IXHttpClient.h>
+#endif
+
+namespace ts::support {
+    void FileDownloader::download(const std::string &url, const std::string &destinationPath) {
+#if defined(_WIN32)
+        HRESULT hr = URLDownloadToFileA(nullptr, url.c_str(), destinationPath.c_str(), 0, nullptr);
+        if (FAILED(hr)) {
+            throw std::runtime_error("Failed to download file from URL '" + url + "' : " + std::to_string(hr));
+        }
+#elif defined(__ANDROID__)
+        bool didAttach = false;
+        JNIEnv* env = ts::jni::getJNIEnv(&didAttach);
+        if (!env) {
+            throw std::runtime_error("Cannot get JNI environment");
+        }
+
+        jclass cls = ts::jni::fileDownloaderClass();
+        jmethodID mid = ts::jni::fileDownloaderDownloadMethod();
+        if (!cls || !mid) {
+            throw std::runtime_error("FileDownloader JNI references not initialized");
+        }
+
+        jstring jurl = env->NewStringUTF(url.c_str());
+        jstring jdest = env->NewStringUTF(destinationPath.c_str());
+        env->CallStaticVoidMethod(cls, mid, jurl, jdest);
+
+        env->DeleteLocalRef(jurl);
+        env->DeleteLocalRef(jdest);
+
+        jboolean hasError = env->ExceptionCheck();
+        if (hasError) {
+            env->ExceptionDescribe();
+            env->ExceptionClear();
+        }
+
+        if (didAttach) {
+            ts::jni::detachCurrentThread();
+        }
+
+        if (hasError) {
+            throw std::runtime_error("Failed to download file from URL '" + url + "'");
+        }
+#elif defined(__linux__)
+        ix::HttpClient httpClient;
+
+        ix::SocketTLSOptions tlsOptions;
+        tlsOptions.caFile = "SYSTEM";
+        httpClient.setTLSOptions(tlsOptions);
+
+        auto args = httpClient.createRequest(url);
+        auto response = httpClient.get(url, args);
+        if (response->statusCode == 200) {
+            std::ofstream outFile(destinationPath, std::ios::binary);
+            if (outFile.is_open()) {
+                outFile << response->body;
+            } else {
+                throw std::runtime_error("Unable to save downloaded file at " + destinationPath);
+            }
+        } else {
+            throw std::runtime_error("Failed to download file from URL '" + url + "' : " + std::to_string(response->statusCode));
+        }
+#else
+        throw std::runtime_error("Failed to download file from URL '" + url + "' : Unsupported Platform");
+#endif
+    }
+}

--- a/servers/c/src/support/FileDownloader.cpp
+++ b/servers/c/src/support/FileDownloader.cpp
@@ -18,6 +18,8 @@ namespace ts::support {
             throw std::runtime_error("Failed to download file from URL '" + url + "' : " + std::to_string(hr));
         }
 #elif defined(__ANDROID__)
+        // To avoid depending on TLS libraries like OpenSSL at the NDK level,
+        // use JNI to delegate the file download to the Java FileDownloader implementation.
         bool didAttach = false;
         JNIEnv* env = ts::jni::getJNIEnv(&didAttach);
         if (!env) {

--- a/servers/c/src/support/FileDownloader.h
+++ b/servers/c/src/support/FileDownloader.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <string>
+
+namespace ts::support {
+    class FileDownloader {
+    public:
+        static void download(const std::string& url, const std::string& destinationPath);
+    };
+}

--- a/servers/c/src/support/Files.cpp
+++ b/servers/c/src/support/Files.cpp
@@ -70,7 +70,9 @@ namespace ts::support {
 #ifdef __ANDROID__
         return androidContext()->assetsDir;
 #endif
-        auto current = filesystem::path(getExecutablePath()).parent_path() / ".." / "assets";
-        return current.string();
+        auto dir = filesystem::path(getExecutablePath()).parent_path() / ".." / "assets";
+        filesystem::create_directory(dir); // Ensure that it exists
+        return dir.string();
     }
+
 }

--- a/servers/c/src/support/Files.h
+++ b/servers/c/src/support/Files.h
@@ -3,7 +3,9 @@
 #include <string>
 
 namespace ts::support::files {
+    /* Working directory */
     std::string filesDir(const std::string &subdir, bool create);
 
+    /* Assets directory containing artifacts built with binary */
     std::string assetsDir();
 }

--- a/servers/c/vendor/CMakeLists.txt
+++ b/servers/c/vendor/CMakeLists.txt
@@ -78,6 +78,13 @@ FetchContent_Declare(
         GIT_REPOSITORY https://github.com/machinezone/IXWebSocket.git
         GIT_TAG v11.4.5
 )
+
+# For FileDownloader on Linux Platform
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    set(USE_TLS ON CACHE BOOL "Enable TLS support")
+    set(USE_OPEN_SSL ON CACHE BOOL "Use OpenSSL for TLS")
+endif()
+
 message(STATUS "Fetching IXWebSocket...")
 FetchContent_MakeAvailable(ixwebsocket)
 


### PR DESCRIPTION
* Download dataset based on the version specified in /newSession. Same as .NET, if the file already exists, do not redownload the file.

* Implement FileDownloader on each platform to avoid extra dependency for TLS. Only linux platform needs to depend on openSSL; Need to make sure that the linux box has `libssl-dev` installed.

* Refactor the session management code to create a separate working directory (session directory) for each session. All session directory will be cleaned up when the app is started.

* Refactor the code to instantiate a new CBLManager for each session (we only have one session now).

* Still keep the asset folder in case we want to include any assets with the binary in the future.