### PR TITLE
DO NOT MERGE YET: Helper functions for qe SGW tests

### DIFF
--- a/client/src/cbltest/api/cloud.py
+++ b/client/src/cbltest/api/cloud.py
@@ -171,7 +171,8 @@ class CouchbaseCloud:
                     raise
         else:
             self.couchbase_server.drop_bucket(bucket_name)
-            await self.couchbase_server.wait_for_bucket_deleted(bucket_name)
+            if wait_for_deleted:
+                await self.couchbase_server.wait_for_bucket_deleted(bucket_name)
 
         if wait_for_deleted:
             await self.__sync_gateway.wait_for_no_databases(bucket_name)

--- a/client/src/cbltest/api/cloud.py
+++ b/client/src/cbltest/api/cloud.py
@@ -129,14 +129,9 @@ class CouchbaseCloud:
 
                 current_span.add_event("Handle HTTP 412")
                 await self.__sync_gateway.delete_database(dataset_name)
-                if self.sync_gateway.using_rosmar:
-                    raise CblTestError(
-                        f"Database {dataset_name} already exists on Sync Gateway and cannot be deleted when "
-                        "using rosmar until CBG-5213 is implemented. To work around, restart a Sync Gateway to "
-                        "delete the rosmar buckets."
-                    )
-                else:
-                    self.__couchbase_server.drop_bucket(db_payload.bucket)
+                await self.drop_bucket(db_payload.bucket)
+                await self.__sync_gateway.wait_for_no_databases(db_payload.bucket)
+                if not self.sync_gateway.using_rosmar:
                     self.__couchbase_server.create_bucket(db_payload.bucket)
                     self._create_collections(db_payload)
 
@@ -163,3 +158,11 @@ class CouchbaseCloud:
                 )
 
             await self.__sync_gateway.load_dataset(dataset_name, data_filepath)
+
+    async def drop_bucket(self, bucket_name: str, *, wait_for_deleted=False):
+        """Drop the bucket from the backing cluster. This is an asynchronous operation unless wait_for_deleted is set to True."""
+        if self.sync_gateway.using_rosmar:
+            await self.sync_gateway._send_request("delete", f"/_rosmar/{bucket_name}")
+        else:
+            self.couchbase_server.drop_bucket(bucket_name)
+            await self.couchbase_server.wait_for_bucket_deleted(bucket_name)

--- a/client/src/cbltest/api/cloud.py
+++ b/client/src/cbltest/api/cloud.py
@@ -162,7 +162,32 @@ class CouchbaseCloud:
     async def drop_bucket(self, bucket_name: str, *, wait_for_deleted=False):
         """Drop the bucket from the backing cluster. This is an asynchronous operation unless wait_for_deleted is set to True."""
         if self.sync_gateway.using_rosmar:
-            await self.sync_gateway._send_request("delete", f"/_rosmar/{bucket_name}")
+            try:
+                await self.sync_gateway._send_request(
+                    "delete", f"/_rosmar/{bucket_name}"
+                )
+            except CblSyncGatewayBadResponseError as e:
+                if e.code != 404:
+                    raise
         else:
             self.couchbase_server.drop_bucket(bucket_name)
             await self.couchbase_server.wait_for_bucket_deleted(bucket_name)
+
+        if wait_for_deleted:
+            await self.__sync_gateway.wait_for_no_databases(bucket_name)
+
+    async def create_database(
+        self, db_name: str, db_payload: PutDatabasePayload
+    ) -> None:
+        """Create a Sync Gateway database with the given name and payload. Delete the bucket prior to creation of the database."""
+        await self.drop_bucket(db_payload.bucket, wait_for_deleted=True)
+        await self.__sync_gateway.wait_for_no_databases(db_payload.bucket)
+        await self.create_bucket(db_payload.bucket)
+        await self.__sync_gateway.put_database(db_name, db_payload)
+        await self.__sync_gateway.wait_for_db_up(db_name)
+
+    async def create_bucket(self, bucket_name: str) -> None:
+        """Create a bucket with the given name. Only applicable if not using Rosmar."""
+        if self.sync_gateway.using_rosmar:
+            return None
+        self.couchbase_server.create_bucket(bucket_name)

