### PR TITLE
Remove final parts of the dataset version parameter

### DIFF
--- a/environment/aws/topology_setup/topology_schema.json
+++ b/environment/aws/topology_setup/topology_schema.json
@@ -91,9 +91,6 @@
                     "cbl_version": {
                         "type": "string"
                     },
-                    "dataset_version": {
-                        "type": "string"
-                    },
                     "platform": {
                         "type": "string",
                         "enum": [

--- a/jenkins/pipelines/QE/android/Jenkinsfile
+++ b/jenkins/pipelines/QE/android/Jenkinsfile
@@ -2,7 +2,6 @@ pipeline {
     agent none
     parameters {
         string(name: 'CBL_VERSION', defaultValue: '', description: 'Couchbase Lite Version')
-        string(name: 'CBL_DATASET_VERSION', defaultValue: '', description: "The dataset version to use")
         string(name: 'SGW_VERSION', defaultValue: '', description: "The version of Sync Gateway to download")
     }
     stages {
@@ -10,9 +9,8 @@ pipeline {
             steps {
                 script {
                     if (params.CBL_VERSION == '') { error "CBL_VERSION is required" }
-                    if (params.CBL_DATASET_VERSION == '') { error "CBL_DATASET_VERSION is required" }
                     if (params.SGW_VERSION == '') { error "SGW_VERSION is required" }
-                    currentBuild.displayName = "android ${params.CBL_VERSION}/${params.CBL_DATASET_VERSION} (#${currentBuild.number})"
+                    currentBuild.displayName = "android ${params.CBL_VERSION} (#${currentBuild.number})"
                 }
             }
         }
@@ -41,7 +39,9 @@ pipeline {
                 sh 'security unlock-keychain -p ${KEYCHAIN_PASSWORD} ~/Library/Keychains/login.keychain-db'
                 echo "Run Android Tests"
                 timeout(time: 120, unit: 'MINUTES') {
-                    sh "jenkins/pipelines/QE/android/android_tests.sh "${params.CBL_VERSION}" "${params.CBL_DATASET_VERSION}" "${params.SGW_VERSION}" ~/.ssh/jborden.pem"
+                    sh """
+                        jenkins/pipelines/QE/android/android_tests.sh "${params.CBL_VERSION}" "${params.SGW_VERSION}" ~/.ssh/jborden.pem
+                    """
                 }
             }
             post {

--- a/jenkins/pipelines/QE/android/android_tests.sh
+++ b/jenkins/pipelines/QE/android/android_tests.sh
@@ -10,23 +10,20 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 source $SCRIPT_DIR/../../shared/config.sh
 
 function usage() {
-    echo "Usage: $0 <cbl_version> <dataset version> <sg version> [private key path] [--setup-only]"
+    echo "Usage: $0 <cbl_version> <sg version> [private key path] [--setup-only]"
     echo "  --setup-only: Only build test server and setup backend, skip test execution"
     exit 1
 }
 
-if [ "$#" -lt 3 ] || [ "$#" -gt 5 ] ; then usage; fi
+if [ "$#" -lt 2 ] || [ "$#" -gt 4 ] ; then usage; fi
 
 CBL_VERSION="$1"
 if [ -z "$CBL_VERSION" ]; then usage; fi
 
-DATASET_VERSION="$2"
-if [ -z "$DATASET_VERSION" ]; then usage; fi
-
-SG_VERSION="$3"
+SG_VERSION="$2"
 if [ -z "$SG_VERSION" ]; then usage; fi
 
-private_key_path="$4"
+private_key_path="$3"
 SETUP_ONLY=false
 
 # Check for --setup-only flag
@@ -48,9 +45,9 @@ create_venv venv
 source venv/bin/activate
 pip install -r $AWS_ENVIRONMENT_DIR/requirements.txt
 if [ -n "$private_key_path" ]; then
-    python3 $SCRIPT_DIR/setup_test.py $CBL_VERSION $DATASET_VERSION $SG_VERSION --private_key $private_key_path
+    python3 $SCRIPT_DIR/setup_test.py $CBL_VERSION $SG_VERSION --private_key $private_key_path
 else
-    python3 $SCRIPT_DIR/setup_test.py $CBL_VERSION $DATASET_VERSION $SG_VERSION
+    python3 $SCRIPT_DIR/setup_test.py $CBL_VERSION $SG_VERSION
 fi
 deactivate
 

--- a/jenkins/pipelines/QE/android/setup_test.py
+++ b/jenkins/pipelines/QE/android/setup_test.py
@@ -20,7 +20,6 @@ from jenkins.pipelines.shared.setup_test import setup_test
 
 @click.command()
 @click.argument("cbl_version")
-@click.argument("dataset_version")
 @click.argument("sgw_version")
 @click.option(
     "--private_key",
@@ -28,13 +27,11 @@ from jenkins.pipelines.shared.setup_test import setup_test
 )
 def cli_entry(
     cbl_version: str,
-    dataset_version: str,
     sgw_version: str,
     private_key: str | None,
 ) -> None:
     setup_test(
         cbl_version,
-        dataset_version,
         sgw_version,
         SCRIPT_DIR / "topology_single_device.json",
         SCRIPT_DIR / "config_android.json",

--- a/jenkins/pipelines/QE/android/topology_single_device.json
+++ b/jenkins/pipelines/QE/android/topology_single_device.json
@@ -4,7 +4,6 @@
         {
             "platform": "jak_android",
             "cbl_version": "{{version}}",
-            "dataset_version": "{{dataset_version}}",
             "location": "HT79F1A00593"
         }
     ],

--- a/jenkins/pipelines/QE/c/Jenkinsfile
+++ b/jenkins/pipelines/QE/c/Jenkinsfile
@@ -2,7 +2,6 @@ pipeline {
     agent none
     parameters {
         string(name: 'CBL_VERSION', defaultValue: '3.2.3', description: 'Couchbase Lite Version')
-        string(name: 'CBL_DATASET_VERSION', defaultValue: '3.2', description: 'The dataset version to use (e.g. 3.2 or 4.0)')
         string(name: 'PLATFORM', defaultValue: 'ios', description: "The platform to test (e.g. ios, android, windows, linux)")
         string(name: 'SGW_VERSION', defaultValue: '3.2.3', description: "The version of Sync Gateway to download")
     }
@@ -16,11 +15,10 @@ pipeline {
             steps {
                 script {
                     if (params.CBL_VERSION == '') { error "CBL_VERSION is required" }
-                    if (params.CBL_DATASET_VERSION == '') { error "CBL_DATASET_VERSION is required" }
                     if (params.PLATFORM == '') { error "PLATFORM is required" }
                     if (params.SGW_VERSION == '') { error "SGW_VERSION is required" }
-                    currentBuild.displayName = "c ${params.CBL_VERSION}/${params.CBL_DATASET_VERSION} (#${currentBuild.number})"
-                    currentBuild.description = "Dataset: ${params.CBL_DATASET_VERSION}"
+                    currentBuild.displayName = "c ${params.CBL_VERSION} (#${currentBuild.number})"
+                    currentBuild.description = "Platform: ${params.PLATFORM}"
                 }
             }
         }
@@ -64,7 +62,7 @@ pipeline {
                         sh 'security unlock-keychain -p ${KEYCHAIN_PASSWORD} ~/Library/Keychains/login.keychain-db'
                         echo "Run iOS Test"
                         timeout(time: 60, unit: 'MINUTES') {
-                            sh "jenkins/pipelines/QE/c/run_test.sh ${params.CBL_VERSION} ${params.CBL_DATASET_VERSION} ios '${params.SGW_VERSION}' ~/.ssh/jborden.pem"
+                            sh "jenkins/pipelines/QE/c/run_test.sh ${params.CBL_VERSION} ios '${params.SGW_VERSION}' ~/.ssh/jborden.pem"
                         }
                     }
                     post { 
@@ -90,7 +88,7 @@ pipeline {
                         sh 'security unlock-keychain -p ${KEYCHAIN_PASSWORD} ~/Library/Keychains/login.keychain-db'
                         echo "Run Android Test"
                         timeout(time: 60, unit: 'MINUTES') {
-                            sh "jenkins/pipelines/QE/c/run_test.sh ${params.CBL_VERSION} ${params.CBL_DATASET_VERSION} android '${params.SGW_VERSION}' ~/.ssh/jborden.pem"
+                            sh "jenkins/pipelines/QE/c/run_test.sh ${params.CBL_VERSION} android '${params.SGW_VERSION}' ~/.ssh/jborden.pem"
                         }
                     }
                     post { 
@@ -116,7 +114,7 @@ pipeline {
                         sh 'security unlock-keychain -p ${KEYCHAIN_PASSWORD} ~/Library/Keychains/login.keychain-db'
                         echo "Run linux Test"
                         timeout(time: 60, unit: 'MINUTES') {
-                            sh "jenkins/pipelines/QE/c/run_test.sh ${params.CBL_VERSION} ${params.CBL_DATASET_VERSION} linux_x86_64 '${params.SGW_VERSION}' ~/.ssh/jborden.pem"
+                            sh "jenkins/pipelines/QE/c/run_test.sh ${params.CBL_VERSION} linux_x86_64 '${params.SGW_VERSION}' ~/.ssh/jborden.pem"
                         }
                     }
                     post { 
@@ -141,7 +139,7 @@ pipeline {
                         // Unlock keychain:
                         pwsh 'security unlock-keychain -p ${KEYCHAIN_PASSWORD} ~/Library/Keychains/login.keychain-db'
                         timeout(time: 60, unit: 'MINUTES') {
-                            pwsh "jenkins\\pipelines\\QE\\c\\run_test.ps1 -Version ${params.CBL_VERSION} -Dataset ${params.CBL_DATASET_VERSION} -SgwVersion ${params.SGW_VERSION} -PrivateKeyPath C:\\Users\\mob-e\\.ssh\\jborden.pem"
+                            pwsh "jenkins\\pipelines\\QE\\c\\run_test.ps1 -Version ${params.CBL_VERSION} -SgwVersion ${params.SGW_VERSION} -PrivateKeyPath C:\\Users\\mob-e\\.ssh\\jborden.pem"
                         }
                     }
                     post { 

--- a/jenkins/pipelines/QE/c/run_test.ps1
+++ b/jenkins/pipelines/QE/c/run_test.ps1
@@ -1,6 +1,5 @@
 param (
     [Parameter(Mandatory=$true)][string]$Version,
-    [Parameter(Mandatory=$true)][string]$DatasetVersion,
     [Parameter(Mandatory=$true)][string]$SgwVersion,
     [Parameter()][string]$PrivateKeyPath
 )
@@ -12,7 +11,7 @@ Import-Module $PSScriptRoot\..\..\shared\config.psm1 -Force
 python -m venv venv
 .\venv\Scripts\activate
 pip install -r $AWS_ENVIRONMENT_DIR\requirements.txt
-$python_args = @("windows", $Version, $DatasetVersion, $SgwVersion)
+$python_args = @("windows", $Version, $SgwVersion)
 if ($null -ne $PrivateKeyPath) {
     $python_args += "--private_key"
     $python_args += $PrivateKeyPath

--- a/jenkins/pipelines/QE/c/run_test.sh
+++ b/jenkins/pipelines/QE/c/run_test.sh
@@ -7,24 +7,22 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 source $SCRIPT_DIR/../../shared/config.sh
 
 function usage() {
-    echo "Usage: $0 <version> <dataset_version> <platform> <sgw_version> [private_key_path] [--setup-only]"
+    echo "Usage: $0 <version> <platform> <sgw_version> [private_key_path] [--setup-only]"
     echo "version: CBL version (e.g. 3.2.1-2)"
-    echo "dataset_version: Version of the Couchbase Lite datasets to use"
     echo "platform: The C platform to build (e.g. ios)"
     echo "sgw_version: Version of Sync Gateway to download and use"
     echo "private_key_path: Path to the private key to use for SSH connections"
     echo "  --setup-only: Only build test server and setup backend, skip test execution"
 }
 
-if [ $# -lt 4 ]; then
+if [ $# -lt 3 ]; then
     usage
     exit 1
 fi
 
 cbl_version=$1
-dataset_version=$2
-platform=$3
-sgw_version=$4
+platform=$2
+sgw_version=$3
 private_key_path=""
 SETUP_ONLY=false
 
@@ -35,10 +33,10 @@ for arg in "$@"; do
     fi
 done
 
-if [ $# -gt 4 ]; then
-    # Check if 5th argument is --setup-only
-    if [ "$5" != "--setup-only" ]; then
-        private_key_path=$5
+if [ $# -gt 3 ]; then
+    # Check if 4th argument is --setup-only
+    if [ "$4" != "--setup-only" ]; then
+        private_key_path=$4
     fi
 fi
 
@@ -46,9 +44,9 @@ create_venv venv
 source venv/bin/activate
 pip install -r $AWS_ENVIRONMENT_DIR/requirements.txt
 if [ -n "$private_key_path" ]; then
-    python3 $SCRIPT_DIR/setup_test.py $platform $cbl_version $dataset_version $sgw_version --private_key $private_key_path
+    python3 $SCRIPT_DIR/setup_test.py $platform $cbl_version $sgw_version --private_key $private_key_path
 else
-    python3 $SCRIPT_DIR/setup_test.py $platform $cbl_version $dataset_version $sgw_version
+    python3 $SCRIPT_DIR/setup_test.py $platform $cbl_version $sgw_version
 fi
 deactivate
 

--- a/jenkins/pipelines/QE/c/setup_test.py
+++ b/jenkins/pipelines/QE/c/setup_test.py
@@ -20,7 +20,6 @@ from jenkins.pipelines.shared.setup_test import setup_test
 @click.command()
 @click.argument("platform")
 @click.argument("cbl_version")
-@click.argument("dataset_version")
 @click.argument("sgw_version")
 @click.option(
     "--private_key",
@@ -30,13 +29,11 @@ from jenkins.pipelines.shared.setup_test import setup_test
 def cli_entry(
     platform: str,
     cbl_version: str,
-    dataset_version: str,
     sgw_version: str,
     private_key: str | None,
 ) -> None:
     setup_test(
         cbl_version,
-        dataset_version,
         sgw_version,
         SCRIPT_DIR / "topologies" / f"topology_single_{platform}.json",
         SCRIPT_DIR / "config.c.json",

--- a/jenkins/pipelines/QE/c/topologies/topology_single_android.json
+++ b/jenkins/pipelines/QE/c/topologies/topology_single_android.json
@@ -4,7 +4,6 @@
         {
             "platform": "c_android",
             "cbl_version": "{{version}}",
-            "dataset_version": "{{dataset_version}}",
             "location": "1BCACS00001MX3"
         }
     ],

--- a/jenkins/pipelines/QE/c/topologies/topology_single_ios.json
+++ b/jenkins/pipelines/QE/c/topologies/topology_single_ios.json
@@ -4,7 +4,6 @@
         {
             "platform": "c_ios",
             "cbl_version": "{{version}}",
-            "dataset_version": "{{dataset_version}}",
             "location": "00008110-000E544201D1401E"
         }
     ],

--- a/jenkins/pipelines/QE/c/topologies/topology_single_linux_x86_64.json
+++ b/jenkins/pipelines/QE/c/topologies/topology_single_linux_x86_64.json
@@ -4,7 +4,6 @@
         {
             "platform": "c_linux_x86_64",
             "cbl_version": "{{version}}",
-            "dataset_version": "{{dataset_version}}",
             "location": "localhost"
         }
     ],

--- a/jenkins/pipelines/QE/c/topologies/topology_single_macos.json
+++ b/jenkins/pipelines/QE/c/topologies/topology_single_macos.json
@@ -4,7 +4,6 @@
         {
             "platform": "c_macos",
             "cbl_version": "{{version}}",
-            "dataset_version": "{{dataset_version}}",
             "location": "localhost"
         }
     ],

--- a/jenkins/pipelines/QE/c/topologies/topology_single_windows.json
+++ b/jenkins/pipelines/QE/c/topologies/topology_single_windows.json
@@ -4,7 +4,6 @@
         {
             "platform": "c_windows",
             "cbl_version": "{{version}}",
-            "dataset_version": "{{dataset_version}}",
             "location": "localhost"
         }
     ],

--- a/jenkins/pipelines/QE/dotnet/Jenkinsfile
+++ b/jenkins/pipelines/QE/dotnet/Jenkinsfile
@@ -2,7 +2,6 @@ pipeline {
     agent none
     parameters {
         string(name: 'CBL_VERSION', defaultValue: '3.2.3', description: 'Couchbase Lite Version')
-        string(name: 'CBL_DATASET_VERSION', defaultValue: '6', description: 'Couchbase Lite Build Number')
         string(name: 'PLATFORM', defaultValue: 'ios', description: "The platform to test (e.g. ios, windows)")
         string(name: 'SGW_VERSION', defaultValue: '', description: "The version of Sync Gateway to download")
     }
@@ -16,11 +15,10 @@ pipeline {
             steps {
                 script {
                     if (params.CBL_VERSION == '') { error "CBL_VERSION is required" }
-                    if (params.CBL_DATASET_VERSION == '') { error "CBL_DATASET_VERSION is required" }
                     if (params.PLATFORM == '') { error "PLATFORM is required" }
                     if (params.SGW_VERSION == '') { error "SGW_VERSION is required" }
-                    currentBuild.displayName = "dotnet ${params.CBL_VERSION}-${params.CBL_DATASET_VERSION}"
-                    currentBuild.description = "Dataset: ${params.CBL_DATASET_VERSION} / SGW: ${params.SGW_VERSION}"
+                    currentBuild.displayName = "dotnet ${params.CBL_VERSION}"
+                    currentBuild.description = "SGW: ${params.SGW_VERSION}"
                 }
             }
         }
@@ -64,7 +62,7 @@ pipeline {
                         sh 'security unlock-keychain -p ${KEYCHAIN_PASSWORD} ~/Library/Keychains/login.keychain-db'
                         echo "Run iOS Test"
                         timeout(time: 60, unit: 'MINUTES') {
-                            sh "jenkins/pipelines/QE/dotnet/run_test.sh ${params.CBL_VERSION} ${params.CBL_DATASET_VERSION} ${params.PLATFORM} ${params.SGW_VERSION} ~/.ssh/jborden.pem"
+                            sh "jenkins/pipelines/QE/dotnet/run_test.sh ${params.CBL_VERSION} ${params.PLATFORM} ${params.SGW_VERSION} ~/.ssh/jborden.pem"
                         }
                     }
                     post {
@@ -87,7 +85,7 @@ pipeline {
                     }
                     steps {
                         timeout(time: 60, unit: 'MINUTES') {
-                            pwsh "jenkins\\pipelines\\QE\\dotnet\\run_test.ps1 -Version ${params.CBL_VERSION} -DatasetVersion ${params.CBL_DATASET_VERSION} -SgwVersion ${params.SGW_VERSION} -PrivateKeyPath C:\\Users\\mob-e\\.ssh\\jborden.pem"
+                            pwsh "jenkins\\pipelines\\QE\\dotnet\\run_test.ps1 -Version ${params.CBL_VERSION} -SgwVersion ${params.SGW_VERSION} -PrivateKeyPath C:\\Users\\mob-e\\.ssh\\jborden.pem"
                         }
                     }
                     post {

--- a/jenkins/pipelines/QE/dotnet/run_test.ps1
+++ b/jenkins/pipelines/QE/dotnet/run_test.ps1
@@ -1,6 +1,5 @@
 param (
     [Parameter(Mandatory=$true)][string]$Version,
-    [Parameter(Mandatory=$true)][string]$DatasetVersion,
     [Parameter(Mandatory=$true)][string]$SgwVersion,
     [Parameter()][string]$PrivateKeyPath
 )
@@ -14,7 +13,7 @@ Install-DotNet
 python -m venv venv
 .\venv\Scripts\activate
 pip install -r $AWS_ENVIRONMENT_DIR\requirements.txt
-$python_args = @("windows", $Version, $DatasetVersion, $SgwVersion)
+$python_args = @("windows", $Version, $SgwVersion)
 if ($null -ne $PrivateKeyPath) {
     $python_args += "--private_key"
     $python_args += $PrivateKeyPath

--- a/jenkins/pipelines/QE/dotnet/run_test.sh
+++ b/jenkins/pipelines/QE/dotnet/run_test.sh
@@ -7,9 +7,8 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 source $SCRIPT_DIR/../../shared/config.sh
 
 function usage() {
-    echo "Usage: $0 <version> <dataset_version> <platform> <sgw_version> [private_key_path] [--setup-only]"
+    echo "Usage: $0 <version> <platform> <sgw_version> [private_key_path] [--setup-only]"
     echo "version: CBL version (e.g. 3.2.1-2)"
-    echo "dataset_version: Version of the Couchbase Lite datasets to use"
     echo "platform: The .NET platform to build (e.g. ios)"
     echo "sgw_version: Version of Sync Gateway to download and use"
     echo "private_key_path: Path to the private key to use for SSH connections"
@@ -25,15 +24,14 @@ function prepare_dotnet() {
     fi
 }
 
-if [ $# -lt 4 ]; then
+if [ $# -lt 3 ]; then
     usage
     exit 1
 fi
 
 cbl_version=$1
-dataset_version=$2
-platform=$3
-sgw_version=$4
+platform=$2
+sgw_version=$3
 private_key_path=""
 SETUP_ONLY=false
 
@@ -44,10 +42,10 @@ for arg in "$@"; do
     fi
 done
 
-if [ $# -gt 4 ]; then
-    # Check if 5th argument is --setup-only
-    if [ "$5" != "--setup-only" ]; then
-        private_key_path=$5
+if [ $# -gt 3 ]; then
+    # Check if 4th argument is --setup-only
+    if [ "$4" != "--setup-only" ]; then
+        private_key_path=$4
     fi
 fi
 
@@ -57,9 +55,9 @@ create_venv venv
 source venv/bin/activate
 pip install -r $AWS_ENVIRONMENT_DIR/requirements.txt
 if [ -n "$private_key_path" ]; then
-    python3 $SCRIPT_DIR/setup_test.py $platform $cbl_version $dataset_version $sgw_version --private_key $private_key_path
+    python3 $SCRIPT_DIR/setup_test.py $platform $cbl_version $sgw_version --private_key $private_key_path
 else
-    python3 $SCRIPT_DIR/setup_test.py $platform $cbl_version $dataset_version $sgw_version
+    python3 $SCRIPT_DIR/setup_test.py $platform $cbl_version $sgw_version
 fi
 deactivate
 

--- a/jenkins/pipelines/QE/dotnet/setup_test.py
+++ b/jenkins/pipelines/QE/dotnet/setup_test.py
@@ -20,7 +20,6 @@ from jenkins.pipelines.shared.setup_test import setup_test
 @click.command()
 @click.argument("platform")
 @click.argument("cbl_version")
-@click.argument("dataset_version")
 @click.argument("sgw_version")
 @click.option(
     "--cbs_version",
@@ -34,14 +33,12 @@ from jenkins.pipelines.shared.setup_test import setup_test
 def cli_entry(
     platform: str,
     cbl_version: str,
-    dataset_version: str,
     sgw_version: str,
     private_key: str | None,
     cbs_version: str,
 ) -> None:
     setup_test(
         cbl_version,
-        dataset_version,
         sgw_version,
         SCRIPT_DIR / "topologies" / f"topology_single_{platform}.json",
         SCRIPT_DIR / "config_aws.json",

--- a/jenkins/pipelines/QE/dotnet/topologies/topology_single_android.json
+++ b/jenkins/pipelines/QE/dotnet/topologies/topology_single_android.json
@@ -4,7 +4,6 @@
         {
             "platform": "dotnet_android",
             "cbl_version": "{{version}}",
-            "dataset_version": "{{dataset_version}}",
             "location": "1BCACS00001MX3"
         }
     ],

--- a/jenkins/pipelines/QE/dotnet/topologies/topology_single_ios.json
+++ b/jenkins/pipelines/QE/dotnet/topologies/topology_single_ios.json
@@ -4,7 +4,6 @@
         {
             "platform": "dotnet_ios",
             "cbl_version": "{{version}}",
-            "dataset_version": "{{dataset_version}}",
             "location": "00008110-000E544201D1401E"
         }
     ],

--- a/jenkins/pipelines/QE/dotnet/topologies/topology_single_macos.json
+++ b/jenkins/pipelines/QE/dotnet/topologies/topology_single_macos.json
@@ -4,7 +4,6 @@
         {
             "platform": "dotnet_macos",
             "cbl_version": "{{version}}",
-            "dataset_version": "{{dataset_version}}",
             "location": "localhost"
         }
     ],

--- a/jenkins/pipelines/QE/dotnet/topologies/topology_single_windows.json
+++ b/jenkins/pipelines/QE/dotnet/topologies/topology_single_windows.json
@@ -4,7 +4,6 @@
         {
             "platform": "dotnet_windows",
             "cbl_version": "{{version}}",
-            "dataset_version": "{{dataset_version}}",
             "location": "localhost"
         }
     ],

--- a/jenkins/pipelines/QE/ios/Jenkinsfile
+++ b/jenkins/pipelines/QE/ios/Jenkinsfile
@@ -3,7 +3,6 @@ pipeline {
     parameters {
         choice(name: 'CBL_EDITION', choices: ['enterprise', 'community'], description: 'Couchbase Lite Edition')
         string(name: 'CBL_VERSION', defaultValue: '3.2.3', description: 'Couchbase Lite Version (build number will be auto-fetched)')
-        string(name: 'CBL_DATASET_VERSION', defaultValue: '3.2', description: "The dataset version to use (e.g. 3.2 or 4.0)")
         string(name: 'SGW_VERSION', defaultValue: '3.2.3', description: "The version of Sync Gateway to download")
     }
     stages {
@@ -13,7 +12,7 @@ pipeline {
                     if (params.CBL_VERSION == '') { error "CBL_VERSION is required" }
                     if (params.SGW_VERSION == '') { error "SGW_VERSION is required" }
                     currentBuild.displayName = "${params.CBL_VERSION}-${CBL_EDITION} (#${currentBuild.number})"
-                    currentBuild.description = "Dataset: ${params.CBL_DATASET_VERSION}"
+                    currentBuild.description = "SGW: ${params.SGW_VERSION}"
                 }
             }
         }
@@ -41,7 +40,7 @@ pipeline {
                 sh 'security unlock-keychain -p ${KEYCHAIN_PASSWORD} ~/Library/Keychains/login.keychain-db'
                 echo "Run iOS Test"
                 timeout(time: 60, unit: 'MINUTES') {
-                    sh "jenkins/pipelines/QE/ios/test.sh ${params.CBL_EDITION} ${params.CBL_VERSION} ${params.CBL_DATASET_VERSION} ${params.SGW_VERSION} ~/.ssh/jborden.pem"
+                    sh "jenkins/pipelines/QE/ios/test.sh ${params.CBL_EDITION} ${params.CBL_VERSION} ${params.SGW_VERSION} ~/.ssh/jborden.pem"
                 }
             }
             post {

--- a/jenkins/pipelines/QE/ios/setup_test.py
+++ b/jenkins/pipelines/QE/ios/setup_test.py
@@ -20,7 +20,6 @@ from jenkins.pipelines.shared.setup_test import setup_test
 
 @click.command()
 @click.argument("cbl_version")
-@click.argument("dataset_version")
 @click.argument("sgw_version")
 @click.option(
     "--private_key",
@@ -28,13 +27,11 @@ from jenkins.pipelines.shared.setup_test import setup_test
 )
 def cli_entry(
     cbl_version: str,
-    dataset_version: str,
     sgw_version: str,
     private_key: str | None,
 ) -> None:
     setup_test(
         cbl_version,
-        dataset_version,
         sgw_version,
         SCRIPT_DIR / "topology_single_device.json",
         SCRIPT_DIR / "config.json",

--- a/jenkins/pipelines/QE/ios/test.sh
+++ b/jenkins/pipelines/QE/ios/test.sh
@@ -4,19 +4,18 @@ trap 'echo "$BASH_COMMAND (line $LINENO) failed, exiting..."; exit 1' ERR
 set -euo pipefail
 
 function usage() {
-    echo "Usage: $0 <edition> <version> <dataset_version> <sgw_version> <private_key_path> [--setup-only]"
+    echo "Usage: $0 <edition> <version> <sgw_version> <private_key_path> [--setup-only]"
     echo "  --setup-only: Only build test server and setup backend, skip test execution"
     echo "  Build number will be auto-fetched for the specified version"
     exit 1
 }
 
-if [ "$#" -lt 5 ] || [ "$#" -gt 6 ]; then usage; fi
+if [ "$#" -lt 4 ] || [ "$#" -gt 5 ]; then usage; fi
 
 EDITION=${1}
 CBL_VERSION=${2}
-CBL_DATASET_VERSION=${3}
-SGW_VERSION=${4}
-private_key_path=${5}
+SGW_VERSION=${3}
+private_key_path=${4}
 SETUP_ONLY=false
 
 # Check for --setup-only flag
@@ -36,9 +35,9 @@ create_venv venv
 source venv/bin/activate
 pip install -r $AWS_ENVIRONMENT_DIR/requirements.txt
 if [ -n "$private_key_path" ]; then
-   python3 $SCRIPT_DIR/setup_test.py $CBL_VERSION $CBL_DATASET_VERSION $SGW_VERSION --private_key $private_key_path
+   python3 $SCRIPT_DIR/setup_test.py $CBL_VERSION $SGW_VERSION --private_key $private_key_path
 else
-   python3 $SCRIPT_DIR/setup_test.py $CBL_VERSION $CBL_DATASET_VERSION $SGW_VERSION
+   python3 $SCRIPT_DIR/setup_test.py $CBL_VERSION $SGW_VERSION
 fi
 deactivate
 

--- a/jenkins/pipelines/QE/ios/topology_single_device.json
+++ b/jenkins/pipelines/QE/ios/topology_single_device.json
@@ -4,7 +4,6 @@
         {
             "platform": "swift_ios",
             "cbl_version": "{{version}}",
-            "dataset_version": "{{dataset_version}}",
             "location": "00008101-000E0519020A001E"
         }
     ],

--- a/jenkins/pipelines/QE/java/Jenkinsfile
+++ b/jenkins/pipelines/QE/java/Jenkinsfile
@@ -3,7 +3,6 @@ pipeline {
     agent none
     parameters {
         string(name: 'CBL_VERSION', defaultValue: '', description: 'Couchbase Lite Version')
-        string(name: 'CBL_DATASET_VERSION', defaultValue: '', description: "The dataset version to use")
         string(name: 'SGW_VERSION', defaultValue: '', description: "The version of Sync Gateway to download")
     }
     stages {
@@ -11,9 +10,8 @@ pipeline {
             steps {
                 script {
                     if (params.CBL_VERSION == '') { error "CBL_VERSION is required" }
-                    if (params.CBL_DATASET_VERSION == '') { error "CBL_DATASET_VERSION is required" }
                     if (params.SGW_VERSION == '') { error "SGW_VERSION is required" }
-                    currentBuild.displayName = "java ${params.CBL_VERSION}/${params.CBL_DATASET_VERSION} (#${currentBuild.number})"
+                    currentBuild.displayName = "java ${params.CBL_VERSION} (#${currentBuild.number})"
                 }
             }
         }
@@ -57,7 +55,7 @@ pipeline {
                     steps {
                         echo "=== Run Linux Desktop Tests"
                         timeout(time: 120, unit: 'MINUTES') {
-                            sh "jenkins/pipelines/QE/java/desktop/run_test.sh ${params.CBL_VERSION} ${params.CBL_DATASET_VERSION} ${params.SGW_VERSION} ~/.ssh/jborden.pem"
+                            sh "jenkins/pipelines/QE/java/desktop/run_test.sh ${params.CBL_VERSION} ${params.SGW_VERSION} ~/.ssh/jborden.pem"
                         }
                         echo "=== Linux Desktop Tests Complete"
                     }
@@ -83,7 +81,7 @@ pipeline {
                     steps {
                         echo "=== Run Linux Web Service Tests"
                         timeout(time: 120, unit: 'MINUTES') {
-                            sh "jenkins/pipelines/QE/java/webservice/run_test.sh ${params.CBL_VERSION} ${params.CBL_DATASET_VERSION} ${params.SGW_VERSION} ~/.ssh/jborden.pem"
+                            sh "jenkins/pipelines/QE/java/webservice/run_test.sh ${params.CBL_VERSION} ${params.SGW_VERSION} ~/.ssh/jborden.pem"
                         }
                         echo "=== Linux Web Service Tests Complete"
                     }

--- a/jenkins/pipelines/QE/java/desktop/run_test.ps1
+++ b/jenkins/pipelines/QE/java/desktop/run_test.ps1
@@ -1,6 +1,5 @@
 param (
     [Parameter(Mandatory=$true)][string]$Version,
-    [Parameter(Mandatory=$true)][string]$DatasetVersion,
     [Parameter(Mandatory=$true)][string]$SgwVersion,
     [Parameter()][string]$PrivateKeyPath
 )
@@ -12,7 +11,7 @@ New-Venv venv
 .\venv\Scripts\activate
 trap { Stop-Venv; break }
 uv pip install -r $AWS_ENVIRONMENT_DIR\requirements.txt
-$python_args = @($Version, $DatasetVersion, $SgwVersion)
+$python_args = @($Version, $SgwVersion)
 if ($null -ne $PrivateKeyPath) {
     $python_args += "--private_key"
     $python_args += $PrivateKeyPath

--- a/jenkins/pipelines/QE/java/desktop/run_test.sh
+++ b/jenkins/pipelines/QE/java/desktop/run_test.sh
@@ -7,25 +7,23 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 source $SCRIPT_DIR/../../../shared/config.sh
 
 function usage() {
-    echo "Usage: $0 <version> <dataset_version> <platform> <sgw_version> [private_key_path]"
+    echo "Usage: $0 <version> <sgw_version> [private_key_path]"
     echo "version: CBL version (e.g. 3.2.1-2)"
-    echo "dataset_version: Version of the Couchbase Lite datasets to use"
     echo "sgw_version: Version of Sync Gateway to download and use"
     echo "private_key_path: Path to the private key to use for SSH connections"
 }
 
-if [ $# -lt 3 ]; then
+if [ $# -lt 2 ]; then
     usage
     exit 1
 fi
 
-if [ $# -gt 3 ]; then
-    private_key_path=$4
+if [ $# -gt 2 ]; then
+    private_key_path=$3
 fi
 
 cbl_version=$1
-dataset_version=$2
-sgw_version=$3
+sgw_version=$2
 
 stop_venv
 create_venv venv
@@ -33,9 +31,9 @@ source venv/bin/activate
 trap stop_venv EXIT
 uv pip install -r $AWS_ENVIRONMENT_DIR/requirements.txt
 if [ -n "$private_key_path" ]; then
-    python3 $SCRIPT_DIR/setup_test.py $cbl_version $dataset_version $sgw_version --private_key $private_key_path
+    python3 $SCRIPT_DIR/setup_test.py $cbl_version $sgw_version --private_key $private_key_path
 else
-    python3 $SCRIPT_DIR/setup_test.py $cbl_version $dataset_version $sgw_version
+    python3 $SCRIPT_DIR/setup_test.py $cbl_version $sgw_version
 fi
 
 pushd $QE_TESTS_DIR

--- a/jenkins/pipelines/QE/java/desktop/setup_test.py
+++ b/jenkins/pipelines/QE/java/desktop/setup_test.py
@@ -19,7 +19,6 @@ from jenkins.pipelines.shared.setup_test import setup_test
 
 @click.command()
 @click.argument("cbl_version")
-@click.argument("dataset_version")
 @click.argument("sgw_version")
 @click.option(
     "--private_key",
@@ -27,13 +26,11 @@ from jenkins.pipelines.shared.setup_test import setup_test
 )
 def cli_entry(
     cbl_version: str,
-    dataset_version: str,
     sgw_version: str,
     private_key: str | None,
 ) -> None:
     setup_test(
         cbl_version,
-        dataset_version,
         sgw_version,
         SCRIPT_DIR / "topology_single_host.json",
         SCRIPT_DIR / "config_java_desktop.json",

--- a/jenkins/pipelines/QE/java/desktop/topology_single_host.json
+++ b/jenkins/pipelines/QE/java/desktop/topology_single_host.json
@@ -4,7 +4,6 @@
         {
             "platform": "jak_desktop",
             "cbl_version": "{{version}}",
-            "dataset_version": "{{dataset_version}}",
             "location": "localhost",
             "download": true
         }

--- a/jenkins/pipelines/QE/java/webservice/run_test.ps1
+++ b/jenkins/pipelines/QE/java/webservice/run_test.ps1
@@ -1,6 +1,5 @@
 param (
     [Parameter(Mandatory=$true)][string]$Version,
-    [Parameter(Mandatory=$true)][string]$DatasetVersion,
     [Parameter(Mandatory=$true)][string]$SgwVersion,
     [Parameter()][string]$PrivateKeyPath
 )
@@ -12,7 +11,7 @@ New-Venv venv
 .\venv\Scripts\activate
 trap { Stop-Venv; break }
 uv pip install -r $AWS_ENVIRONMENT_DIR\requirements.txt
-$python_args = @($Version, $DatasetVersion, $SgwVersion)
+$python_args = @($Version, $SgwVersion)
 if ($null -ne $PrivateKeyPath) {
     $python_args += "--private_key"
     $python_args += $PrivateKeyPath

--- a/jenkins/pipelines/QE/java/webservice/run_test.sh
+++ b/jenkins/pipelines/QE/java/webservice/run_test.sh
@@ -7,25 +7,23 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 source $SCRIPT_DIR/../../../shared/config.sh
 
 function usage() {
-    echo "Usage: $0 <version> <dataset_version> <sgw_version> [private_key_path]"
+    echo "Usage: $0 <version> <sgw_version> [private_key_path]"
     echo "version: CBL version (e.g. 3.2.1-2)"
-    echo "dataset_version: Version of the Couchbase Lite datasets to use"
     echo "sgw_version: Version of Sync Gateway to download and use"
     echo "private_key_path: Path to the private key to use for SSH connections"
 }
 
-if [ $# -lt 3 ]; then
+if [ $# -lt 2 ]; then
     usage
     exit 1
 fi
 
-if [ $# -gt 3 ]; then
-    private_key_path=$4
+if [ $# -gt 2 ]; then
+    private_key_path=$3
 fi
 
 cbl_version=$1
-dataset_version=$2
-sgw_version=$3
+sgw_version=$2
 
 stop_venv
 create_venv venv
@@ -33,9 +31,9 @@ source venv/bin/activate
 trap stop_venv EXIT
 uv pip install -r $AWS_ENVIRONMENT_DIR/requirements.txt
 if [ -n "$private_key_path" ]; then
-    python3 $SCRIPT_DIR/setup_test.py $cbl_version $dataset_version $sgw_version --private_key $private_key_path
+    python3 $SCRIPT_DIR/setup_test.py $cbl_version $sgw_version --private_key $private_key_path
 else
-    python3 $SCRIPT_DIR/setup_test.py $cbl_version $dataset_version $sgw_version
+    python3 $SCRIPT_DIR/setup_test.py $cbl_version $sgw_version
 fi
 
 pushd $QE_TESTS_DIR

--- a/jenkins/pipelines/QE/java/webservice/setup_test.py
+++ b/jenkins/pipelines/QE/java/webservice/setup_test.py
@@ -19,7 +19,6 @@ from jenkins.pipelines.shared.setup_test import setup_test
 
 @click.command()
 @click.argument("cbl_version")
-@click.argument("dataset_version")
 @click.argument("sgw_version")
 @click.option(
     "--private_key",
@@ -27,13 +26,11 @@ from jenkins.pipelines.shared.setup_test import setup_test
 )
 def cli_entry(
     cbl_version: str,
-    dataset_version: str,
     sgw_version: str,
     private_key: str | None,
 ) -> None:
     setup_test(
         cbl_version,
-        dataset_version,
         sgw_version,
         SCRIPT_DIR / "topology_single_host.json",
         SCRIPT_DIR / "config_java_webservice.json",

--- a/jenkins/pipelines/QE/java/webservice/topology_single_host.json
+++ b/jenkins/pipelines/QE/java/webservice/topology_single_host.json
@@ -4,7 +4,6 @@
         {
             "platform": "jak_webservice",
             "cbl_version": "{{version}}",
-            "dataset_version": "{{dataset_version}}",
             "location": "localhost",
             "download": true
         }

--- a/jenkins/pipelines/QE/multiplatform/Jenkinsfile
+++ b/jenkins/pipelines/QE/multiplatform/Jenkinsfile
@@ -12,11 +12,6 @@ pipeline {
                         'Supported platforms: ios, android, dotnet, java, c'
         )
         string(
-            name: 'CBL_DATASET_VERSION',
-            defaultValue: '3.2',
-            description: 'CBL Dataset Version'
-        )
-        string(
             name: 'SGW_VERSION',
             defaultValue: '3.2.3',
             description: 'Sync Gateway Version'
@@ -39,10 +34,9 @@ pipeline {
             steps {
                 script {
                     if (params.PLATFORM_VERSIONS == '') { error "PLATFORM_VERSIONS is required" }
-                    if (params.CBL_DATASET_VERSION == '') { error "CBL_DATASET_VERSION is required" }
                     if (params.SGW_VERSION == '') { error "SGW_VERSION is required" }
                     currentBuild.displayName = "${params.PLATFORM_VERSIONS}-${params.SGW_VERSION} (#${currentBuild.number})"
-                    currentBuild.description = "Dataset: ${params.CBL_DATASET_VERSION}"
+                    currentBuild.description = "SGW: ${params.SGW_VERSION}"
                 }
             }
         }
@@ -50,7 +44,6 @@ pipeline {
             steps {
                 script {
                     echo "Platform Versions: ${params.PLATFORM_VERSIONS}"
-                    echo "Dataset Version: ${params.CBL_DATASET_VERSION}"
                     echo "SGW Version: ${params.SGW_VERSION}"
                     echo "Auto-fetch builds: ${!params.DISABLE_AUTO_FETCH}"
                     
@@ -148,7 +141,7 @@ pipeline {
                 sh 'security unlock-keychain -p ${KEYCHAIN_PASSWORD} ~/Library/Keychains/login.keychain-db'
                 echo "Run Multiplatform Test"
                 timeout(time: 60, unit: 'MINUTES') {
-                    sh "jenkins/pipelines/QE/multiplatform/test_multiplatform.sh ${params.PLATFORM_VERSIONS} ${params.CBL_DATASET_VERSION} ${params.SGW_VERSION} ${params.CBL_TEST_NAME}"
+                    sh "jenkins/pipelines/QE/multiplatform/test_multiplatform.sh ${params.PLATFORM_VERSIONS} ${params.SGW_VERSION} ${params.CBL_TEST_NAME}"
                 }
             }
         }

--- a/jenkins/pipelines/QE/multiplatform/setup_test.py
+++ b/jenkins/pipelines/QE/multiplatform/setup_test.py
@@ -23,7 +23,6 @@ from jenkins.pipelines.shared.setup_test import resolved_version
 
 def setup_multiplatform_test(
     platform_versions: dict,
-    dataset_version: str,
     sgw_version: str,
     private_key: str | None = None,
     couchbase_version: str = "7.6",
@@ -35,7 +34,6 @@ def setup_multiplatform_test(
 
     Args:
         platform_versions: Dict mapping platform names to their versions (e.g., {"ios": "3.1.5", "android": "3.2.3"})
-        dataset_version: CBL dataset version to use
         sgw_version: Sync Gateway version to use
         private_key: Optional SSH private key path
         couchbase_version: Couchbase Server version
@@ -93,10 +91,6 @@ def setup_multiplatform_test(
 
             # Replace template variables with actual platform versions
             for ts in topology["test_servers"]:
-                # Replace dataset version template
-                if ts.get("dataset_version") == "{{dataset_version}}":
-                    ts["dataset_version"] = dataset_version
-
                 # Replace platform-specific CBL version templates
                 platform = ts.get("platform", "")
                 if (
@@ -160,7 +154,6 @@ def parse_platform_configs(platform_configs: str) -> dict:
 
 @click.command()
 @click.argument("platform_configs")
-@click.argument("dataset_version")
 @click.argument("sgw_version")
 @click.option(
     "--private_key",
@@ -168,7 +161,6 @@ def parse_platform_configs(platform_configs: str) -> dict:
 )
 def cli_entry(
     platform_configs: str,
-    dataset_version: str,
     sgw_version: str,
     private_key: str | None,
 ) -> None:
@@ -176,7 +168,6 @@ def cli_entry(
     Setup multiplatform testing environment with platform-specific CBL versions.
 
     PLATFORM_CONFIGS: Space-separated platform specifications (e.g., "android:3.2.3 ios:3.1.5")
-    DATASET_VERSION: CBL dataset version to use
     SGW_VERSION: Sync Gateway version to use
     """
     # Parse platform versions from the configuration string
@@ -188,7 +179,6 @@ def cli_entry(
 
     setup_multiplatform_test(
         platform_versions,
-        dataset_version,
         sgw_version,
         private_key,
         setup_dir="QE",

--- a/jenkins/pipelines/QE/multiplatform/test_multiplatform.sh
+++ b/jenkins/pipelines/QE/multiplatform/test_multiplatform.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 # Multiplatform CBL test runner
-# Usage: ./test_multiplatform.sh "platform1:version1[-build1] platform2:version2[-build2]..." <dataset_version> <sgw_version> [test_name]
+# Usage: ./test_multiplatform.sh "platform1:version1[-build1] platform2:version2[-build2]..." <sgw_version> [test_name]
 # Examples:
-#   ./test_multiplatform.sh "android:3.2.3 ios:3.1.5" 3.2 3.2.3
-#   ./test_multiplatform.sh "android:3.2.3 ios:3.1.5" 3.2 3.2.3 "test_delta_sync.py::TestDeltaSync::test_delta_sync_replication"
+#   ./test_multiplatform.sh "android:3.2.3 ios:3.1.5" 3.2.3
+#   ./test_multiplatform.sh "android:3.2.3 ios:3.1.5" 3.2.3 "test_delta_sync.py::TestDeltaSync::test_delta_sync_replication"
 
 trap 'echo "$BASH_COMMAND (line $LINENO) failed, exiting..."; exit 1' ERR
 set -euo pipefail
@@ -41,20 +41,20 @@ function list_available_tests() {
 }
 
 function usage() {
-    echo "Usage: $0 \"platform1:version1[-build1] platform2:version2[-build2]...\" <dataset_version> <sgw_version> [test_name]"
+    echo "Usage: $0 \"platform1:version1[-build1] platform2:version2[-build2]...\" <sgw_version> [test_name]"
     echo ""
     echo "Supported platforms: android, ios, dotnet, c, java"
     echo "Private key: ${HOME}/.ssh/jborden.pem (hardcoded)"
     echo ""
     echo "Examples:"
     echo "  # Auto-fetch latest builds with default test:"
-    echo "  $0 \"android:3.2.3 ios:3.1.5\" 3.2 3.2.3"
+    echo "  $0 \"android:3.2.3 ios:3.1.5\" 3.2.3"
     echo ""
     echo "  # With specific test:"
-    echo "  $0 \"android:3.2.3 ios:3.1.5\" 3.2 3.2.3 \"test_no_conflicts.py::TestNoConflicts::test_multiple_cbls_updates_concurrently_with_push\""
+    echo "  $0 \"android:3.2.3 ios:3.1.5\" 3.2.3 \"test_no_conflicts.py::TestNoConflicts::test_multiple_cbls_updates_concurrently_with_push\""
     echo ""
     echo "  # With explicit builds:"
-    echo "  $0 \"android:3.2.3 ios:3.1.5-6\" 3.2 3.2.3"
+    echo "  $0 \"android:3.2.3 ios:3.1.5-6\" 3.2.3"
     echo ""
     echo "  # List available tests:"
     echo "  $0 --list-tests"
@@ -74,24 +74,18 @@ if [ $# -eq 1 ] && [ "$1" = "--list-tests" ]; then
     exit 0
 fi
 
-if [ $# -lt 3 ] || [ $# -gt 4 ]; then
+if [ $# -lt 2 ] || [ $# -gt 3 ]; then
     usage
 fi
 
 PLATFORM_CONFIGS="$1"
-DATASET_VERSION="$2"
-SG_VERSION="$3"
+SG_VERSION="$2"
 PRIVATE_KEY_PATH="${HOME}/.ssh/jborden.pem"
-TEST_NAME="${4:-test_delta_sync.py::TestDeltaSync::test_delta_sync_replication}"
+TEST_NAME="${3:-test_delta_sync.py::TestDeltaSync::test_delta_sync_replication}"
 
 # Validate inputs
 if [ -z "$PLATFORM_CONFIGS" ]; then
     echo "❌ Error: Platform configurations cannot be empty"
-    usage
-fi
-
-if [ -z "$DATASET_VERSION" ]; then
-    echo "❌ Error: Dataset version cannot be empty"
     usage
 fi
 
@@ -108,7 +102,6 @@ fi
 echo "🚀 MULTIPLATFORM CBL TEST SETUP"
 echo "==============================="
 echo "📋 Platform configurations: $PLATFORM_CONFIGS"
-echo "📊 Dataset version: $DATASET_VERSION"
 echo "🔄 SG version: $SG_VERSION"
 echo "🔑 Private key: $PRIVATE_KEY_PATH"
 echo "🧪 Test: $TEST_NAME"
@@ -184,7 +177,7 @@ pip install -r $AWS_ENVIRONMENT_DIR/requirements.txt
 
 # Use the centralized multiplatform setup script
 echo "🚀 Running multiplatform setup..."
-python3 setup_multiplatform.py "$PLATFORM_CONFIGS" "$DATASET_VERSION" "$SG_VERSION" --setup-only
+python3 setup_multiplatform.py "$PLATFORM_CONFIGS" "$SG_VERSION" --setup-only
 SETUP_SUCCESS=$?
 
 deactivate

--- a/jenkins/pipelines/QE/multiplatform/topology.json
+++ b/jenkins/pipelines/QE/multiplatform/topology.json
@@ -4,13 +4,11 @@
         {
             "platform": "swift_ios",
             "cbl_version": "{{ios_version}}",
-            "dataset_version": "{{dataset_version}}",
             "location": "00008110-000E544201D1401E"
         },
         {
             "platform": "jak_android",
             "cbl_version": "{{android_version}}",
-            "dataset_version": "{{dataset_version}}",
             "location": "RZCT31DWZEV"
         }
     ],

--- a/jenkins/pipelines/dev_e2e/android/Jenkinsfile
+++ b/jenkins/pipelines/dev_e2e/android/Jenkinsfile
@@ -4,7 +4,6 @@ pipeline {
         choice(name: 'CBL_EDITION', choices: ['enterprise', 'community'], description: 'Couchbase Lite Edition')
         string(name: 'CBL_VERSION', defaultValue: '', description: 'Couchbase Lite Version')
         string(name: 'CBL_BUILD', defaultValue: '', description: 'Couchbase Lite Build Number')
-        string(name: 'CBL_DATASET_VERSION', defaultValue: '', description: "The dataset version to use")
         string(name: 'SGW_VERSION', defaultValue: '', description: "The version of Sync Gateway to download")
     }
     stages {
@@ -13,9 +12,8 @@ pipeline {
                 script {
                     if (params.CBL_VERSION == '') { error "CBL_VERSION is required" }
                     if (params.CBL_BUILD == '') { error "CBL_BUILD is required" }
-                    if (params.CBL_DATASET_VERSION == '') { error "CBL_DATASET_VERSION is required" }
                     if (params.SGW_VERSION == '') { error "SGW_VERSION is required" }
-                    currentBuild.displayName = "android-${CBL_EDITION} ${params.CBL_VERSION}-${params.CBL_BUILD}/${params.CBL_DATASET_VERSION} (#${currentBuild.number})"
+                    currentBuild.displayName = "android-${CBL_EDITION} ${params.CBL_VERSION}-${params.CBL_BUILD} (#${currentBuild.number})"
                 }
             }
         }
@@ -42,7 +40,7 @@ pipeline {
                 echo "Run Android Tests"
                 timeout(time: 60, unit: 'MINUTES') {
                     sh """
-                        jenkins/pipelines/dev_e2e/android/android_tests.sh "${params.CBL_VERSION}-${params.CBL_BUILD}" "${params.CBL_DATASET_VERSION}" "${params.SGW_VERSION}" ~/.ssh/jborden.pem
+                        jenkins/pipelines/dev_e2e/android/android_tests.sh "${params.CBL_VERSION}-${params.CBL_BUILD}" "${params.SGW_VERSION}" ~/.ssh/jborden.pem
                     """
                 }
             }

--- a/jenkins/pipelines/dev_e2e/android/android_tests.sh
+++ b/jenkins/pipelines/dev_e2e/android/android_tests.sh
@@ -10,22 +10,19 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 source $SCRIPT_DIR/../../shared/config.sh
 
 function usage() {
-    echo "Usage: $0 <cbl_version> <dataset version> <sg version> [private key path]"
+    echo "Usage: $0 <cbl_version> <sg version> [private key path]"
     exit 1
 }
 
-if [ "$#" -lt 3 ] | [ "$#" -gt 4 ] ; then usage; fi
+if [ "$#" -lt 2 ] | [ "$#" -gt 3 ] ; then usage; fi
 
 CBL_VERSION="$1"
 if [ -z "$CBL_VERSION" ]; then usage; fi
 
-DATASET_VERSION="$2"
-if [ -z "$DATASET_VERSION" ]; then usage; fi
-
-SG_VERSION="$3"
+SG_VERSION="$2"
 if [ -z "$SG_VERSION" ]; then usage; fi
 
-private_key_path="$4"
+private_key_path="$3"
 STATUS=0
 
 echo "Install Android SDK"
@@ -39,9 +36,9 @@ source venv/bin/activate
 trap stop_venv EXIT
 uv pip install -r $AWS_ENVIRONMENT_DIR/requirements.txt
 if [ -n "$private_key_path" ]; then
-    python3 $SCRIPT_DIR/setup_test.py $CBL_VERSION $DATASET_VERSION $SG_VERSION --private_key $private_key_path
+    python3 $SCRIPT_DIR/setup_test.py $CBL_VERSION $SG_VERSION --private_key $private_key_path
 else
-    python3 $SCRIPT_DIR/setup_test.py $CBL_VERSION $DATASET_VERSION $SG_VERSION
+    python3 $SCRIPT_DIR/setup_test.py $CBL_VERSION $SG_VERSION
 fi
 
 echo "Start logcat"

--- a/jenkins/pipelines/dev_e2e/android/setup_test.py
+++ b/jenkins/pipelines/dev_e2e/android/setup_test.py
@@ -20,7 +20,6 @@ from jenkins.pipelines.shared.setup_test import setup_test
 
 @click.command()
 @click.argument("cbl_version")
-@click.argument("dataset_version")
 @click.argument("sgw_version")
 @click.option(
     "--private_key",
@@ -28,13 +27,11 @@ from jenkins.pipelines.shared.setup_test import setup_test
 )
 def cli_entry(
     cbl_version: str,
-    dataset_version: str,
     sgw_version: str,
     private_key: str | None,
 ) -> None:
     setup_test(
         cbl_version,
-        dataset_version,
         sgw_version,
         SCRIPT_DIR / "topology_single_device.json",
         SCRIPT_DIR / "config_android.json",

--- a/jenkins/pipelines/dev_e2e/android/topology_single_device.json
+++ b/jenkins/pipelines/dev_e2e/android/topology_single_device.json
@@ -4,7 +4,6 @@
         {
             "platform": "jak_android",
             "cbl_version": "{{version}}",
-            "dataset_version": "{{dataset_version}}",
             "location": "1BCACS00001MX3",
             "download": true
         }

--- a/jenkins/pipelines/dev_e2e/c/Jenkinsfile
+++ b/jenkins/pipelines/dev_e2e/c/Jenkinsfile
@@ -4,7 +4,6 @@ pipeline {
         choice(name: 'CBL_EDITION', choices: ['enterprise', 'community'], description: 'Couchbase Lite Edition')
         string(name: 'CBL_VERSION', defaultValue: '3.2.0', description: 'Couchbase Lite Version')
         string(name: 'CBL_BUILD', defaultValue: '', description: 'Couchbase Lite Build Number')
-        string(name: 'CBL_DATASET_VERSION', defaultValue: '', description: "The dataset version to use (e.g. 3.2 or 4.0)")
         string(name: 'SGW_VERSION', defaultValue: '', description: "The version of Sync Gateway to download")
     }
     options {
@@ -16,10 +15,9 @@ pipeline {
                 script {
                     if (params.CBL_VERSION == '') { error "CBL_VERSION is required" }
                     if (params.CBL_BUILD == '') { error "CBL_BUILD is required" }
-                    if (params.CBL_DATASET_VERSION == '') { error "CBL_DATASET_VERSION is required" }
                     if (params.SGW_VERSION == '') { error "SGW_VERSION is required" }
                     currentBuild.displayName = "${params.CBL_VERSION}-${params.CBL_BUILD}-${CBL_EDITION} (#${currentBuild.number})"
-                    currentBuild.description = "Dataset: ${params.CBL_DATASET_VERSION}"
+                    currentBuild.description = "SGW: ${params.SGW_VERSION}"
                 }
             }
         }
@@ -62,7 +60,7 @@ pipeline {
                     steps {
                         echo "Run macOS Test"
                         timeout(time: 60, unit: 'MINUTES') {
-                            sh "jenkins/pipelines/dev_e2e/c/run_test.sh ${params.CBL_VERSION}-${params.CBL_BUILD} ${params.CBL_DATASET_VERSION} macos '${params.SGW_VERSION}' ~/.ssh/jborden.pem"
+                            sh "jenkins/pipelines/dev_e2e/c/run_test.sh ${params.CBL_VERSION}-${params.CBL_BUILD} macos '${params.SGW_VERSION}' ~/.ssh/jborden.pem"
                         }
                     }
                     post { 
@@ -89,7 +87,7 @@ pipeline {
                         sh 'security unlock-keychain -p ${KEYCHAIN_PASSWORD} ~/Library/Keychains/login.keychain-db'
                         echo "Run iOS Test"
                         timeout(time: 60, unit: 'MINUTES') {
-                            sh "jenkins/pipelines/dev_e2e/c/run_test.sh ${params.CBL_VERSION}-${params.CBL_BUILD} ${params.CBL_DATASET_VERSION} ios '${params.SGW_VERSION}' ~/.ssh/jborden.pem"
+                            sh "jenkins/pipelines/dev_e2e/c/run_test.sh ${params.CBL_VERSION}-${params.CBL_BUILD} ios '${params.SGW_VERSION}' ~/.ssh/jborden.pem"
                         }
                     }
                     post { 
@@ -113,7 +111,7 @@ pipeline {
                     steps {
                         echo "Run Android Test"
                         timeout(time: 60, unit: 'MINUTES') {
-                            sh "jenkins/pipelines/dev_e2e/c/run_test.sh ${params.CBL_VERSION}-${params.CBL_BUILD} ${params.CBL_DATASET_VERSION} android '${params.SGW_VERSION}' ~/.ssh/jborden.pem"
+                            sh "jenkins/pipelines/dev_e2e/c/run_test.sh ${params.CBL_VERSION}-${params.CBL_BUILD} android '${params.SGW_VERSION}' ~/.ssh/jborden.pem"
                         }
                     }
                     post { 
@@ -137,7 +135,7 @@ pipeline {
                     steps {
                         echo "Run linux Test"
                         timeout(time: 60, unit: 'MINUTES') {
-                            sh "jenkins/pipelines/dev_e2e/c/run_test.sh ${params.CBL_VERSION}-${params.CBL_BUILD} ${params.CBL_DATASET_VERSION} linux_x86_64 '${params.SGW_VERSION}' ~/.ssh/jborden.pem"
+                            sh "jenkins/pipelines/dev_e2e/c/run_test.sh ${params.CBL_VERSION}-${params.CBL_BUILD} linux_x86_64 '${params.SGW_VERSION}' ~/.ssh/jborden.pem"
                         }
                     }
                     post { 
@@ -157,7 +155,7 @@ pipeline {
                     }
                     steps {
                         timeout(time: 60, unit: 'MINUTES') {
-                            pwsh "jenkins\\pipelines\\dev_e2e\\c\\run_test.ps1 -Version ${params.CBL_VERSION}-${params.CBL_BUILD} -Dataset ${params.CBL_DATASET_VERSION} -SgwVersion ${params.SGW_VERSION} -PrivateKeyPath C:\\Users\\mob-e\\.ssh\\jborden.pem"
+                            pwsh "jenkins\\pipelines\\dev_e2e\\c\\run_test.ps1 -Version ${params.CBL_VERSION}-${params.CBL_BUILD} -SgwVersion ${params.SGW_VERSION} -PrivateKeyPath C:\\Users\\mob-e\\.ssh\\jborden.pem"
                         }
                     }
                     post { 

--- a/jenkins/pipelines/dev_e2e/c/run_test.ps1
+++ b/jenkins/pipelines/dev_e2e/c/run_test.ps1
@@ -1,6 +1,5 @@
 param (
     [Parameter(Mandatory=$true)][string]$Version,
-    [Parameter(Mandatory=$true)][string]$DatasetVersion,
     [Parameter(Mandatory=$true)][string]$SgwVersion,
     [Parameter()][string]$PrivateKeyPath
 )
@@ -14,7 +13,7 @@ New-Venv venv
 .\venv\Scripts\activate
 trap { Stop-Venv; break }
 uv pip install -r $AWS_ENVIRONMENT_DIR\requirements.txt
-$python_args = @("windows", $Version, $DatasetVersion, $SgwVersion)
+$python_args = @("windows", $Version, $SgwVersion)
 if ($null -ne $PrivateKeyPath) {
     $python_args += "--private_key"
     $python_args += $PrivateKeyPath

--- a/jenkins/pipelines/dev_e2e/c/run_test.sh
+++ b/jenkins/pipelines/dev_e2e/c/run_test.sh
@@ -7,27 +7,25 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 source $SCRIPT_DIR/../../shared/config.sh
 
 function usage() {
-    echo "Usage: $0 <version> <dataset_version> <platform> <sgw_version> [private_key_path]"
+    echo "Usage: $0 <version> <platform> <sgw_version> [private_key_path]"
     echo "version: CBL version (e.g. 3.2.1-2)"
-    echo "dataset_version: Version of the Couchbase Lite datasets to use"
     echo "platform: The C platform to build (e.g. ios)"
     echo "sgw_version: Version of Sync Gateway to download and use"
     echo "private_key_path: Path to the private key to use for SSH connections"
 }
 
-if [ $# -lt 4 ]; then
+if [ $# -lt 3 ]; then
     usage
     exit 1
 fi
 
-if [ $# -gt 4 ]; then
-    private_key_path=$5
+if [ $# -gt 3 ]; then
+    private_key_path=$4
 fi
 
 cbl_version=$1
-dataset_version=$2
-platform=$3
-sgw_version=$4
+platform=$2
+sgw_version=$3
 
 stop_venv
 create_venv venv
@@ -35,9 +33,9 @@ source venv/bin/activate
 trap stop_venv EXIT
 uv pip install -r $AWS_ENVIRONMENT_DIR/requirements.txt
 if [ -n "$private_key_path" ]; then
-    python3 $SCRIPT_DIR/setup_test.py $platform $cbl_version $dataset_version $sgw_version --private_key $private_key_path
+    python3 $SCRIPT_DIR/setup_test.py $platform $cbl_version $sgw_version --private_key $private_key_path
 else
-    python3 $SCRIPT_DIR/setup_test.py $platform $cbl_version $dataset_version $sgw_version
+    python3 $SCRIPT_DIR/setup_test.py $platform $cbl_version $sgw_version
 fi
 
 pushd $DEV_E2E_TESTS_DIR

--- a/jenkins/pipelines/dev_e2e/c/setup_test.py
+++ b/jenkins/pipelines/dev_e2e/c/setup_test.py
@@ -20,7 +20,6 @@ from jenkins.pipelines.shared.setup_test import setup_test
 @click.command()
 @click.argument("platform")
 @click.argument("cbl_version")
-@click.argument("dataset_version")
 @click.argument("sgw_version")
 @click.option(
     "--private_key",
@@ -30,13 +29,11 @@ from jenkins.pipelines.shared.setup_test import setup_test
 def cli_entry(
     platform: str,
     cbl_version: str,
-    dataset_version: str,
     sgw_version: str,
     private_key: str | None,
 ) -> None:
     setup_test(
         cbl_version,
-        dataset_version,
         sgw_version,
         SCRIPT_DIR / "topologies" / f"topology_single_{platform}.json",
         SCRIPT_DIR / "config.c.json",

--- a/jenkins/pipelines/dev_e2e/c/topologies/topology_single_android.json
+++ b/jenkins/pipelines/dev_e2e/c/topologies/topology_single_android.json
@@ -4,7 +4,6 @@
         {
             "platform": "c_android",
             "cbl_version": "{{version}}",
-            "dataset_version": "{{dataset_version}}",
             "location": "1BCACS00001MX3",
             "download": true
         }

--- a/jenkins/pipelines/dev_e2e/c/topologies/topology_single_ios.json
+++ b/jenkins/pipelines/dev_e2e/c/topologies/topology_single_ios.json
@@ -4,7 +4,6 @@
         {
             "platform": "c_ios",
             "cbl_version": "{{version}}",
-            "dataset_version": "{{dataset_version}}",
             "location": "00008110-000A48A63E10401E",
             "download": true
         }

--- a/jenkins/pipelines/dev_e2e/c/topologies/topology_single_linux_x86_64.json
+++ b/jenkins/pipelines/dev_e2e/c/topologies/topology_single_linux_x86_64.json
@@ -4,7 +4,6 @@
         {
             "platform": "c_linux_x86_64",
             "cbl_version": "{{version}}",
-            "dataset_version": "{{dataset_version}}",
             "location": "localhost",
             "download": true
         }

--- a/jenkins/pipelines/dev_e2e/c/topologies/topology_single_macos.json
+++ b/jenkins/pipelines/dev_e2e/c/topologies/topology_single_macos.json
@@ -4,7 +4,6 @@
         {
             "platform": "c_macos",
             "cbl_version": "{{version}}",
-            "dataset_version": "{{dataset_version}}",
             "location": "localhost",
             "download": true
         }

--- a/jenkins/pipelines/dev_e2e/c/topologies/topology_single_windows.json
+++ b/jenkins/pipelines/dev_e2e/c/topologies/topology_single_windows.json
@@ -4,7 +4,6 @@
         {
             "platform": "c_windows",
             "cbl_version": "{{version}}",
-            "dataset_version": "{{dataset_version}}",
             "location": "localhost",
             "download": true
         }

--- a/jenkins/pipelines/dev_e2e/dotnet/Jenkinsfile
+++ b/jenkins/pipelines/dev_e2e/dotnet/Jenkinsfile
@@ -4,7 +4,6 @@ pipeline {
         choice(name: 'CBL_EDITION', choices: ['enterprise', 'community'], description: 'Couchbase Lite Edition')
         string(name: 'CBL_VERSION', defaultValue: '3.2.0', description: 'Couchbase Lite Version')
         string(name: 'CBL_BUILD', defaultValue: '', description: 'Couchbase Lite Build Number')
-        string(name: 'CBL_DATASET_VERSION', defaultValue: '3.2', description: 'The version of the Couchbase Lite datasets to use')
         string(name: 'SGW_VERSION', defaultValue: '', description: "The version of Sync Gateway to download")
     }
     options {
@@ -17,7 +16,6 @@ pipeline {
                 script {
                     if (params.CBL_VERSION == '') { error "CBL_VERSION is required" }
                     if (params.CBL_BUILD == '') { error "CBL_BUILD is required" }
-                    if (params.CBL_DATASET_VERSION == '') { error "CBL_DATASET_VERSION is required" }
                     if (params.SGW_VERSION == '') { error "SGW_VERSION is required" }
                     currentBuild.displayName = "${params.CBL_VERSION}-${params.CBL_BUILD}"
                     currentBuild.description = "SGW: ${params.SGW_VERSION}"
@@ -62,7 +60,7 @@ pipeline {
                     }
                     steps {
                         timeout(time: 60, unit: 'MINUTES') {
-                            pwsh "jenkins\\pipelines\\dev_e2e\\dotnet\\run_test.ps1 -Version ${params.CBL_VERSION}-${params.CBL_BUILD} -Dataset ${params.CBL_DATASET_VERSION} -SgwVersion ${params.SGW_VERSION} -PrivateKeyPath C:\\Users\\mob-e\\.ssh\\jborden.pem"
+                            pwsh "jenkins\\pipelines\\dev_e2e\\dotnet\\run_test.ps1 -Version ${params.CBL_VERSION}-${params.CBL_BUILD} -SgwVersion ${params.SGW_VERSION} -PrivateKeyPath C:\\Users\\mob-e\\.ssh\\jborden.pem"
                         }
                     }
                     post { 
@@ -88,7 +86,7 @@ pipeline {
                     steps {
                         sh 'security unlock-keychain -p ${KEYCHAIN_PASSWORD} ~/Library/Keychains/login.keychain-db'
                         timeout(time: 60, unit: 'MINUTES') {
-                            sh "jenkins/pipelines/dev_e2e/dotnet/run_test.sh ${params.CBL_VERSION}-${params.CBL_BUILD} ${params.CBL_DATASET_VERSION} macos '${params.SGW_VERSION}' ~/.ssh/jborden.pem"
+                            sh "jenkins/pipelines/dev_e2e/dotnet/run_test.sh ${params.CBL_VERSION}-${params.CBL_BUILD} macos '${params.SGW_VERSION}' ~/.ssh/jborden.pem"
                         }
                     }
                     post { 
@@ -114,7 +112,7 @@ pipeline {
                     steps {
                         sh 'security unlock-keychain -p ${KEYCHAIN_PASSWORD} ~/Library/Keychains/login.keychain-db'
                         timeout(time: 60, unit: 'MINUTES') {
-                            sh "jenkins/pipelines/dev_e2e/dotnet/run_test.sh ${params.CBL_VERSION}-${params.CBL_BUILD} ${params.CBL_DATASET_VERSION} ios '${params.SGW_VERSION}' ~/.ssh/jborden.pem"
+                            sh "jenkins/pipelines/dev_e2e/dotnet/run_test.sh ${params.CBL_VERSION}-${params.CBL_BUILD} ios '${params.SGW_VERSION}' ~/.ssh/jborden.pem"
                         }
                     }
                     post {
@@ -136,7 +134,7 @@ pipeline {
                     }
                     steps {
                         timeout(time: 60, unit: 'MINUTES') {
-                            sh "jenkins/pipelines/dev_e2e/dotnet/run_test.sh ${params.CBL_VERSION}-${params.CBL_BUILD} ${params.CBL_DATASET_VERSION} android '${params.SGW_VERSION}' ~/.ssh/jborden.pem"
+                            sh "jenkins/pipelines/dev_e2e/dotnet/run_test.sh ${params.CBL_VERSION}-${params.CBL_BUILD} android '${params.SGW_VERSION}' ~/.ssh/jborden.pem"
                         }
                     }
                     post {

--- a/jenkins/pipelines/dev_e2e/dotnet/run_test.ps1
+++ b/jenkins/pipelines/dev_e2e/dotnet/run_test.ps1
@@ -1,6 +1,5 @@
 param (
     [Parameter(Mandatory=$true)][string]$Version,
-    [Parameter(Mandatory=$true)][string]$DatasetVersion,
     [Parameter(Mandatory=$true)][string]$SgwVersion,
     [Parameter()][string]$PrivateKeyPath
 )
@@ -16,7 +15,7 @@ New-Venv venv
 . venv\Scripts\activate.ps1
 trap { Stop-Venv; break }
 uv pip install -r $AWS_ENVIRONMENT_DIR\requirements.txt
-$python_args = @("windows", $Version, $DatasetVersion, $SgwVersion)
+$python_args = @("windows", $Version, $SgwVersion)
 if ($null -ne $PrivateKeyPath) {
     $python_args += "--private_key"
     $python_args += $PrivateKeyPath

--- a/jenkins/pipelines/dev_e2e/dotnet/run_test.sh
+++ b/jenkins/pipelines/dev_e2e/dotnet/run_test.sh
@@ -7,9 +7,8 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 source $SCRIPT_DIR/../../shared/config.sh
 
 function usage() {
-    echo "Usage: $0 <version> <dataset_version> <platform> <sgw_version> [private_key_path]"
+    echo "Usage: $0 <version> <platform> <sgw_version> [private_key_path]"
     echo "version: CBL version (e.g. 3.2.1-2)"
-    echo "dataset_version: Version of the Couchbase Lite datasets to use"
     echo "platform: The .NET platform to build (e.g. ios)"
     echo "sgw_version: Version of Sync Gateway to download and use"
     echo "private_key_path: Path to the private key to use for SSH connections"
@@ -24,19 +23,18 @@ function prepare_dotnet() {
     fi
 }
 
-if [ $# -lt 4 ]; then
+if [ $# -lt 3 ]; then
     usage
     exit 1
 fi
 
-if [ $# -gt 4 ]; then
-    private_key_path=$5
+if [ $# -gt 3 ]; then
+    private_key_path=$4
 fi
 
 cbl_version=$1
-dataset_version=$2
-platform=$3
-sgw_version=$4
+platform=$2
+sgw_version=$3
 
 prepare_dotnet
 
@@ -46,9 +44,9 @@ source venv/bin/activate
 trap stop_venv EXIT
 uv pip install -r $AWS_ENVIRONMENT_DIR/requirements.txt
 if [ -n "$private_key_path" ]; then
-    python3 $SCRIPT_DIR/setup_test.py $platform $cbl_version $dataset_version $sgw_version --private_key $private_key_path
+    python3 $SCRIPT_DIR/setup_test.py $platform $cbl_version $sgw_version --private_key $private_key_path
 else
-    python3 $SCRIPT_DIR/setup_test.py $platform $cbl_version $dataset_version $sgw_version
+    python3 $SCRIPT_DIR/setup_test.py $platform $cbl_version $sgw_version
 fi
 
 pushd $DEV_E2E_TESTS_DIR

--- a/jenkins/pipelines/dev_e2e/dotnet/setup_test.py
+++ b/jenkins/pipelines/dev_e2e/dotnet/setup_test.py
@@ -20,7 +20,6 @@ from jenkins.pipelines.shared.setup_test import setup_test
 @click.command()
 @click.argument("platform")
 @click.argument("cbl_version")
-@click.argument("dataset_version")
 @click.argument("sgw_version")
 @click.option(
     "--cbs_version",
@@ -34,14 +33,12 @@ from jenkins.pipelines.shared.setup_test import setup_test
 def cli_entry(
     platform: str,
     cbl_version: str,
-    dataset_version: str,
     sgw_version: str,
     private_key: str | None,
     cbs_version: str,
 ) -> None:
     setup_test(
         cbl_version,
-        dataset_version,
         sgw_version,
         SCRIPT_DIR / "topologies" / f"topology_single_{platform}.json",
         SCRIPT_DIR / "config_aws.json",

--- a/jenkins/pipelines/dev_e2e/dotnet/topologies/topology_single_android.json
+++ b/jenkins/pipelines/dev_e2e/dotnet/topologies/topology_single_android.json
@@ -4,7 +4,6 @@
         {
             "platform": "dotnet_android",
             "cbl_version": "{{version}}",
-            "dataset_version": "{{dataset_version}}",
             "location": "1BCACS00001MX3",
             "download": true
         }

--- a/jenkins/pipelines/dev_e2e/dotnet/topologies/topology_single_ios.json
+++ b/jenkins/pipelines/dev_e2e/dotnet/topologies/topology_single_ios.json
@@ -4,7 +4,6 @@
         {
             "platform": "dotnet_ios",
             "cbl_version": "{{version}}",
-            "dataset_version": "{{dataset_version}}",
             "location": "00008110-000A48A63E10401E",
             "download": true
         }

--- a/jenkins/pipelines/dev_e2e/dotnet/topologies/topology_single_macos.json
+++ b/jenkins/pipelines/dev_e2e/dotnet/topologies/topology_single_macos.json
@@ -4,7 +4,6 @@
         {
             "platform": "dotnet_macos",
             "cbl_version": "{{version}}",
-            "dataset_version": "{{dataset_version}}",
             "location": "localhost",
             "download": true
         }

--- a/jenkins/pipelines/dev_e2e/dotnet/topologies/topology_single_windows.json
+++ b/jenkins/pipelines/dev_e2e/dotnet/topologies/topology_single_windows.json
@@ -4,7 +4,6 @@
         {
             "platform": "dotnet_windows",
             "cbl_version": "{{version}}",
-            "dataset_version": "{{dataset_version}}",
             "location": "localhost",
             "download": true
         }

--- a/jenkins/pipelines/dev_e2e/ios/Jenkinsfile
+++ b/jenkins/pipelines/dev_e2e/ios/Jenkinsfile
@@ -4,7 +4,6 @@ pipeline {
         choice(name: 'CBL_EDITION', choices: ['enterprise', 'community'], description: 'Couchbase Lite Edition')
         string(name: 'CBL_VERSION', defaultValue: '4.0.0', description: 'Couchbase Lite Version')
         string(name: 'CBL_BUILD', defaultValue: '', description: 'Couchbase Lite Build Number')
-        string(name: 'CBL_DATASET_VERSION', defaultValue: '4.0', description: "The dataset version to use (e.g. 3.2 or 4.0)")
         string(name: 'SGW_VERSION', defaultValue: '', description: "The version of Sync Gateway to download")
     }
     stages {
@@ -15,7 +14,7 @@ pipeline {
                     if (params.CBL_BUILD == '') { error "CBL_BUILD is required" }
                     if (params.SGW_VERSION == '') { error "SGW_VERSION is required" }
                     currentBuild.displayName = "${params.CBL_VERSION}-${params.CBL_BUILD}-${CBL_EDITION} (#${currentBuild.number})"
-                    currentBuild.description = "Dataset: ${params.CBL_DATASET_VERSION}"
+                    currentBuild.description = "SGW: ${params.SGW_VERSION}"
                 }
             }
         }
@@ -46,7 +45,7 @@ pipeline {
                 sh 'security unlock-keychain -p ${KEYCHAIN_PASSWORD} ~/Library/Keychains/login.keychain-db'
                 echo "Run iOS Test"
                 timeout(time: 60, unit: 'MINUTES') {
-                    sh "jenkins/pipelines/dev_e2e/ios/test.sh '${params.CBL_EDITION}' '${params.CBL_VERSION}' '${params.CBL_BUILD}' '${params.CBL_DATASET_VERSION}' '${params.SGW_VERSION}' ~/.ssh/jborden.pem"
+                    sh "jenkins/pipelines/dev_e2e/ios/test.sh '${params.CBL_EDITION}' '${params.CBL_VERSION}' '${params.CBL_BUILD}' '${params.SGW_VERSION}' ~/.ssh/jborden.pem"
                 }
             }
             post { 

--- a/jenkins/pipelines/dev_e2e/ios/setup_test.py
+++ b/jenkins/pipelines/dev_e2e/ios/setup_test.py
@@ -20,7 +20,6 @@ from jenkins.pipelines.shared.setup_test import setup_test
 
 @click.command()
 @click.argument("cbl_version")
-@click.argument("dataset_version")
 @click.argument("sgw_version")
 @click.option(
     "--private_key",
@@ -28,13 +27,11 @@ from jenkins.pipelines.shared.setup_test import setup_test
 )
 def cli_entry(
     cbl_version: str,
-    dataset_version: str,
     sgw_version: str,
     private_key: str | None,
 ) -> None:
     setup_test(
         cbl_version,
-        dataset_version,
         sgw_version,
         SCRIPT_DIR / "topology_single_device.json",
         SCRIPT_DIR / "config.json",

--- a/jenkins/pipelines/dev_e2e/ios/test.sh
+++ b/jenkins/pipelines/dev_e2e/ios/test.sh
@@ -6,9 +6,8 @@ set -euo pipefail
 EDITION=${1}
 CBL_VERSION=${2}
 CBL_BLD_NUM=${3}
-CBL_DATASET_VERSION=${4}
-SGW_VERSION=${5}
-private_key_path=${6}
+SGW_VERSION=${4}
+private_key_path=${5}
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 source $SCRIPT_DIR/../../shared/config.sh
@@ -21,9 +20,9 @@ source venv/bin/activate
 trap stop_venv EXIT
 uv pip install -r $AWS_ENVIRONMENT_DIR/requirements.txt
 if [ -n "$private_key_path" ]; then
-    python3 $SCRIPT_DIR/setup_test.py $CBL_VERSION-$CBL_BLD_NUM $CBL_DATASET_VERSION $SGW_VERSION --private_key $private_key_path
+    python3 $SCRIPT_DIR/setup_test.py $CBL_VERSION-$CBL_BLD_NUM $SGW_VERSION --private_key $private_key_path
 else
-    python3 $SCRIPT_DIR/setup_test.py $CBL_VERSION-$CBL_BLD_NUM $CBL_DATASET_VERSION $SGW_VERSION
+    python3 $SCRIPT_DIR/setup_test.py $CBL_VERSION-$CBL_BLD_NUM $SGW_VERSION
 fi
 
 # Run Tests :

--- a/jenkins/pipelines/dev_e2e/ios/topology_single_device.json
+++ b/jenkins/pipelines/dev_e2e/ios/topology_single_device.json
@@ -4,7 +4,6 @@
         {
             "platform": "swift_ios",
             "cbl_version": "{{version}}",
-            "dataset_version": "{{dataset_version}}",
             "location": "00008110-000A48A63E10401E",
             "download": true
         }

--- a/jenkins/pipelines/dev_e2e/java/Jenkinsfile
+++ b/jenkins/pipelines/dev_e2e/java/Jenkinsfile
@@ -5,7 +5,6 @@ pipeline {
         choice(name: 'CBL_EDITION', choices: ['enterprise', 'community'], description: 'Couchbase Lite Edition')
         string(name: 'CBL_VERSION', defaultValue: '', description: 'Couchbase Lite Version')
         string(name: 'CBL_BUILD', defaultValue: '', description: 'Couchbase Lite Build Number')
-        string(name: 'CBL_DATASET_VERSION', defaultValue: '', description: "The dataset version to use")
         string(name: 'SGW_VERSION', defaultValue: '', description: "The version of Sync Gateway to download")
     }
     stages {
@@ -14,9 +13,8 @@ pipeline {
                 script {
                     if (params.CBL_VERSION == '') { error "CBL_VERSION is required" }
                     if (params.CBL_BUILD == '') { error "CBL_BUILD is required" }
-                    if (params.CBL_DATASET_VERSION == '') { error "CBL_DATASET_VERSION is required" }
                     if (params.SGW_VERSION == '') { error "SGW_VERSION is required" }
-                    currentBuild.displayName = "java-${CBL_EDITION} ${params.CBL_VERSION}-${params.CBL_BUILD}/${params.CBL_DATASET_VERSION} (#${currentBuild.number})"
+                    currentBuild.displayName = "java-${CBL_EDITION} ${params.CBL_VERSION}-${params.CBL_BUILD} (#${currentBuild.number})"
                 }
             }
         }
@@ -66,7 +64,7 @@ pipeline {
                         echo "=== Run OSX Desktop Tests"
                         timeout(time: 120, unit: 'MINUTES') {
                             sh """
-                                jenkins/pipelines/dev_e2e/java/desktop/run_test.sh ${params.CBL_VERSION}-${params.CBL_BUILD} ${params.CBL_DATASET_VERSION} ${params.SGW_VERSION} ~/.ssh/jborden.pem
+                                jenkins/pipelines/dev_e2e/java/desktop/run_test.sh ${params.CBL_VERSION}-${params.CBL_BUILD} ${params.SGW_VERSION} ~/.ssh/jborden.pem
                             """
                         }
                         echo "=== OSX Desktop Tests Complete"
@@ -97,7 +95,7 @@ pipeline {
                         echo "=== Run Windows Desktop Tests"
                         timeout(time: 120, unit: 'MINUTES') {
                             pwsh """
-                                jenkins\\pipelines\\dev_e2e\\java\\desktop\\run_test.ps1 -Version ${params.CBL_VERSION}-${params.CBL_BUILD} -DatasetVersion ${params.CBL_DATASET_VERSION} -SgwVersion ${params.SGW_VERSION} -PrivateKeyPath C:\\Users\\mob-e\\.ssh\\jborden.pem
+                                jenkins\\pipelines\\dev_e2e\\java\\desktop\\run_test.ps1 -Version ${params.CBL_VERSION}-${params.CBL_BUILD} -SgwVersion ${params.SGW_VERSION} -PrivateKeyPath C:\\Users\\mob-e\\.ssh\\jborden.pem
                             """
                         }
                         echo "=== Windows Desktop Tests Complete"
@@ -126,7 +124,7 @@ pipeline {
                         echo "=== Run Linux Desktop Tests"
                         timeout(time: 120, unit: 'MINUTES') {
                             sh """
-                                jenkins/pipelines/dev_e2e/java/desktop/run_test.sh ${params.CBL_VERSION}-${params.CBL_BUILD} ${params.CBL_DATASET_VERSION} ${params.SGW_VERSION} ~/.ssh/jborden.pem
+                                jenkins/pipelines/dev_e2e/java/desktop/run_test.sh ${params.CBL_VERSION}-${params.CBL_BUILD} ${params.SGW_VERSION} ~/.ssh/jborden.pem
                             """
                         }
                         echo "=== Linux Desktop Tests Complete"
@@ -157,7 +155,7 @@ pipeline {
                         echo "=== Run OSX Web Service Tests"
                         timeout(time: 120, unit: 'MINUTES') {
                             sh """
-                                jenkins/pipelines/dev_e2e/java/webservice/run_test.sh ${params.CBL_VERSION}-${params.CBL_BUILD} ${params.CBL_DATASET_VERSION} ${params.SGW_VERSION} ~/.ssh/jborden.pem
+                                jenkins/pipelines/dev_e2e/java/webservice/run_test.sh ${params.CBL_VERSION}-${params.CBL_BUILD} ${params.SGW_VERSION} ~/.ssh/jborden.pem
                             """
                         }
                         echo "=== OSX Web Service Tests Complete"
@@ -188,7 +186,7 @@ pipeline {
                         echo "=== Run Windows Web Service Tests"
                         timeout(time: 120, unit: 'MINUTES') {
                             pwsh """
-                                jenkins\\pipelines\\dev_e2e\\java\\webservice\\run_test.ps1 -Version ${params.CBL_VERSION}-${params.CBL_BUILD} -DatasetVersion ${params.CBL_DATASET_VERSION} -SgwVersion ${params.SGW_VERSION} -PrivateKeyPath C:\\Users\\mob-e\\.ssh\\jborden.pem
+                                jenkins\\pipelines\\dev_e2e\\java\\webservice\\run_test.ps1 -Version ${params.CBL_VERSION}-${params.CBL_BUILD} -SgwVersion ${params.SGW_VERSION} -PrivateKeyPath C:\\Users\\mob-e\\.ssh\\jborden.pem
                             """
                         }
                         echo "=== Windows Web Service Tests Complete"
@@ -219,7 +217,7 @@ pipeline {
                         echo "=== Run Linux Web Service Tests"
                         timeout(time: 120, unit: 'MINUTES') {
                             sh """
-                                jenkins/pipelines/dev_e2e/java/webservice/run_test.sh ${params.CBL_VERSION}-${params.CBL_BUILD} ${params.CBL_DATASET_VERSION} ${params.SGW_VERSION} ~/.ssh/jborden.pem
+                                jenkins/pipelines/dev_e2e/java/webservice/run_test.sh ${params.CBL_VERSION}-${params.CBL_BUILD} ${params.SGW_VERSION} ~/.ssh/jborden.pem
                             """
                         }
                         echo "=== Linux Web Service Tests Complete"

--- a/jenkins/pipelines/dev_e2e/java/desktop/run_test.ps1
+++ b/jenkins/pipelines/dev_e2e/java/desktop/run_test.ps1
@@ -1,6 +1,5 @@
 param (
     [Parameter(Mandatory=$true)][string]$Version,
-    [Parameter(Mandatory=$true)][string]$DatasetVersion,
     [Parameter(Mandatory=$true)][string]$SgwVersion,
     [Parameter()][string]$PrivateKeyPath
 )
@@ -12,7 +11,7 @@ New-Venv venv
 .\venv\Scripts\activate
 trap { Stop-Venv; break }
 uv pip install -r $AWS_ENVIRONMENT_DIR\requirements.txt
-$python_args = @($Version, $DatasetVersion, $SgwVersion)
+$python_args = @($Version, $SgwVersion)
 if ($null -ne $PrivateKeyPath) {
     $python_args += "--private_key"
     $python_args += $PrivateKeyPath

--- a/jenkins/pipelines/dev_e2e/java/desktop/run_test.sh
+++ b/jenkins/pipelines/dev_e2e/java/desktop/run_test.sh
@@ -7,25 +7,23 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 source $SCRIPT_DIR/../../../shared/config.sh
 
 function usage() {
-    echo "Usage: $0 <version> <dataset_version> <platform> <sgw_version> [private_key_path]"
+    echo "Usage: $0 <version> <sgw_version> [private_key_path]"
     echo "version: CBL version (e.g. 3.2.1-2)"
-    echo "dataset_version: Version of the Couchbase Lite datasets to use"
     echo "sgw_version: Version of Sync Gateway to download and use"
     echo "private_key_path: Path to the private key to use for SSH connections"
 }
 
-if [ $# -lt 3 ]; then
+if [ $# -lt 2 ]; then
     usage
     exit 1
 fi
 
-if [ $# -gt 3 ]; then
-    private_key_path=$4
+if [ $# -gt 2 ]; then
+    private_key_path=$3
 fi
 
 cbl_version=$1
-dataset_version=$2
-sgw_version=$3
+sgw_version=$2
 
 stop_venv
 create_venv venv
@@ -33,9 +31,9 @@ source venv/bin/activate
 trap stop_venv EXIT
 uv pip install -r $AWS_ENVIRONMENT_DIR/requirements.txt
 if [ -n "$private_key_path" ]; then
-    python3 $SCRIPT_DIR/setup_test.py $cbl_version $dataset_version $sgw_version --private_key $private_key_path
+    python3 $SCRIPT_DIR/setup_test.py $cbl_version $sgw_version --private_key $private_key_path
 else
-    python3 $SCRIPT_DIR/setup_test.py $cbl_version $dataset_version $sgw_version
+    python3 $SCRIPT_DIR/setup_test.py $cbl_version $sgw_version
 fi
 
 pushd $DEV_E2E_TESTS_DIR

--- a/jenkins/pipelines/dev_e2e/java/desktop/setup_test.py
+++ b/jenkins/pipelines/dev_e2e/java/desktop/setup_test.py
@@ -19,7 +19,6 @@ from jenkins.pipelines.shared.setup_test import setup_test
 
 @click.command()
 @click.argument("cbl_version")
-@click.argument("dataset_version")
 @click.argument("sgw_version")
 @click.option(
     "--private_key",
@@ -27,13 +26,11 @@ from jenkins.pipelines.shared.setup_test import setup_test
 )
 def cli_entry(
     cbl_version: str,
-    dataset_version: str,
     sgw_version: str,
     private_key: str | None,
 ) -> None:
     setup_test(
         cbl_version,
-        dataset_version,
         sgw_version,
         SCRIPT_DIR / "topology_single_host.json",
         SCRIPT_DIR / "config_java_desktop.json",

--- a/jenkins/pipelines/dev_e2e/java/desktop/topology_single_host.json
+++ b/jenkins/pipelines/dev_e2e/java/desktop/topology_single_host.json
@@ -4,7 +4,6 @@
         {
             "platform": "jak_desktop",
             "cbl_version": "{{version}}",
-            "dataset_version": "{{dataset_version}}",
             "location": "localhost",
             "download": true
         }

--- a/jenkins/pipelines/dev_e2e/java/webservice/run_test.ps1
+++ b/jenkins/pipelines/dev_e2e/java/webservice/run_test.ps1
@@ -1,6 +1,5 @@
 param (
     [Parameter(Mandatory=$true)][string]$Version,
-    [Parameter(Mandatory=$true)][string]$DatasetVersion,
     [Parameter(Mandatory=$true)][string]$SgwVersion,
     [Parameter()][string]$PrivateKeyPath
 )
@@ -12,7 +11,7 @@ New-Venv venv
 .\venv\Scripts\activate
 trap { Stop-Venv; break }
 uv pip install -r $AWS_ENVIRONMENT_DIR\requirements.txt
-$python_args = @($Version, $DatasetVersion, $SgwVersion)
+$python_args = @($Version, $SgwVersion)
 if ($null -ne $PrivateKeyPath) {
     $python_args += "--private_key"
     $python_args += $PrivateKeyPath

--- a/jenkins/pipelines/dev_e2e/java/webservice/run_test.sh
+++ b/jenkins/pipelines/dev_e2e/java/webservice/run_test.sh
@@ -7,25 +7,23 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 source $SCRIPT_DIR/../../../shared/config.sh
 
 function usage() {
-    echo "Usage: $0 <version> <dataset_version> <sgw_version> [private_key_path]"
+    echo "Usage: $0 <version> <sgw_version> [private_key_path]"
     echo "version: CBL version (e.g. 3.2.1-2)"
-    echo "dataset_version: Version of the Couchbase Lite datasets to use"
     echo "sgw_version: Version of Sync Gateway to download and use"
     echo "private_key_path: Path to the private key to use for SSH connections"
 }
 
-if [ $# -lt 3 ]; then
+if [ $# -lt 2 ]; then
     usage
     exit 1
 fi
 
-if [ $# -gt 3 ]; then
-    private_key_path=$4
+if [ $# -gt 2 ]; then
+    private_key_path=$3
 fi
 
 cbl_version=$1
-dataset_version=$2
-sgw_version=$3
+sgw_version=$2
 
 stop_venv
 create_venv venv
@@ -33,9 +31,9 @@ source venv/bin/activate
 trap stop_venv EXIT
 uv pip install -r $AWS_ENVIRONMENT_DIR/requirements.txt
 if [ -n "$private_key_path" ]; then
-    python3 $SCRIPT_DIR/setup_test.py $cbl_version $dataset_version $sgw_version --private_key $private_key_path
+    python3 $SCRIPT_DIR/setup_test.py $cbl_version $sgw_version --private_key $private_key_path
 else
-    python3 $SCRIPT_DIR/setup_test.py $cbl_version $dataset_version $sgw_version
+    python3 $SCRIPT_DIR/setup_test.py $cbl_version $sgw_version
 fi
 
 pushd $DEV_E2E_TESTS_DIR

--- a/jenkins/pipelines/dev_e2e/java/webservice/setup_test.py
+++ b/jenkins/pipelines/dev_e2e/java/webservice/setup_test.py
@@ -19,7 +19,6 @@ from jenkins.pipelines.shared.setup_test import setup_test
 
 @click.command()
 @click.argument("cbl_version")
-@click.argument("dataset_version")
 @click.argument("sgw_version")
 @click.option(
     "--private_key",
@@ -27,13 +26,11 @@ from jenkins.pipelines.shared.setup_test import setup_test
 )
 def cli_entry(
     cbl_version: str,
-    dataset_version: str,
     sgw_version: str,
     private_key: str | None,
 ) -> None:
     setup_test(
         cbl_version,
-        dataset_version,
         sgw_version,
         SCRIPT_DIR / "topology_single_host.json",
         SCRIPT_DIR / "config_java_webservice.json",

--- a/jenkins/pipelines/dev_e2e/java/webservice/topology_single_host.json
+++ b/jenkins/pipelines/dev_e2e/java/webservice/topology_single_host.json
@@ -4,7 +4,6 @@
         {
             "platform": "jak_webservice",
             "cbl_version": "{{version}}",
-            "dataset_version": "{{dataset_version}}",
             "location": "localhost",
             "download": true
         }

--- a/jenkins/pipelines/dev_e2e/main/Jenkinsfile
+++ b/jenkins/pipelines/dev_e2e/main/Jenkinsfile
@@ -4,7 +4,6 @@ pipeline {
         choice(name: 'CBL_PLATFORM', choices: ['all', 'c', 'android', 'java', 'ios', 'dotnet'], description: 'CBL Platform')
         string(name: 'CBL_VERSION', defaultValue: '4.0.0', description: 'CBL Version')
         string(name: 'CBL_BUILD', defaultValue: '0', description: 'CBL Build Number, Use 0 for the latest successful build')
-        string(name: 'CBL_DATASET_VERSION', defaultValue: '4.0', description: "The dataset version to use (e.g. 3.2 or 4.0)")
         string(name: 'SGW_VERSION', defaultValue: '4.0.0', description: 'The version of Sync Gateway to use')
         booleanParam(name: 'FORCE_TRIGGER', defaultValue: false, description: 'Force Triggering Test Job(s)') 
     }
@@ -45,7 +44,6 @@ pipeline {
                                 def platform = env.CBL_PLATFORM
                                 def version = params.CBL_VERSION
                                 def buildNo = params.CBL_BUILD
-                                def datasetVersion = params.CBL_DATASET_VERSION
                                 def sgwVersion = params.SGW_VERSION
                                 def force = params.FORCE_TRIGGER
                                 def sgwUrl = ""
@@ -98,12 +96,11 @@ pipeline {
                                 // Trigger Test Job:
                                 if (triggerTestJob) {
                                     def jobName = "staging-e2e-test-${platform}"
-                                    echo "Triggering '${jobName}' job for ${platform} v${version}-${buildNo} with dataset ${datasetVersion}"
+                                    echo "Triggering '${jobName}' job for ${platform} v${version}-${buildNo}"
 
                                     build job: jobName, parameters: [
                                         string(name: "CBL_VERSION", value: version),
                                         string(name: "CBL_BUILD", value: buildNo),
-                                        string(name: "CBL_DATASET_VERSION", value: datasetVersion),
                                         string(name: "SGW_URL", value: sgwUrl),
                                         string(name: "SGW_VERSION", value: sgwVersion)
                                     ], wait: false

--- a/jenkins/pipelines/shared/setup_test.py
+++ b/jenkins/pipelines/shared/setup_test.py
@@ -41,7 +41,6 @@ def resolved_version(product: str, version: str) -> str:
 
 def setup_test(
     cbl_version: str,
-    dataset_version: str,
     sgw_version: str,
     topology_file_in: Path,
     config_file_in: Path,
@@ -124,7 +123,6 @@ def setup_test(
         topology["tag"] = topology_tag
         for ts in topology["test_servers"]:
             ts["cbl_version"] = cbl_version
-            ts["dataset_version"] = dataset_version
 
         with open(topology_file_out, "w") as fout:
             json.dump(topology, fout, indent=4)


### PR DESCRIPTION
This is the same thing repeated across 12 different folders.  Removing dataset_version and its variants from the Jenkinsfile, topology, run tests script(s) and setup_test.py.  Reviewers can look at their own implementation and need not worry about others.