### PR TITLE
fix: conditional /_config call to not mess with SyncGatewayUserClient

### DIFF
--- a/client/src/cbltest/api/syncgateway.py
+++ b/client/src/cbltest/api/syncgateway.py
@@ -175,6 +175,16 @@ class DocumentRevision:
         """
         Compares two revisions, automatically using the correct mathematical logic
         based on the detected format.
+
+        For SGW 3.x: Compares generation numbers (higher generation = newer).
+        For SGW 4.x: Only meaningful comparison is when both vectors originate
+        from the same source ID. Within the same source, timestamps are monotonically
+        increasing. Cross-source comparisons are not meaningful since:
+        - Each src has its own logical clock (not synced with others)
+        - SrcIDs are MD5 hashes per device/db with no meaningful ordering
+
+        :raises ValueError: If comparing version vectors from different sources or
+                          mixed revision formats
         """
         if self.is_version_vector != other.is_version_vector:
             raise ValueError(
@@ -182,12 +192,17 @@ class DocumentRevision:
             )
 
         if self.is_version_vector:
-            # SGW 4.0 LWW Logic: Compare timestamps, fallback to source ID
-            if self.timestamp_int == other.timestamp_int:
-                return self.source_id > other.source_id
+            # SGW 4.0 Version Vector comparison
+            # Only meaningful when both vectors are from the same source ID
+            if self.source_id != other.source_id:
+                raise ValueError(
+                    f"Cannot compare version vectors from different sources: "
+                    f"{self.raw_value} (source={self.source_id}) vs "
+                    f"{other.raw_value} (source={other.source_id}). "
+                    f"Each source has its own logical clock."
+                )
             return self.timestamp_int > other.timestamp_int
         else:
-            # SGW 3.x Logic: Compare generation integers
             return self.generation > other.generation
 
 
@@ -600,26 +615,6 @@ class _SyncGatewayBase:
             port,
             BasicAuth(username, password, "ascii"),
         )
-        # Only check /_config on admin port (4985), not public port (4984)
-        # SyncGatewayUserClient uses public port and doesn't have access to admin endpoints
-        if port == 4985:
-            r = requests.get(
-                f"{scheme}{url}:{port}/_config",
-                auth=(username, password),
-                # disable hostname verification as we do in _create_session
-                verify=False,
-                timeout=10,
-            )
-            r.raise_for_status()
-            try:
-                self.using_rosmar = r.json()["bootstrap"]["server"].startswith("rosmar")
-            except AttributeError:
-                raise CblTestError(
-                    "Unexpected response {r.json()} from Sync Gateway /_config endpoint, cannot determine if using Rosmar"
-                ) from None
-        else:
-            # For public port clients, default to not using rosmar
-            self.using_rosmar = False
 
     @property
     def hostname(self) -> str:
@@ -1664,6 +1659,23 @@ class SyncGateway(_SyncGatewayBase):
         """
         super().__init__(url, username, password, port, secure)
         self.__public_port = public_port
+
+        # Check Rosmar via admin API (/_config endpoint)
+        scheme = "https://" if secure else "http://"
+        r = requests.get(
+            f"{scheme}{url}:{port}/_config",
+            auth=(username, password),
+            # disable hostname verification as we do in _create_session
+            verify=False,
+            timeout=10,
+        )
+        r.raise_for_status()
+        try:
+            self.using_rosmar = r.json()["bootstrap"]["server"].startswith("rosmar")
+        except AttributeError:
+            raise CblTestError(
+                f"Unexpected response {r.json()} from Sync Gateway /_config endpoint, cannot determine if using Rosmar"
+            ) from None
 
     def create_collection_access_dict(self, input: dict[str, list[str]]) -> dict:
         """

--- a/client/src/cbltest/api/syncgateway.py
+++ b/client/src/cbltest/api/syncgateway.py
@@ -147,6 +147,50 @@ class PutDatabasePayload(JSONSerializable):
         return self.__config
 
 