--- a/client/src/cbltest/api/syncgateway.py
+++ b/client/src/cbltest/api/syncgateway.py
@@ -530,7 +530,7 @@ class DatabaseStatusResponse:
 class _SyncGatewayBase:
     """
     Base class for Sync Gateway clients containing common document and database operations.
-    This class should not be instantiated directly - use SyncGateway or SyncGatewayPublic instead.
+    This class should not be instantiated directly - use SyncGateway or SyncGatewayUserClient instead.
     """
 
     def __init__(
@@ -557,21 +557,6 @@ class _SyncGatewayBase:
             port,
             BasicAuth(username, password, "ascii"),
         )
-        r = requests.get(
-            f"{scheme}{url}:{port}/_config",
-            auth=(username, password),
-            # disable hostname verification as we do in _create_session
-            verify=False,
-            timeout=10,
-        )
-        r.raise_for_status()
-        try:
-            self.using_rosmar = r.json()["bootstrap"]["server"].startswith("rosmar")
-        except AttributeError:
-            raise CblTestError(
-                "Unexpected response {r.json()} from Sync Gateway /_config endpoint, cannot determine if using Rosmar"
-            ) from None
-            self.using_rosmar = False
 
     @property
     def hostname(self) -> str:
@@ -587,6 +572,11 @@ class _SyncGatewayBase:
     def secure(self) -> bool:
         """Gets whether the Sync Gateway instance uses TLS"""
         return self.__secure
+
+    @property
+    def scheme(self) -> str:
+        """Gets the URL scheme to use when connecting to the Sync Gateway instance (http or https)"""
+        return "https://" if self.secure else "http://"
 
     def _create_session(
         self, secure: bool, scheme: str, url: str, port: int, auth: BasicAuth | None
@@ -647,9 +637,8 @@ class _SyncGatewayBase:
 
     async def get_version(self) -> CouchbaseVersion:
         # Telemetry not really important for this call
-        scheme = "https://" if self.secure else "http://"
         async with self._create_session(
-            self.secure, scheme, self.hostname, 4984, None
+            self.secure, self.scheme, self.hostname, 4984, None
         ) as s:
             resp = await self._send_request("get", "/", session=s)
             assert isinstance(resp, dict)
@@ -1346,9 +1335,8 @@ class _SyncGatewayBase:
         )
         params = {"rev": revision}
 
-        scheme = "https://" if self.secure else "http://"
         async with self._create_session(
-            self.secure, scheme, self.hostname, 4984, auth
+            self.secure, self.scheme, self.hostname, 4984, auth
         ) as session:
             return await self._send_request("GET", path, params=params, session=session)
 
@@ -1616,6 +1604,21 @@ class SyncGateway(_SyncGatewayBase):
         """
         super().__init__(url, username, password, port, secure)
         self.__public_port = public_port
+        r = requests.get(
+            f"{self.scheme}{url}:{port}/_config",
+            auth=(username, password),
+            # disable hostname verification as we do in _create_session
+            verify=False,
+            timeout=10,
+        )
+        r.raise_for_status()
+        try:
+            self.using_rosmar = r.json()["bootstrap"]["server"].startswith("rosmar")
+        except AttributeError:
+            raise CblTestError(
+                "Unexpected response {r.json()} from Sync Gateway /_config endpoint, cannot determine if using Rosmar"
+            ) from None
+            self.using_rosmar = False
 
     def create_collection_access_dict(self, input: dict[str, list[str]]) -> dict:
         """
@@ -1847,9 +1850,8 @@ class SyncGateway(_SyncGatewayBase):
         # Check if SGW is already running by probing the public endpoint (4984)
         try:
             # Use a short timeout to distinguish "not running" from "slow"
-            scheme = "https://" if self.secure else "http://"
             async with self._create_session(
-                self.secure, scheme, self.hostname, 4984, None
+                self.secure, self.scheme, self.hostname, 4984, None
             ) as session:
                 async with session.get("/", timeout=ClientTimeout(total=5)) as resp:
                     if resp.status == 200:

--- a/client/src/cbltest/api/syncgateway.py
+++ b/client/src/cbltest/api/syncgateway.py
@@ -8,6 +8,7 @@ from typing import Any, cast
 from urllib.parse import urljoin
 
 import requests
