### PR TITLE
CBL-7548 : Support ReplicatorConfiguration's headers in Test Server

### DIFF
--- a/servers/jak/shared/common/main/java/com/couchbase/lite/mobiletest/endpoints/v1/ReplicatorManager.java
+++ b/servers/jak/shared/common/main/java/com/couchbase/lite/mobiletest/endpoints/v1/ReplicatorManager.java
@@ -42,6 +42,7 @@ import com.couchbase.lite.Collection;
 import com.couchbase.lite.CollectionConfiguration;
 import com.couchbase.lite.Conflict;
 import com.couchbase.lite.ConflictResolver;
+import com.couchbase.lite.CouchbaseLiteException;
 import com.couchbase.lite.Database;
 import com.couchbase.lite.Document;
 import com.couchbase.lite.DocumentReplication;
@@ -82,6 +83,7 @@ public class ReplicatorManager extends BaseReplicatorManager {
     private static final String KEY_ENABLE_DOC_LISTENER = "enableDocumentListener";
     private static final String KEY_SESSION_AUTH_ID = "sessionID";
     private static final String KEY_SESSION_AUTH_COOKIE = "cookieName";
+    private static final String KEY_HEADERS = "headers";
     private static final String KEY_ENABLE_AUTOPURGE = "enableAutoPurge";
     private static final String KEY_PINNED_CERT = "pinnedServerCert";
 
@@ -183,6 +185,7 @@ public class ReplicatorManager extends BaseReplicatorManager {
         l.add(KEY_IS_CONTINUOUS);
         l.add(KEY_AUTHENTICATOR);
         l.add(KEY_ENABLE_DOC_LISTENER);
+        l.add(KEY_HEADERS);
         l.add(KEY_ENABLE_AUTOPURGE);
         l.add(KEY_PINNED_CERT);
         LEGAL_CONFIG_KEYS = Collections.unmodifiableSet(l);
@@ -306,17 +309,22 @@ public class ReplicatorManager extends BaseReplicatorManager {
         if (dbName == null) { throw new ClientError("Replicator configuration doesn't specify a database"); }
 
         final TypedList collections = config.getList(KEY_COLLECTIONS);
-        if (collections == null || collections.isEmpty()) {
+        if (collections == null) {
             throw new ClientError("Replicator configuration doesn't specify a list of collections");
         }
 
         final Database db = dbSvc.getOpenDb(ctxt, dbName);
 
-        final ReplicatorConfiguration replConfig = new ReplicatorConfiguration(
-                addCollections(
-                        db,
-                        collections,
-                        ctxt), endpoint);
+        final ReplicatorConfiguration replConfig;
+        if (collections.isEmpty()) {
+            try {
+                replConfig = new ReplicatorConfiguration(CollectionConfiguration.fromCollections(Set.of(db.getDefaultCollection())), endpoint);
+            } catch (CouchbaseLiteException e) {
+                throw new ClientError("No collection found");
+            }
+        } else {
+            replConfig = new ReplicatorConfiguration(addCollections(db, collections, ctxt), endpoint);
+        }
 
         final String replType = config.getString(KEY_TYPE);
         if (replType != null) {
@@ -343,6 +351,20 @@ public class ReplicatorManager extends BaseReplicatorManager {
 
         final String pinnedCert = config.getString(KEY_PINNED_CERT);
         if (pinnedCert != null) { replConfig.setPinnedServerX509Certificate(str2X509Cert(pinnedCert)); }
+
+        final TypedMap headers = config.getMap(KEY_HEADERS);
+
+        if (headers != null) {
+            android.util.Log.d("Aniket", "Header not null");
+            final Map<String, String> headerMap = new HashMap<>();
+            for (String key : headers.getKeys()) {
+                final String value = headers.getString(key);
+                if (value != null) {
+                    headerMap.put(key, value);
+                }
+            }
+            replConfig.setHeaders(headerMap);
+        }
 
         final TypedMap authenticator = config.getMap(KEY_AUTHENTICATOR);
         if (authenticator != null) {

--- a/servers/jak/shared/common/main/java/com/couchbase/lite/mobiletest/services/Log.java
+++ b/servers/jak/shared/common/main/java/com/couchbase/lite/mobiletest/services/Log.java
@@ -60,7 +60,10 @@ public final class Log {
         @NonNull String tag,
         @NonNull String msg,
         @Nullable Exception err) {
-        LOGGER.get().writeLog(level, tag, msg, err);
+        TestLogger logger = LOGGER.get();
+        if(logger != null) {
+            logger.writeLog(level, tag, msg, err);
+        }
     }
 
     public static void installDefaultLogger() { installLogger(new DefaultLogger(LogLevel.VERBOSE)); }


### PR DESCRIPTION
- Added header field to replicator configuration
- Updated empty collection field to handle with defaultCollection while creating replicator configuration
- LOGGER.get() can give NULL if it is not set, so added null check