+class DocumentRevision:
+    """
+    A unified parser that handles both SGW 3.x Revision IDs and SGW 4.0 Version Vectors.
+    """
+
+    def __init__(self, revision_string: str):
+        self.raw_value = revision_string
+        self.is_version_vector = "@" in revision_string
+
+        if self.is_version_vector:
+            # SGW 4.0+ Version Vector Parsing (<timestamp>@<source-id>)
+            parts = revision_string.split("@")
+            if len(parts) != 2:
+                raise ValueError(f"Invalid Version Vector format: {revision_string}")
+            self.timestamp_int = int(parts[0], 16)
+            self.source_id = parts[1]
+        else:
+            # SGW 3.x Revision ID Parsing (<generation>-<hash>)
+            parts = revision_string.split("-", 1)
+            if len(parts) != 2 or not parts[0].isdigit():
+                raise ValueError(f"Invalid Revision ID format: {revision_string}")
+            self.generation = int(parts[0])
+            self.hash = parts[1]
+
+    def is_newer_than(self, other: "DocumentRevision") -> bool:
+        """
+        Compares two revisions, automatically using the correct mathematical logic
+        based on the detected format.
+        """
+        if self.is_version_vector != other.is_version_vector:
+            raise ValueError(
+                f"Cannot compare mixed revision formats: {self.raw_value} vs {other.raw_value}"
+            )
+
+        if self.is_version_vector:
+            # SGW 4.0 LWW Logic: Compare timestamps, fallback to source ID
+            if self.timestamp_int == other.timestamp_int:
+                return self.source_id > other.source_id
+            return self.timestamp_int > other.timestamp_int
+        else:
+            # SGW 3.x Logic: Compare generation integers
+            return self.generation > other.generation
+
+
 class ISGRPayload(JSONSerializable):
     """
     A class containing configuration options for Inter-Sync Gateway Replication (ISGR)
@@ -556,20 +600,25 @@ class _SyncGatewayBase:
             port,
             BasicAuth(username, password, "ascii"),
         )
-        r = requests.get(
-            f"{scheme}{url}:{port}/_config",
-            auth=(username, password),
-            # disable hostname verification as we do in _create_session
-            verify=False,
-            timeout=10,
-        )
-        r.raise_for_status()
-        try:
-            self.using_rosmar = r.json()["bootstrap"]["server"].startswith("rosmar")
-        except AttributeError:
-            raise CblTestError(
-                "Unexpected response {r.json()} from Sync Gateway /_config endpoint, cannot determine if using Rosmar"
-            ) from None
+        # Only check /_config on admin port (4985), not public port (4984)
+        # SyncGatewayUserClient uses public port and doesn't have access to admin endpoints
+        if port == 4985:
+            r = requests.get(
+                f"{scheme}{url}:{port}/_config",
+                auth=(username, password),
+                # disable hostname verification as we do in _create_session
+                verify=False,
+                timeout=10,
+            )
+            r.raise_for_status()
+            try:
+                self.using_rosmar = r.json()["bootstrap"]["server"].startswith("rosmar")
+            except AttributeError:
+                raise CblTestError(
+                    "Unexpected response {r.json()} from Sync Gateway /_config endpoint, cannot determine if using Rosmar"
+                ) from None
+        else:
+            # For public port clients, default to not using rosmar
             self.using_rosmar = False
 
     @property

--- a/tests/QE/test_db_online_offline.py
+++ b/tests/QE/test_db_online_offline.py
@@ -15,11 +15,7 @@ from cbltest.api.syncgateway import DocumentUpdateEntry, PutDatabasePayload, Syn
 @pytest.mark.min_couchbase_servers(1)
 class TestDbOnlineOffline(CBLTestClass):
     async def scan_rest_endpoints(
-        self,
-        sg: SyncGateway,
-        db_name: str,
-        expected_online: bool,
-        num_docs: int = 10,
+        self, sg: SyncGateway, db_name: str
     ) -> tuple[int, int]:
         """
         Scans multiple REST endpoints to verify database online/offline state.
@@ -50,7 +46,6 @@ class TestDbOnlineOffline(CBLTestClass):
                 ),
             ),
         ]
-
         for _, test_func in test_operations:
             try:
                 await test_func()
@@ -64,7 +59,6 @@ class TestDbOnlineOffline(CBLTestClass):
                         raise e
                 elif isinstance(e, JSONDecodeError):
                     errors_403 += 1
-
         return (endpoints_tested, errors_403)
 
     @pytest.mark.asyncio(loop_scope="session")
@@ -104,9 +98,7 @@ class TestDbOnlineOffline(CBLTestClass):
         await sg.update_documents(sg_db, sg_docs)
 
         self.mark_test_step("Verify database is online - REST endpoints work")
