### PR TITLE
Fix Android’s MergeDictResolver

### DIFF
--- a/servers/jak/shared/common/main/java/com/couchbase/lite/mobiletest/endpoints/v1/ReplicatorManager.java
+++ b/servers/jak/shared/common/main/java/com/couchbase/lite/mobiletest/endpoints/v1/ReplicatorManager.java
@@ -206,7 +206,7 @@ public class ReplicatorManager extends BaseReplicatorManager {
 
             final MutableDictionary mergedDict = new MutableDictionary();
             for (String key : localDict) {
-                mergedDict.setValue(docProp, localDict.getValue(key));
+                mergedDict.setValue(key, localDict.getValue(key));
             }
 
             for (String key : remoteDict) {
@@ -215,7 +215,7 @@ public class ReplicatorManager extends BaseReplicatorManager {
                     return doc.setString(key, String.format("Conflicting values found at key named %s", key));
                 }
 
-                mergedDict.setValue(docProp, remoteValue);
+                mergedDict.setValue(key, remoteValue);
             }
 
             return doc.setDictionary(docProp, mergedDict);


### PR DESCRIPTION
The merged dict was set with a wrong key.

Reference : [CBL-7902](https://jira.issues.couchbase.com/browse/CBL-7902)

[CBL-7902]: https://couchbasecloud.atlassian.net/browse/CBL-7902?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