### PR TITLE
Add missing header

### DIFF
--- a/servers/c/src/cbl/KeyPath.h
+++ b/servers/c/src/cbl/KeyPath.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <stdexcept>
 #include <optional>
 #include <string>


### PR DESCRIPTION
Not sure why this isn't necessary on platforms you are using, but reproducible for me on gcc 15.2 and gcc 11.4