### PR TITLE
Add API for starting and stopping XDCR

### DIFF
--- a/client/src/cbltest/api/replicator.py
+++ b/client/src/cbltest/api/replicator.py
@@ -75,6 +75,7 @@ class Replicator:
         enable_document_listener: bool = False,
         enable_auto_purge: bool = True,
         pinned_server_cert: str | None = None,
+        headers: dict[str, str] | None = None,
     ):
         assert database._request_factory.version == 1, (
             "This version of the cbl test API requires request API v1"
@@ -112,6 +113,9 @@ class Replicator:
 
         self.pinned_server_cert: str | None = pinned_server_cert
         """The PEM representation of the certificate that the remote is using"""
+
+        self.headers: dict[str, str] | None = headers
+        """Optional headers to add to the replication requests"""
 
     def add_default_collection(self) -> None:
         """A convenience method for adding the default config for the default collection, if desired"""

--- a/client/src/cbltest/plugins/greenboard_fixture.py
+++ b/client/src/cbltest/plugins/greenboard_fixture.py
@@ -25,6 +25,11 @@ async def greenboard(cblpytest: CBLPyTest, pytestconfig: pytest.Config):
         yield
         return
 
+    if len(cblpytest.test_servers) == 0:
+        cbl_info("No test servers available, skipping greenboard upload")
+        yield
+        return
+
     uploader = GreenboardUploader(
         cblpytest.config.greenboard_url,
         cblpytest.config.greenboard_username,

--- a/client/src/cbltest/version.py
+++ b/client/src/cbltest/version.py
@@ -1,7 +1,7 @@
 from typing import Final
 
 # For hatchling to easily detect the version
-__version__ = "1.2.1"
+__version__ = "1.2.2"
 
 # Typed version for outside use
 VERSION: Final[str] = __version__


### PR DESCRIPTION
Alongside this, implement 1.2.2 of the API spec (headers property) and fix bug in greenboard uploader when no test servers are present.