### PR TITLE
CBL-7474 : Updated replication creation due to failing testcase test_replicate_public_channel

### DIFF
--- a/servers/jak/shared/common/main/java/com/couchbase/lite/mobiletest/endpoints/v1/Session.java
+++ b/servers/jak/shared/common/main/java/com/couchbase/lite/mobiletest/endpoints/v1/Session.java
@@ -37,7 +37,7 @@ import com.couchbase.lite.mobiletest.util.StringUtils;
 
 @SuppressFBWarnings({"EI_EXPOSE_REP", "EI_EXPOSE_REP2"})
 public class Session {
-    private static final String DEFAULT_DATASET_VERSION = "3.2";
+    private static final String DEFAULT_DATASET_VERSION = "4.0";
 
     private static final String TAG = "RESET";
 

--- a/servers/jak/shared/common/main/java/com/couchbase/lite/mobiletest/services/Log.java
+++ b/servers/jak/shared/common/main/java/com/couchbase/lite/mobiletest/services/Log.java
@@ -60,7 +60,10 @@ public final class Log {
         @NonNull String tag,
         @NonNull String msg,
         @Nullable Exception err) {
-        LOGGER.get().writeLog(level, tag, msg, err);
+        final TestLogger logger = LOGGER.get();
+        if (logger != null) {
+            logger.writeLog(level, tag, msg, err);
+        }
     }
 
     public static void installDefaultLogger() { installLogger(new DefaultLogger(LogLevel.VERBOSE)); }

--- a/servers/jak/shared/common/main/java/com/couchbase/lite/mobiletest/services/RemoteLogger.java
+++ b/servers/jak/shared/common/main/java/com/couchbase/lite/mobiletest/services/RemoteLogger.java
@@ -127,7 +127,6 @@ public class RemoteLogger extends Log.TestLogger {
     public void writeLog(LogLevel level, String tag, String msg, Exception err) {
         final WebSocket socket = webSocket.get();
         if (socket == null) {
-            Log.p(TAG, "RemoteLogger is not connected");
             return;
         }
 


### PR DESCRIPTION
- Updated empty collection field to handle with defaultCollection while creating replicator configuration
- LOGGER.get() can give NULL if it is not set, so added null check