+import tenacity
 from aiohttp import BasicAuth, ClientError, ClientSession, ClientTimeout, TCPConnector
 from aiohttp.client_exceptions import ClientConnectorError
 from opentelemetry.trace import get_tracer
@@ -17,7 +18,7 @@ from cbltest.api.jsonserializable import JSONDictionary, JSONSerializable
 from cbltest.assertions import _assert_not_null
 from cbltest.httplog import get_next_writer
 from cbltest.jsonhelper import _get_typed_required
-from cbltest.logging import cbl_error, cbl_info, cbl_warning
+from cbltest.logging import cbl_error, cbl_info, cbl_trace, cbl_warning
 from cbltest.utils import assert_not_null
 from cbltest.version import VERSION
 
@@ -659,7 +660,7 @@ class _SyncGatewayBase:
 
     def tls_cert(self) -> str | None:
         if not self.secure:
-            cbl_warning(
+            cbl_trace(
                 "Sync Gateway instance not using TLS, returning empty tls_cert..."
             )
             return None
@@ -1873,6 +1874,22 @@ class SyncGateway(_SyncGatewayBase):
                         raise Exception(f"Failed to start SGW: {resp.status} - {body}")
                     # Wait a bit for SGW to fully initialize
                     await asyncio.sleep(5)
+
+    @tenacity.retry(
+        wait=tenacity.wait_fixed(0.1),
+        # Sync Gateway polling time is 10s, so wait 60s for polling time + any additional work
+        stop=tenacity.stop_after_delay(60),
+        reraise=True,
+        retry=tenacity.retry_if_exception_type(AssertionError),
+    )
+    async def wait_for_no_databases(self, bucket_name: str):
+        with self._tracer.start_as_current_span("get_all_dbs"):
+            resp = await self._send_request("get", "/_all_dbs?verbose=true")
+            assert isinstance(resp, list), resp
+            for db in resp:
+                assert db["bucket"] != bucket_name, (
+                    f"Database {db=} is still backed by bucket {bucket_name}"
+                )
 
     async def wait_for_db_gone_clusterwide(
         self,

--- a/client/src/cbltest/api/syncgateway.py
+++ b/client/src/cbltest/api/syncgateway.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import re
 import ssl
 from abc import ABC, abstractmethod
@@ -634,6 +635,15 @@ class _SyncGatewayBase:
                 )
 
             return ret_val
+
+    async def supports_version_vectors(self) -> bool:
+        """Return true if Sync Gateway supports version vectors."""
+        resp_data = await self._send_request("get", "/_cluster_info")
+        for bucket in resp_data:
+            return bucket.get("enable_cross_cluster_versioning")
+        raise CblTestError(
+            "Could not determine if Sync Gateway supports version vectors, need at least one database"
+        )
 
     async def get_version(self) -> CouchbaseVersion:
         # Telemetry not really important for this call
@@ -1950,6 +1960,7 @@ class SyncGateway(_SyncGatewayBase):
         # Wait for the node to settle down after coming online
         await asyncio.sleep(settle_online)
 
+    @contextlib.asynccontextmanager
     async def create_user_client(
         self,
         db_name: str,
@@ -1978,13 +1989,17 @@ class SyncGateway(_SyncGatewayBase):
         )
 
         # Return user-specific SG client for public API access
-        return SyncGatewayUserClient(
+        client = SyncGatewayUserClient(
             self.hostname,
             username,
             password,
             port=self.__public_port,
             secure=self.secure,
         )
+        try:
+            yield client
+        finally:
+            await client.close()
 
     async def start_isgr(self, db_name: str, payload: ISGRPayload) -> str:
         """

--- a/client/src/cbltest/api/syncgateway.py
+++ b/client/src/cbltest/api/syncgateway.py
@@ -5,7 +5,7 @@ import ssl
 from abc import ABC, abstractmethod
 from json import dumps, loads
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, AsyncIterator, cast
 from urllib.parse import urljoin
 
 import requests
@@ -1961,23 +1961,27 @@ class SyncGateway(_SyncGatewayBase):
         await asyncio.sleep(settle_online)
 
     @contextlib.asynccontextmanager
+    @contextlib.asynccontextmanager
     async def create_user_client(
         self,
         db_name: str,
         username: str,
         password: str,
         channels: list[str],
-    ) -> "SyncGatewayUserClient":
+    ) -> AsyncIterator["SyncGatewayUserClient"]:
         """
-        Helper method to create a user with channel access and return a user-specific SG client.
+        Helper method to create a user with channel access and yield a user-specific SG client.
 
         This is a convenience method for tests that need to verify user-level access control.
+        Use it with ``async with`` only. The yielded client is automatically closed when the
+        context exits and must not be used outside that block.
 
         :param db_name: The database name
         :param username: The username to create
         :param password: The password for the user
         :param channels: List of channels the user should have access to
-        :return: A SyncGatewayUserClient instance authenticated as the user (uses public port)
+        :return: An async context manager yielding a SyncGatewayUserClient authenticated as
+            the user (uses public port)
         """
         # Clean up user if exists from previous run
         await self.delete_user(db_name, username)

--- a/environment/local/run_sync_gateway.py
+++ b/environment/local/run_sync_gateway.py
@@ -49,6 +49,7 @@ def main(start, stop, server):
     if stop:
         bridge.stop("localhost")
     else:
+        bridge.stop("localhost")
         bridge.run("localhost")
 
 

--- a/environment/local/sync_gateway_config/basic_sync_gateway_rosmar.json
+++ b/environment/local/sync_gateway_config/basic_sync_gateway_rosmar.json
@@ -12,5 +12,8 @@
       "log_level": "debug",
       "log_keys": ["*"]
     }
+  },
+  "unsupported": {
+    "rosmar_bucket_management": true
   }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "paramiko==3.5.0",
     "psutil==7.0.0",
     "pyyaml==6.0.2",
+    "tenacity==9.1.4",
     "tqdm==4.67.1",
 ]
 

--- a/tests/QE/test_db_online_offline.py
+++ b/tests/QE/test_db_online_offline.py
@@ -1,18 +1,26 @@
-import asyncio
-from json.decoder import JSONDecodeError
+import dataclasses
 from pathlib import Path
-from typing import Any
 
 import pytest
 from cbltest import CBLPyTest
 from cbltest.api.cbltestclass import CBLTestClass
 from cbltest.api.error import CblSyncGatewayBadResponseError
-from cbltest.api.syncgateway import DocumentUpdateEntry, PutDatabasePayload, SyncGateway
+from cbltest.api.syncgateway import (
+    DocumentUpdateEntry,
+    PutDatabasePayload,
+    SyncGateway,
+)
+
+
+@dataclasses.dataclass
+class DatabaseConfig:
+    bucket_name: str
+    channel: str
+    username: str
 
 
 @pytest.mark.sgw
 @pytest.mark.min_sync_gateways(1)
-@pytest.mark.min_couchbase_servers(1)
 class TestDbOnlineOffline(CBLTestClass):
     async def scan_rest_endpoints(
         self,
@@ -20,12 +28,10 @@ class TestDbOnlineOffline(CBLTestClass):
         db_name: str,
         expected_online: bool,
         num_docs: int = 10,
-    ) -> tuple[int, int]:
+    ):
         """
         Scans multiple REST endpoints to verify database online/offline state.
         """
-        endpoints_tested = 0
-        errors_403 = 0
 
         test_operations = [
             (
@@ -51,35 +57,35 @@ class TestDbOnlineOffline(CBLTestClass):
             ),
         ]
 
-        for _, test_func in test_operations:
+        for test_name, test_func in test_operations:
             try:
                 await test_func()
-                endpoints_tested += 1
-            except (CblSyncGatewayBadResponseError, JSONDecodeError) as e:
-                endpoints_tested += 1
-                if isinstance(e, CblSyncGatewayBadResponseError):
-                    if e.code in [403, 503]:
-                        errors_403 += 1
-                    elif e.code != 404:  # 404 is OK
-                        raise e
-                elif isinstance(e, JSONDecodeError):
-                    errors_403 += 1
-
-        return (endpoints_tested, errors_403)
+            except CblSyncGatewayBadResponseError as e:
+                if expected_online:
+                    assert e is not None, (
+                        f"Expected endpoint {test_name} but got exception: {e}"
+                    )
+                else:
+                    # 404 is true for Sync Gateway 4.0.4+ CBG-5156
+                    # 403 will occur if Sync Gateway < 4.0.4 or using rosmar
+                    assert e.code in [403, 404], (
+                        f"Expected 403 or 404 for endpoint {test_name} but got {e.code}"
+                    )
+                    return
+            assert expected_online, (
+                f"Expected endpoint {test_name} to fail with 404 if offline, but it succeeded with 200"
+            )
 
     @pytest.mark.asyncio(loop_scope="session")
     async def test_db_offline_on_bucket_deletion(
         self, cblpytest: CBLPyTest, dataset_path: Path
     ) -> None:
-        sg = cblpytest.sync_gateways[0]
-        cbs = cblpytest.couchbase_servers[0]
+        cloud = cblpytest.simple_cloud()
+        sg = cloud.sync_gateway
         num_docs = 10
         sg_db = "db"
         bucket_name = "data-bucket"
         channels = ["ABC"]
-
-        self.mark_test_step("Create bucket and default collection")
-        cbs.create_bucket(bucket_name)
 
         self.mark_test_step("Configure Sync Gateway database endpoint")
         db_config = {
@@ -87,9 +93,7 @@ class TestDbOnlineOffline(CBLTestClass):
             "index": {"num_replicas": 0},
             "scopes": {"_default": {"collections": {"_default": {}}}},
         }
-        db_payload = PutDatabasePayload(db_config)
-        await sg.put_database(sg_db, db_payload)
-        await sg.wait_for_db_up(sg_db)
+        await cloud.create_database(sg_db, PutDatabasePayload(db_config))
 
         self.mark_test_step(f"Create {num_docs} docs via Sync Gateway")
         sg_docs: list[DocumentUpdateEntry] = []
@@ -104,74 +108,64 @@ class TestDbOnlineOffline(CBLTestClass):
         await sg.update_documents(sg_db, sg_docs)
 
         self.mark_test_step("Verify database is online - REST endpoints work")
-        endpoints_tested, errors_403 = await self.scan_rest_endpoints(
-            sg, sg_db, expected_online=True
-        )
-        assert errors_403 == 0, (
-            f"DB is online but {errors_403}/{endpoints_tested} endpoints returned 403"
-        )
-
+        await self.scan_rest_endpoints(sg, sg_db, expected_online=True)
         self.mark_test_step("Delete bucket to sever connection")
-        cbs.drop_bucket(bucket_name)
-        db_status = await sg.get_database_status(sg_db)
-        while db_status is not None and db_status.state == "Online":
-            db_status = await sg.get_database_status(sg_db)
-            await asyncio.sleep(10)
+        await cloud.drop_bucket(bucket_name)
+        await sg.wait_for_no_databases(bucket_name)
 
         self.mark_test_step("Verify database is offline - REST endpoints return 403")
-        endpoints_tested, errors_403 = await self.scan_rest_endpoints(
-            sg, sg_db, expected_online=False
-        )
-        assert endpoints_tested > 0, "No endpoints were tested"
-        assert errors_403 == endpoints_tested, (
-            f"DB is offline but only {errors_403}/{endpoints_tested} endpoints returned 403"
-        )
+        await self.scan_rest_endpoints(sg, sg_db, expected_online=False)
 
     @pytest.mark.asyncio(loop_scope="session")
     async def test_multiple_dbs_bucket_deletion(
-        self, cblpytest: CBLPyTest, dataset_path: Path
+        self,
+        cblpytest: CBLPyTest,
+        dataset_path: Path,
     ) -> None:
-        sg = cblpytest.sync_gateways[0]
-        cbs = cblpytest.couchbase_servers[0]
+        cloud = cblpytest.simple_cloud()
+        sg = cloud.sync_gateway
         num_docs = 10
 
-        db_configs: list[list[Any]] = [
-            ["db1", "data-bucket-1", "ABC", "vipul", None],
-            ["db2", "data-bucket-2", "CBS", "lupiv", None],
-            ["db3", "data-bucket-3", "ABC", "vipul", None],
-            ["db4", "data-bucket-4", "CBS", "lupiv", None],
-        ]
+        db_configs: dict[str, DatabaseConfig] = {
+            "db1": DatabaseConfig("data-bucket-1", "ABC", "vipul"),
+            "db2": DatabaseConfig("data-bucket-2", "CBS", "vipul"),
+            "db3": DatabaseConfig("data-bucket-3", "ABC", "vipul"),
+            "db4": DatabaseConfig("data-bucket-4", "CBS", "lupiv"),
+        }
 
         self.mark_test_step("Create buckets and configure databases")
-        for i, [db_name, bucket_name, channel, username, _] in enumerate(db_configs):
-            cbs.create_bucket(bucket_name)
-
-            db_config = {
-                "bucket": bucket_name,
-                "index": {"num_replicas": 0},
-                "scopes": {"_default": {"collections": {"_default": {}}}},
-            }
-            db_payload = PutDatabasePayload(db_config)
-            await sg.put_database(db_name, db_payload)
-            await sg.wait_for_db_up(db_name)
-            db_configs[i][4] = await sg.create_user_client(
-                db_name, username, "pass", [channel]
+        for db_name, config in db_configs.items():
+            await cloud.create_database(
+                db_name,
+                PutDatabasePayload(
+                    {
+                        "bucket": config.bucket_name,
+                        "index": {"num_replicas": 0},
+                        "scopes": {"_default": {"collections": {"_default": {}}}},
+                    }
+                ),
             )
-
-            self.mark_test_step(f"Create {num_docs} docs via Sync Gateway")
-            sg_docs: list[DocumentUpdateEntry] = []
-            for j in range(num_docs):
-                sg_docs.append(
-                    DocumentUpdateEntry(
-                        f"doc_{j}",
-                        None,
-                        body={"db": db_name, "index": j, "channels": [channel]},
+            async with sg.create_user_client(
+                db_name, config.username, "pass", [config.channel]
+            ) as client:
+                self.mark_test_step(f"Create {num_docs} docs via Sync Gateway")
+                sg_docs: list[DocumentUpdateEntry] = []
+                for j in range(num_docs):
+                    sg_docs.append(
+                        DocumentUpdateEntry(
+                            f"doc_{j}",
+                            None,
+                            body={
+                                "db": db_name,
+                                "index": j,
+                                "channels": [config.channel],
+                            },
+                        )
                     )
-                )
-            await sg.update_documents(db_name, sg_docs, "_default", "_default")
+                await client.update_documents(db_name, sg_docs, "_default", "_default")
 
         self.mark_test_step("Verify all databases are online")
-        for [db_name, _, _, _, _] in db_configs:
+        for db_name in db_configs:
             status = await sg.get_database_status(db_name)
             assert status is not None, f"{db_name} database doesn't exist"
             assert status.state == "Online", (
@@ -181,34 +175,16 @@ class TestDbOnlineOffline(CBLTestClass):
         self.mark_test_step(
             "Delete buckets for db1 and db3 and wait for databases to go offline"
         )
-        cbs.drop_bucket("data-bucket-1")
-        cbs.drop_bucket("data-bucket-3")
-        await cbs.wait_for_bucket_deleted("data-bucket-1")
-        await cbs.wait_for_bucket_deleted("data-bucket-3")
-        for db_name in ["db1", "db3"]:
-            db_status = await sg.get_database_status(db_name)
-            while db_status is not None and db_status.state == "Online":
-                db_status = await sg.get_database_status(db_name)
-                await asyncio.sleep(10)
+        await cloud.drop_bucket("data-bucket-1", wait_for_deleted=True)
+        await cloud.drop_bucket("data-bucket-3", wait_for_deleted=True)
+
+        await sg.wait_for_no_databases("data-bucket-1")
+        await sg.wait_for_no_databases("data-bucket-3")
 
         self.mark_test_step("Verify db2 and db4 remain online")
         for db_name in ["db2", "db4"]:
-            endpoints_tested, errors_403 = await self.scan_rest_endpoints(
-                sg, db_name, expected_online=True
-            )
-            assert errors_403 == 0, (
-                f"{db_name} should be online but got {errors_403} 403 errors"
-            )
+            await self.scan_rest_endpoints(sg, db_name, expected_online=True)
 
         self.mark_test_step("Verify db1 and db3 are offline (return 403)")
         for db_name in ["db1", "db3"]:
-            endpoints_tested, errors_403 = await self.scan_rest_endpoints(
-                sg, db_name, expected_online=False
-            )
-            assert errors_403 == endpoints_tested, (
-                f"{db_name}: Expected all {endpoints_tested} endpoints to return 403, got {errors_403}"
-            )
-
-        for [_, _, _, _, user_client] in db_configs:
-            if user_client is not None:
-                await user_client.close()
+            await self.scan_rest_endpoints(sg, db_name, expected_online=False)

--- a/tests/QE/test_multiple_servers.py
+++ b/tests/QE/test_multiple_servers.py
@@ -6,7 +6,6 @@ import requests
 from cbltest import CBLPyTest
 from cbltest.api.cbltestclass import CBLTestClass
 from cbltest.api.syncgateway import DocumentUpdateEntry, ISGRPayload, PutDatabasePayload
-from packaging.version import Version
 
 
 def _check_node_in_cluster(cbs_hostname: str, cluster_nodes: list) -> tuple[bool, bool]:
@@ -138,9 +137,7 @@ class TestMultipleServers(CBLTestClass):
         original_revs = {row.id: row.revision for row in all_docs.rows}
         original_vvs = {}
 
-        sgw_version_obj = await sg.get_version()
-        sgw_version = Version(sgw_version_obj.version)
-        supports_version_vectors = sgw_version >= Version("4.0.0")
+        supports_version_vectors = sg.supports_version_vectors()
         if supports_version_vectors:
             changes_initial = await sg_user.get_changes(sg_db, version_type="cv")
             original_vvs = {

--- a/tests/QE/test_replication_multiple_clients.py
+++ b/tests/QE/test_replication_multiple_clients.py
@@ -150,10 +150,7 @@ class TestReplicationMultipleClients(CBLTestClass):
                 f"Invalid revision format for {row.id}: {row.revision}"
             )
 
-        sgw_version_obj = await sg.get_version()
-        sgw_version = Version(sgw_version_obj.version)
-        supports_version_vectors = sgw_version >= Version("4.0.0")
-        if supports_version_vectors:
+        if sg.supports_version_vectors():
             self.mark_test_step(
                 "Verify all documents have correct version vector format (SGW 4.0+)"
             )

--- a/tests/QE/test_users_channels.py
+++ b/tests/QE/test_users_channels.py
@@ -5,7 +5,6 @@ import pytest
 from cbltest import CBLPyTest
 from cbltest.api.cbltestclass import CBLTestClass
 from cbltest.api.syncgateway import DocumentUpdateEntry, PutDatabasePayload
-from packaging.version import Version
 
 
 @pytest.mark.sgw
@@ -121,10 +120,7 @@ class TestUsersChannels(CBLTestClass):
                     f"Invalid revision format for {row.id}: {row.revision}"
                 )
 
-        sgw_version_obj = await sgs[0].get_version()
-        sgw_version = Version(sgw_version_obj.version)
-        supports_version_vectors = sgw_version >= Version("4.0.0")
-        if supports_version_vectors:
+        if sg.supports_version_vectors():
             self.mark_test_step(
                 "Verify all documents have correct version vector format (SGW 4.0+)"
             )

--- a/tests/QE/test_xattrs.py
+++ b/tests/QE/test_xattrs.py
@@ -7,7 +7,6 @@ from cbltest import CBLPyTest
 from cbltest.api.cbltestclass import CBLTestClass
 from cbltest.api.error import CblSyncGatewayBadResponseError
 from cbltest.api.syncgateway import DocumentUpdateEntry, PutDatabasePayload
-from packaging.version import Version
 
 
 @pytest.mark.sgw
@@ -86,9 +85,7 @@ class TestXattrs(CBLTestClass):
         assert sg_created_count == num_docs, (
             f"Expected {num_docs} SG docs, but found {sg_created_count}"
         )
-        sgw_version_obj = await sg.get_version()
-        sgw_version = Version(sgw_version_obj.version)
-        supports_version_vectors = sgw_version >= Version("4.0.0")
+        supports_version_vectors = sg.supports_version_vectors()
         original_revisions = {row.id: row.revision for row in sg_all_docs.rows}
         if supports_version_vectors:
             original_vv = {row.id: row.cv for row in sg_all_docs.rows}
@@ -244,9 +241,7 @@ class TestXattrs(CBLTestClass):
             row.id: row.revision for row in sg_all_docs.rows
         }
 
-        sgw_version_obj = await sg.get_version()
-        sgw_version = Version(sgw_version_obj.version)
-        supports_version_vectors = sgw_version >= Version("4.0.0")
+        supports_version_vectors = sg.supports_version_vectors()
         all_doc_version_vectors: dict[str, str | None] = {}
         if supports_version_vectors:
             self.mark_test_step("Store original version vectors for SG docs (optional)")

--- a/uv.lock
+++ b/uv.lock
@@ -400,6 +400,7 @@ dependencies = [
     { name = "paramiko" },
     { name = "psutil" },
     { name = "pyyaml" },
+    { name = "tenacity" },
     { name = "tqdm" },
 ]
 
@@ -417,6 +418,7 @@ requires-dist = [
     { name = "paramiko", specifier = "==3.5.0" },
     { name = "psutil", specifier = "==7.0.0" },
     { name = "pyyaml", specifier = "==6.0.2" },
+    { name = "tenacity", specifier = "==9.1.4" },
     { name = "tqdm", specifier = "==4.67.1" },
 ]
 
@@ -1187,6 +1189,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1b/fa/2ef715a1cd329ef47c1a050e10dee91a9054b7ce2fcfdd6a06d139afb7ec/ruff-0.15.4-py3-none-win32.whl", hash = "sha256:65594a2d557d4ee9f02834fcdf0a28daa8b3b9f6cb2cb93846025a36db47ef22", size = 10506664, upload-time = "2026-02-26T20:03:50.56Z" },
     { url = "https://files.pythonhosted.org/packages/d0/a8/c688ef7e29983976820d18710f955751d9f4d4eb69df658af3d006e2ba3e/ruff-0.15.4-py3-none-win_amd64.whl", hash = "sha256:04196ad44f0df220c2ece5b0e959c2f37c777375ec744397d21d15b50a75264f", size = 11651048, upload-time = "2026-02-26T20:04:17.191Z" },
     { url = "https://files.pythonhosted.org/packages/3e/0a/9e1be9035b37448ce2e68c978f0591da94389ade5a5abafa4cf99985d1b2/ruff-0.15.4-py3-none-win_arm64.whl", hash = "sha256:60d5177e8cfc70e51b9c5fad936c634872a74209f934c1e79107d11787ad5453", size = 10966776, upload-time = "2026-02-26T20:03:56.908Z" },
+]
+
+[[package]]
+name = "tenacity"
+version = "9.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Do not merge until the following PRs are resolved

https://github.com/couchbaselabs/couchbase-lite-tests/pull/386
https://github.com/couchbaselabs/couchbase-lite-tests/pull/387

You can take or leave part of these PRs. I wanted to be able to run some QE tests with rosmar or a SG dev build in the test_db_online_offline.py.

Fixes:

- Change `create_user_client` to use a context manager so that `close` is automatically called if a test fails
- Create a more robust way to drop buckets, wait for SG dbs to be absent, create a new database. This needs to be a helper function in the case that rosmar is used, since it doesn't communicate with CBS to create a bucket and uses `CouchbaseCloud` instance.
- A SG dev build doesn't have a version number, so create a different helper function for vv support relying on the presence of `enable_cross_cluster_versioning` in `/_cluster_info` which is only present in SG 4.0
- Switch `scan_rest_endpoints` to provide a clear error if they fail for some reason. I believe that it should never return 500, but only 403 or 404 errors if offline.


To test locally:

```
uv run environment/local/start_local.py --build-testserver 4.0.3
uv run environment/local/run_sync_gateway.py --server rosmar --start
uv run pytest --config environment/local/rosmar_config.json tests/dev_e2e
```
 
This PR you can take or leave but it has some interesting fixes. @vipbhardwaj you should test this with SG 3.3 and SG 4.0 if you want to merge this code. There are other places that could use these helper functions, but I only changed code that I could test.