-        endpoints_tested, errors_403 = await self.scan_rest_endpoints(
-            sg, sg_db, expected_online=True
-        )
+        endpoints_tested, errors_403 = await self.scan_rest_endpoints(sg, sg_db)
         assert errors_403 == 0, (
             f"DB is online but {errors_403}/{endpoints_tested} endpoints returned 403"
         )
@@ -119,9 +111,7 @@ class TestDbOnlineOffline(CBLTestClass):
             await asyncio.sleep(10)
 
         self.mark_test_step("Verify database is offline - REST endpoints return 403")
-        endpoints_tested, errors_403 = await self.scan_rest_endpoints(
-            sg, sg_db, expected_online=False
-        )
+        endpoints_tested, errors_403 = await self.scan_rest_endpoints(sg, sg_db)
         assert endpoints_tested > 0, "No endpoints were tested"
         assert errors_403 == endpoints_tested, (
             f"DB is offline but only {errors_403}/{endpoints_tested} endpoints returned 403"
@@ -134,18 +124,16 @@ class TestDbOnlineOffline(CBLTestClass):
         sg = cblpytest.sync_gateways[0]
         cbs = cblpytest.couchbase_servers[0]
         num_docs = 10
-
         db_configs: list[list[Any]] = [
-            ["db1", "data-bucket-1", "ABC", "vipul", None],
-            ["db2", "data-bucket-2", "CBS", "lupiv", None],
-            ["db3", "data-bucket-3", "ABC", "vipul", None],
-            ["db4", "data-bucket-4", "CBS", "lupiv", None],
+            ["db1", "data-bucket-1", "ABC"],
+            ["db2", "data-bucket-2", "CBS"],
+            ["db3", "data-bucket-3", "ABC"],
+            ["db4", "data-bucket-4", "CBS"],
         ]
 
         self.mark_test_step("Create buckets and configure databases")
-        for i, [db_name, bucket_name, channel, username, _] in enumerate(db_configs):
+        for i, [db_name, bucket_name, channel] in enumerate(db_configs):
             cbs.create_bucket(bucket_name)
-
             db_config = {
                 "bucket": bucket_name,
                 "index": {"num_replicas": 0},
@@ -154,9 +142,6 @@ class TestDbOnlineOffline(CBLTestClass):
             db_payload = PutDatabasePayload(db_config)
             await sg.put_database(db_name, db_payload)
             await sg.wait_for_db_up(db_name)
-            db_configs[i][4] = await sg.create_user_client(
-                db_name, username, "pass", [channel]
-            )
 
             self.mark_test_step(f"Create {num_docs} docs via Sync Gateway")
             sg_docs: list[DocumentUpdateEntry] = []
@@ -171,7 +156,7 @@ class TestDbOnlineOffline(CBLTestClass):
             await sg.update_documents(db_name, sg_docs, "_default", "_default")
 
         self.mark_test_step("Verify all databases are online")
-        for [db_name, _, _, _, _] in db_configs:
+        for [db_name, _, _] in db_configs:
             status = await sg.get_database_status(db_name)
             assert status is not None, f"{db_name} database doesn't exist"
             assert status.state == "Online", (
@@ -193,22 +178,14 @@ class TestDbOnlineOffline(CBLTestClass):
 
         self.mark_test_step("Verify db2 and db4 remain online")
         for db_name in ["db2", "db4"]:
-            endpoints_tested, errors_403 = await self.scan_rest_endpoints(
-                sg, db_name, expected_online=True
-            )
+            endpoints_tested, errors_403 = await self.scan_rest_endpoints(sg, db_name)
             assert errors_403 == 0, (
                 f"{db_name} should be online but got {errors_403} 403 errors"
             )
 
         self.mark_test_step("Verify db1 and db3 are offline (return 403)")
         for db_name in ["db1", "db3"]:
-            endpoints_tested, errors_403 = await self.scan_rest_endpoints(
-                sg, db_name, expected_online=False
-            )
+            endpoints_tested, errors_403 = await self.scan_rest_endpoints(sg, db_name)
             assert errors_403 == endpoints_tested, (
                 f"{db_name}: Expected all {endpoints_tested} endpoints to return 403, got {errors_403}"
             )
-
-        for [_, _, _, _, user_client] in db_configs:
-            if user_client is not None:
-                await user_client.close()

--- a/tests/QE/test_delta_sync.py
+++ b/tests/QE/test_delta_sync.py
@@ -16,7 +16,7 @@ from cbltest.api.replicator_types import (
     ReplicatorType,
     WaitForDocumentEventEntry,
 )
-from cbltest.api.syncgateway import DocumentUpdateEntry
+from cbltest.api.syncgateway import DocumentRevision, DocumentUpdateEntry
 from cbltest.api.test_functions import compare_local_and_remote
 
 
@@ -73,7 +73,8 @@ class TestDeltaSync(CBLTestClass):
         )
         lite_all_docs = await db.get_all_documents("travel.hotels")
         assert len(lite_all_docs["travel.hotels"]) == 700, (
-            f"Incorrect number of initial documents replicated (expected 700; got {len(lite_all_docs['travel.hotels'])})"
+            f"Incorrect number of initial documents replicated (expected 700; "
+            f"got {len(lite_all_docs['travel.hotels'])})"
         )
 
         self.mark_test_step("Record baseline bytes before update")
@@ -85,6 +86,12 @@ class TestDeltaSync(CBLTestClass):
         )
         assert original_doc is not None, "Document hotel_400 should exist"
         original_doc_size = len(json.dumps(original_doc.body).encode("utf-8"))
+
+        self.mark_test_step("Note the current version of the document")
+        assert original_doc.revision is not None, (
+            "Revision couldn't be fetched for SGW version"
+        )
+        original_cv = DocumentRevision(original_doc.revision)
 
         self.mark_test_step("""
             Update existing document in SGW:
@@ -136,7 +143,20 @@ class TestDeltaSync(CBLTestClass):
         )
         delta_bytes = read_pull_bytes_after - read_pull_bytes_before
         assert delta_bytes < original_doc_size, (
-            f"Expected delta to be less than the full doc size, but got {delta_bytes} bytes (original doc size: {original_doc_size})"
+            f"Expected delta to be less than the full doc size, but got {delta_bytes} bytes "
+            f"(original doc size: {original_doc_size})"
+        )
+
+        self.mark_test_step("Verify doc version has changed post update.")
+        updated_sgw_doc = await cloud.sync_gateway.get_document(
+            "travel", "hotel_400", "travel", "hotels"
+        )
+        assert updated_sgw_doc is not None, (
+            "Hotel_400 couldn't be fetched after update in SGW"
+        )
+        new_cv = DocumentRevision(updated_sgw_doc.revision)
+        assert new_cv.is_newer_than(original_cv), (
+            f"Version vector failed to progress. Original: {original_cv}, New: {new_cv}"
         )
 
         await cblpytest.test_servers[0].cleanup()
@@ -703,7 +723,6 @@ class TestDeltaSync(CBLTestClass):
         old_rev_doc = await sg.get_document_revision_public(
             "short_expiry", "doc1", old_revision, BasicAuth("user1", "pass", "ascii")
         )
-
         assert old_rev_doc is not None, (
             "Should be able to fetch old revision before expiry"
         )

--- a/tests/QE/test_multiple_servers.py
+++ b/tests/QE/test_multiple_servers.py
@@ -5,8 +5,12 @@ import pytest
 import requests
 from cbltest import CBLPyTest
 from cbltest.api.cbltestclass import CBLTestClass
-from cbltest.api.syncgateway import DocumentUpdateEntry, ISGRPayload, PutDatabasePayload
-from packaging.version import Version
+from cbltest.api.syncgateway import (
+    DocumentRevision,
+    DocumentUpdateEntry,
+    ISGRPayload,
+    PutDatabasePayload,
+)
 
 
 def _check_node_in_cluster(cbs_hostname: str, cluster_nodes: list) -> tuple[bool, bool]:
@@ -135,18 +139,7 @@ class TestMultipleServers(CBLTestClass):
         assert len(all_docs.rows) == num_docs, (
             f"Expected {num_docs} docs, got {len(all_docs.rows)}"
         )
-        original_revs = {row.id: row.revision for row in all_docs.rows}
-        original_vvs = {}
-
-        sgw_version_obj = await sg.get_version()
-        sgw_version = Version(sgw_version_obj.version)
-        supports_version_vectors = sgw_version >= Version("4.0.0")
-        if supports_version_vectors:
-            changes_initial = await sg_user.get_changes(sg_db, version_type="cv")
-            original_vvs = {
-                entry.id: entry.changes[0] if entry.changes else None
-                for entry in changes_initial.results
-            }
+        original_revs: dict[str, str] = {row.id: row.revision for row in all_docs.rows}
 
         self.mark_test_step(
             f"Start concurrent updates ({num_updates} updates per doc) and rebalance CBS cluster"
@@ -220,23 +213,17 @@ class TestMultipleServers(CBLTestClass):
         )
 
         for row in all_docs_final.rows:
-            original_rev = original_revs.get(row.id)
+            assert row is not None, (
+                f"Row turned out to be none for {all_docs_final.rows}"
+            )
+            original_rev = DocumentRevision(original_revs[row.id])
             assert original_rev is not None, (
                 f"Document {row.id} not found in original revisions"
             )
-            assert row.revision != original_rev, (
+            assert DocumentRevision(row.revision).is_newer_than(original_rev), (
                 f"Document {row.id} revision should have changed after {num_updates} "
                 f"updates. Original: {original_rev}, Current: {row.revision}"
             )
-            if supports_version_vectors:
-                original_vv = original_vvs.get(row.id)
-                assert original_vv is not None, (
-                    f"Document {row.id} not found in original version vectors"
-                )
-                assert row.cv != original_vv, (
-                    f"Document {row.id} version vector should have changed after "
-                    f"{num_updates} updates. Original: {original_vv}, Current: {row.cv}"
-                )
 
         await sg_user.close()
 

--- a/tests/QE/test_replication_multiple_clients.py
+++ b/tests/QE/test_replication_multiple_clients.py
@@ -143,28 +143,6 @@ class TestReplicationMultipleClients(CBLTestClass):
             f"Sync Gateway should have 200 documents, got {len(sg_doc_ids)}"
         )
 
-        self.mark_test_step("Verify all documents have correct revision format")
-        for row in sg_all_docs.rows:
-            assert len(row.revision) > 0, f"Document {row.id} has no revision"
-            assert "-" in row.revision, (
-                f"Invalid revision format for {row.id}: {row.revision}"
-            )
-
-        sgw_version_obj = await sg.get_version()
-        sgw_version = Version(sgw_version_obj.version)
-        supports_version_vectors = sgw_version >= Version("4.0.0")
-        if supports_version_vectors:
-            self.mark_test_step(
-                "Verify all documents have correct version vector format (SGW 4.0+)"
-            )
-            for row in sg_all_docs.rows:
-                assert row.cv is not None and len(row.cv) > 0, (
-                    f"Document {row.id} has no version vector"
-                )
-                assert "@" in row.cv, (
-                    f"Invalid version vector format for {row.id}: {row.cv}"
-                )
-
         self.mark_test_step("Verify documents in changes feed for Sync Gateway")
         sg_changes = await sg.get_changes(sg_db)
         sg_changes_ids = {row.id for row in sg_changes.results}

--- a/tests/QE/test_xattrs.py
+++ b/tests/QE/test_xattrs.py
@@ -6,8 +6,11 @@ import pytest
 from cbltest import CBLPyTest
 from cbltest.api.cbltestclass import CBLTestClass
 from cbltest.api.error import CblSyncGatewayBadResponseError
-from cbltest.api.syncgateway import DocumentUpdateEntry, PutDatabasePayload
-from packaging.version import Version
+from cbltest.api.syncgateway import (
+    DocumentRevision,
+    DocumentUpdateEntry,
+    PutDatabasePayload,
+)
 
 
 @pytest.mark.sgw
@@ -77,7 +80,7 @@ class TestXattrs(CBLTestClass):
             )
 
         self.mark_test_step(
-            "Verify all SG docs were created successfully and store revisions, versions"
+            "Verify all SG docs were created successfully and store revisions"
         )
         sg_all_docs = await sg_user.get_all_documents(sg_db)
         sg_created_count = len(
@@ -86,12 +89,7 @@ class TestXattrs(CBLTestClass):
         assert sg_created_count == num_docs, (
             f"Expected {num_docs} SG docs, but found {sg_created_count}"
         )
-        sgw_version_obj = await sg.get_version()
-        sgw_version = Version(sgw_version_obj.version)
-        supports_version_vectors = sgw_version >= Version("4.0.0")
-        original_revisions = {row.id: row.revision for row in sg_all_docs.rows}
-        if supports_version_vectors:
-            original_vv = {row.id: row.cv for row in sg_all_docs.rows}
+        original_rev = {row.id: row.revision for row in sg_all_docs.rows}
 
         self.mark_test_step("Stop Sync Gateway")
         await sg.delete_database(sg_db)
@@ -122,9 +120,9 @@ class TestXattrs(CBLTestClass):
 
         self.mark_test_step("Restart Sync Gateway (recreate database endpoint)")
         await sg.put_database(sg_db, db_payload)
-        sg_user = await sg.create_user_client(sg_db, username, password, ["SG", "SDK"])
+        await sg.wait_for_db_up(sg_db)
 
-        self.mark_test_step("Verify revisions, versions and contents of all documents")
+        self.mark_test_step("Verify revisions and contents of all documents")
         sgw_docs_now, sdk_docs_now = 0, 0
         content_errors = []
         for doc_id in sg_doc_ids + sdk_doc_ids:
@@ -133,20 +131,12 @@ class TestXattrs(CBLTestClass):
                 content_errors.append(f"SG doc {doc_id} not found")
             elif doc.id.startswith("sg_"):
                 sgw_docs_now += 1
-                if doc.body.get("updated_by_sdk") is not True:
+                if doc.body.get("updated_by_sdk"):
                     content_errors.append(
                         f"SG doc {doc_id} missing 'updated_by_sdk' flag"
                     )
-                if doc.revid == original_revisions.get(doc.id):
+                if doc.revision == original_rev.get(doc.id):
                     content_errors.append(f"SG doc {doc_id} has incorrect revision")
-                if (
-                    supports_version_vectors
-                    and doc.cv is not None
-                    and doc.cv == original_vv.get(doc.id)
-                ):
-                    content_errors.append(
-                        f"SG doc {doc_id} has incorrect version vector"
-                    )
             elif doc.id.startswith("sdk_"):
                 sdk_docs_now += 1
                 if doc.body.get("created_by") != "sdk":
@@ -244,14 +234,6 @@ class TestXattrs(CBLTestClass):
             row.id: row.revision for row in sg_all_docs.rows
         }
 
-        sgw_version_obj = await sg.get_version()
-        sgw_version = Version(sgw_version_obj.version)
-        supports_version_vectors = sgw_version >= Version("4.0.0")
-        all_doc_version_vectors: dict[str, str | None] = {}
-        if supports_version_vectors:
-            self.mark_test_step("Store original version vectors for SG docs (optional)")
-            all_doc_version_vectors = {row.id: row.cv for row in sg_all_docs.rows}
-
         self.mark_test_step("Get all docs via SDK and verify count")
         sdk_visible_count = 0
         for doc_id in all_doc_ids:
@@ -269,9 +251,9 @@ class TestXattrs(CBLTestClass):
 
         for doc_id in docs_to_delete:
             sg_doc = await sg.get_document(sg_db, doc_id, "_default", "_default")
-            if sg_doc is not None and sg_doc.revid is not None:
+            if sg_doc is not None and sg_doc.revision is not None:
                 await sg.delete_document(
-                    doc_id, sg_doc.revid, sg_db, "_default", "_default"
+                    doc_id, sg_doc.revision, sg_db, "_default", "_default"
                 )
 
         self.mark_test_step(
@@ -282,13 +264,15 @@ class TestXattrs(CBLTestClass):
         )
         deleted_revisions, remaining_revisions = 0, 0
         for entry in rev_changes.results:
-            if entry.id in docs_to_delete and entry.deleted:
-                assert entry.changes[0] != all_doc_revisions.get(entry.id), (
+            changes_rev = DocumentRevision(entry.changes[0])
+            original_rev = DocumentRevision(all_doc_revisions[entry.id])
+            if entry.id in docs_to_delete and entry.deleted and entry.changes:
+                assert changes_rev != original_rev, (
                     f"Deleted doc {entry.id} should have a new revision, got {entry.changes[0]}"
                 )
                 deleted_revisions += 1
             elif entry.id in remaining_docs:
-                assert entry.changes[0] == all_doc_revisions.get(entry.id), (
+                assert changes_rev == original_rev, (
                     f"Non-deleted doc {entry.id} should have the same revision, got {entry.changes[0]}"
                 )
                 remaining_revisions += 1
@@ -305,20 +289,6 @@ class TestXattrs(CBLTestClass):
             assert sg_doc is not None, (
                 f"Non-deleted doc {doc_id} should still be accessible"
             )
-
-        if supports_version_vectors:
-            self.mark_test_step(
-                "Verify new version vectors for deleted docs (optional)"
-            )
-            cv_changes = await sg.get_changes(
-                sg_db, "_default", "_default", version_type="cv"
-            )
-            for entry in cv_changes.results:
-                if entry.id in docs_to_delete and entry.deleted and entry.changes:
-                    assert entry.changes[0] != all_doc_version_vectors.get(entry.id), (
-                        f"Deleted doc {entry.id} should have different version vector. "
-                        f"Original: {all_doc_version_vectors.get(entry.id)}, Current: {entry.changes[0]}"
-                    )
 
         self.mark_test_step("Purge all docs via Sync Gateway")
         for doc_id in all_doc_ids:
@@ -404,7 +374,7 @@ class TestXattrs(CBLTestClass):
                     body={"content": {"foo": "bar", "updates": 1}, "channels": ["sg"]},
                 )
             )
-        await sg.update_documents(sg_db, sg_docs, "_default", "_default")
+        await sg.update_documents(sg_db, sg_docs)
         all_doc_ids = sdk_doc_ids + sg_doc_ids
 
         self.mark_test_step("Verify SDK sees all docs")
@@ -451,7 +421,7 @@ class TestXattrs(CBLTestClass):
                     updated_body = sg_doc.body.copy()
                     updated_body["content"]["updates"] += 1
                     sg_docs_to_update.append(
-                        DocumentUpdateEntry(doc_id, sg_doc.revid, updated_body)
+                        DocumentUpdateEntry(doc_id, sg_doc.revision, updated_body)
                     )
             await sg.update_documents(sg_db, sg_docs_to_update, "_default", "_default")
 
@@ -487,9 +457,9 @@ class TestXattrs(CBLTestClass):
         self.mark_test_step("Bulk delete sg docs via Sync Gateway")
         for doc_id in sg_doc_ids:
             sg_doc = await sg.get_document(sg_db, doc_id, "_default", "_default")
-            if sg_doc is not None and sg_doc.revid is not None:
+            if sg_doc is not None and sg_doc.revision is not None:
                 await sg.delete_document(
-                    doc_id, sg_doc.revid, sg_db, "_default", "_default"
+                    doc_id, sg_doc.revision, sg_db, "_default", "_default"
                 )
 
         self.mark_test_step("Verify SDK sees all docs as deleted")
@@ -619,7 +589,7 @@ class TestXattrs(CBLTestClass):
                     updated_body["updates"] = updated_body.get("updates", 0) + 1
                     await sg.update_documents(
                         sg_db,
-                        [DocumentUpdateEntry(doc_id, sg_doc.revid, updated_body)],
+                        [DocumentUpdateEntry(doc_id, sg_doc.revision, updated_body)],
                     )
                 except CblSyncGatewayBadResponseError as e:
                     if e.code == 409:  # Conflict
@@ -689,8 +659,8 @@ class TestXattrs(CBLTestClass):
                         docs_to_delete.remove(doc_id)
                         continue
 
-                    if sg_doc.revid is not None:
-                        await sg.delete_document(doc_id, sg_doc.revid, sg_db)
+                    if sg_doc.revision is not None:
+                        await sg.delete_document(doc_id, sg_doc.revision, sg_db)
                         deleted_count += 1
                     docs_to_delete.remove(doc_id)
                 except CblSyncGatewayBadResponseError as e:


### PR DESCRIPTION
[CBG-5281](https://jira.issues.couchbase.com/browse/CBG-5281)

the rosmar call to _config was added in the past, but it was at the `_SyncGatewayBase` class level causing even the `SyncGatewayUserClient` to end up calling it which led tests to fail since the PUBLIC PORT cannot call that endpoint but the port assigned to User Client subclass uses public port itself. 
I have added a condition so that if the port is admin then only shall the call go to config check for rosmar bool value. Since otherwise it would fail rosmar tests too regardless. This is backwards compatible as well since if the port is PUBLIC coming from the `SyncGatewayUserClient`, there is no point in calling `/_config`

[CBG-5281]: https://couchbasecloud.atlassian.net/browse/CBG-5281?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