### PR TITLE
CBG-5213 support dropping rosmar buckets

### DIFF
--- a/client/src/cbltest/api/cloud.py
+++ b/client/src/cbltest/api/cloud.py
@@ -159,10 +159,15 @@ class CouchbaseCloud:
 
             await self.__sync_gateway.load_dataset(dataset_name, data_filepath)
 
-    async def drop_bucket(self, bucket_name: str, *, wait_for_deleted=False):
-        """Drop the bucket from the backing cluster. This is an asynchronous operation unless wait_for_deleted is set to True."""
+    async def drop_bucket(self, bucket_name: str):
+        """Drop the bucket from the backing cluster."""
         if self.sync_gateway.using_rosmar:
-            await self.sync_gateway._send_request("delete", f"/_rosmar/{bucket_name}")
+            try:
+                await self.sync_gateway._send_request(
+                    "delete", f"/_rosmar/{bucket_name}"
+                )
+            except CblSyncGatewayBadResponseError as e:
+                if e.code != 404:
+                    raise
         else:
             self.couchbase_server.drop_bucket(bucket_name)
-            await self.couchbase_server.wait_for_bucket_deleted(bucket_name)

--- a/client/src/cbltest/api/cloud.py
+++ b/client/src/cbltest/api/cloud.py
@@ -129,14 +129,9 @@ class CouchbaseCloud:
 
                 current_span.add_event("Handle HTTP 412")
                 await self.__sync_gateway.delete_database(dataset_name)
-                if self.sync_gateway.using_rosmar:
-                    raise CblTestError(
-                        f"Database {dataset_name} already exists on Sync Gateway and cannot be deleted when "
-                        "using rosmar until CBG-5213 is implemented. To work around, restart a Sync Gateway to "
-                        "delete the rosmar buckets."
-                    )
-                else:
-                    self.__couchbase_server.drop_bucket(db_payload.bucket)
+                await self.drop_bucket(db_payload.bucket)
+                await self.__sync_gateway.wait_for_no_databases(db_payload.bucket)
+                if not self.sync_gateway.using_rosmar:
                     self.__couchbase_server.create_bucket(db_payload.bucket)
                     self._create_collections(db_payload)
 
@@ -163,3 +158,11 @@ class CouchbaseCloud:
                 )
 
             await self.__sync_gateway.load_dataset(dataset_name, data_filepath)
+
+    async def drop_bucket(self, bucket_name: str, *, wait_for_deleted=False):
+        """Drop the bucket from the backing cluster. This is an asynchronous operation unless wait_for_deleted is set to True."""
+        if self.sync_gateway.using_rosmar:
+            await self.sync_gateway._send_request("delete", f"/_rosmar/{bucket_name}")
+        else:
+            self.couchbase_server.drop_bucket(bucket_name)
+            await self.couchbase_server.wait_for_bucket_deleted(bucket_name)

--- a/client/src/cbltest/api/syncgateway.py
+++ b/client/src/cbltest/api/syncgateway.py
@@ -8,6 +8,7 @@ from typing import Any, cast
 from urllib.parse import urljoin
 
 import requests
+import tenacity
 from aiohttp import BasicAuth, ClientError, ClientSession, ClientTimeout, TCPConnector
 from aiohttp.client_exceptions import ClientConnectorError
 from opentelemetry.trace import get_tracer
@@ -17,7 +18,7 @@ from cbltest.api.jsonserializable import JSONDictionary, JSONSerializable
 from cbltest.assertions import _assert_not_null
 from cbltest.httplog import get_next_writer
 from cbltest.jsonhelper import _get_typed_required
-from cbltest.logging import cbl_error, cbl_info, cbl_warning
+from cbltest.logging import cbl_error, cbl_info, cbl_trace, cbl_warning
 from cbltest.utils import assert_not_null
 from cbltest.version import VERSION
 
@@ -659,7 +660,7 @@ class _SyncGatewayBase:
 
     def tls_cert(self) -> str | None:
         if not self.secure:
-            cbl_warning(
+            cbl_trace(
                 "Sync Gateway instance not using TLS, returning empty tls_cert..."
             )
             return None
@@ -1873,6 +1874,22 @@ class SyncGateway(_SyncGatewayBase):
                         raise Exception(f"Failed to start SGW: {resp.status} - {body}")
                     # Wait a bit for SGW to fully initialize
                     await asyncio.sleep(5)
+
+    @tenacity.retry(
+        wait=tenacity.wait_fixed(0.1),
+        # Sync Gateway polling time is 10s, so wait 60s for polling time + any additional work
+        stop=tenacity.stop_after_delay(60),
+        reraise=True,
+        retry=tenacity.retry_if_exception_type(AssertionError),
+    )
+    async def wait_for_no_databases(self, bucket_name: str):
+        with self._tracer.start_as_current_span("get_all_dbs"):
+            resp = await self._send_request("get", "/_all_dbs?verbose=true")
+            assert isinstance(resp, list), resp
+            for db in resp:
+                assert db["bucket"] != bucket_name, (
+                    f"Database {db=} is still backed by bucket {bucket_name}"
+                )
 
     async def wait_for_db_gone_clusterwide(
         self,

--- a/client/src/cbltest/api/syncgateway.py
+++ b/client/src/cbltest/api/syncgateway.py
@@ -1876,8 +1876,9 @@ class SyncGateway(_SyncGatewayBase):
                     await asyncio.sleep(5)
 
     @tenacity.retry(
-        wait=tenacity.wait_fixed(0.1),
-        # Sync Gateway polling time is 10s, so wait 60s for polling time + any additional work
+        wait=tenacity.wait_random_exponential(multiplier=1, max=10),
+        # Sync Gateway polling time is 10s, so use bounded exponential backoff with jitter
+        # and wait up to 60s for polling time + any additional work.
         stop=tenacity.stop_after_delay(60),
         reraise=True,
         retry=tenacity.retry_if_exception_type(AssertionError),

--- a/environment/local/run_sync_gateway.py
+++ b/environment/local/run_sync_gateway.py
@@ -49,6 +49,7 @@ def main(start, stop, server):
     if stop:
         bridge.stop("localhost")
     else:
+        bridge.stop("localhost")
         bridge.run("localhost")
 
 

--- a/environment/local/run_sync_gateway.py
+++ b/environment/local/run_sync_gateway.py
@@ -46,11 +46,10 @@ def main(start, stop, server):
         log_filename="sync_gateway.log",
     )
 
+    bridge.stop("localhost")
     if stop:
-        bridge.stop("localhost")
-    else:
-        bridge.stop("localhost")
-        bridge.run("localhost")
+        return
+    bridge.run("localhost")
 
 
 if __name__ == "__main__":

--- a/environment/local/sync_gateway_config/basic_sync_gateway_rosmar.json
+++ b/environment/local/sync_gateway_config/basic_sync_gateway_rosmar.json
@@ -12,5 +12,8 @@
       "log_level": "debug",
       "log_keys": ["*"]
     }
+  },
+  "unsupported": {
+    "rosmar_bucket_management": true
   }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "paramiko==3.5.0",
     "psutil==7.0.0",
     "pyyaml==6.0.2",
+    "tenacity==9.1.4",
     "tqdm==4.67.1",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -400,6 +400,7 @@ dependencies = [
     { name = "paramiko" },
     { name = "psutil" },
     { name = "pyyaml" },
+    { name = "tenacity" },
     { name = "tqdm" },
 ]
 
@@ -417,6 +418,7 @@ requires-dist = [
     { name = "paramiko", specifier = "==3.5.0" },
     { name = "psutil", specifier = "==7.0.0" },
     { name = "pyyaml", specifier = "==6.0.2" },
+    { name = "tenacity", specifier = "==9.1.4" },
     { name = "tqdm", specifier = "==4.67.1" },
 ]
 
@@ -1187,6 +1189,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1b/fa/2ef715a1cd329ef47c1a050e10dee91a9054b7ce2fcfdd6a06d139afb7ec/ruff-0.15.4-py3-none-win32.whl", hash = "sha256:65594a2d557d4ee9f02834fcdf0a28daa8b3b9f6cb2cb93846025a36db47ef22", size = 10506664, upload-time = "2026-02-26T20:03:50.56Z" },
     { url = "https://files.pythonhosted.org/packages/d0/a8/c688ef7e29983976820d18710f955751d9f4d4eb69df658af3d006e2ba3e/ruff-0.15.4-py3-none-win_amd64.whl", hash = "sha256:04196ad44f0df220c2ece5b0e959c2f37c777375ec744397d21d15b50a75264f", size = 11651048, upload-time = "2026-02-26T20:04:17.191Z" },
     { url = "https://files.pythonhosted.org/packages/3e/0a/9e1be9035b37448ce2e68c978f0591da94389ade5a5abafa4cf99985d1b2/ruff-0.15.4-py3-none-win_arm64.whl", hash = "sha256:60d5177e8cfc70e51b9c5fad936c634872a74209f934c1e79107d11787ad5453", size = 10966776, upload-time = "2026-02-26T20:03:56.908Z" },
+]
+
+[[package]]
+name = "tenacity"
+version = "9.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Create CouchbaseCloud.drop_bucket function since this might be a Sync Gateway operation or a server operation
- Change the behavior when creating the database to make sure all databases that are backed by a given bucket are actually gone. If you had multiple databases on the same bucket using different collections, then dropping all of them is necessary to avoid issues creating a database if the new databases targets different collections than the dropped one.
- Add special rosmar option to sync gateway config support dropping rosmar buckets
- Make sure to stop sync gateway if it was already running

Testing done:

```
uv run environment/local/start_local.py --build-testserver 4.0.3
uv run environment/local/run_sync_gateway.py --server rosmar --start
uv run pytest --config environment/local/rosmar_config.json tests/dev_e2e 
```

And with Couchbase Server:

```
uv run environment/local/run_sync_gateway.py --server cbs --start
uv run pytest --config environment/local/cbs_config.json tests/dev_e2e 
```