### PR TITLE
fix: SGW 4.0.0 shown as 0.0.0 + keep all-fail runs

### DIFF
--- a/client/src/cbltest/greenboarduploader.py
+++ b/client/src/cbltest/greenboarduploader.py
@@ -63,7 +63,7 @@ class GreenboardUploader:
         :param platform: The platform name (e.g. couchbase-lite-net) as specified by the test server
         :param version: The version string (e.g. 3.2.0-b0136, etc) as specified by the test server
         """
-        if self.__overall_fail and not self.__has_sgw_marker:
+        if self.__overall_fail:
             cbl_warning("Overall result is failure, skipping upload...")
             return
 

--- a/client/src/cbltest/greenboarduploader.py
+++ b/client/src/cbltest/greenboarduploader.py
@@ -63,17 +63,26 @@ class GreenboardUploader:
         :param platform: The platform name (e.g. couchbase-lite-net) as specified by the test server
         :param version: The version string (e.g. 3.2.0-b0136, etc) as specified by the test server
         """
-        if self.__overall_fail:
+        if self.__overall_fail and not self.__has_sgw_marker:
             cbl_warning("Overall result is failure, skipping upload...")
             return
 
-        version_components = version.split("-")
-        if len(version_components) != 2:
-            version = "0.0.0"
-            build = 0
-        else:
-            version = version_components[0]
-            build = int(version_components[1].lstrip("b"))
+        version_to_parse = sgw_version if platform == "sync-gateway" else version
+        version_components = version_to_parse.split("-")
+
+        parsed_version = "0.0.0"
+        parsed_build = 0
+
+        if len(version_components) > 0 and version_components[0]:
+            parsed_version = version_components[0]
+
+        if len(version_components) > 1:
+            try:
+                # Handles build numbers like 'b1234' or just '1234'
+                parsed_build = int(version_components[1].lstrip("b"))
+            except ValueError:
+                # If the part after '-' is not a number, build remains 0
+                cbl_warning(f"Could not parse build number from '{version_to_parse}'")
 
         auth = PasswordAuthenticator(self.__username, self.__password)
         opts = ClusterOptions(auth)
@@ -87,8 +96,8 @@ class GreenboardUploader:
         cluster.bucket("greenboard").default_collection().upsert(
             str(uuid4()),
             {
-                "build": build,
-                "version": version,
+                "build": parsed_build,
+                "version": parsed_version,
                 "sgwVersion": sgw_version,
                 "failCount": self.__fail_count,
                 "passCount": self.__pass_count,


### PR DESCRIPTION
https://jira.issues.couchbase.com/browse/CBG-5293

SGW docs were added properly but the runs for 4.0.0 were shown as 0.0.0 because the build couldn't be fetched perhaps. Since the build might be fetched later, the current fix to support SGW and not trash other platforms is to keep version ONLY if `version_components` doesn't have two elements.
Which is the current SGW case