### PR TITLE
Proget parameterizing

### DIFF
--- a/client/src/cbltest/api/edgeserver.py
+++ b/client/src/cbltest/api/edgeserver.py
@@ -26,6 +26,7 @@ from cbltest.api.syncgateway import (
 from cbltest.assertions import _assert_not_null
 from cbltest.httplog import get_next_writer
 from cbltest.jsonhelper import _get_typed_required
+from cbltest.logging import cbl_warning
 from cbltest.version import VERSION
 
 
@@ -40,7 +41,22 @@ class EdgeServerVersion(CouchbaseVersion):
         if first_lparen == -1 or first_semicol == -1:
             return ("unknown", 0)
 
-        return input[0:first_lparen], int(input[first_lparen + 1 : first_semicol])
+        version = input[0:first_lparen].strip()
+        if not version:
+            cbl_warning(
+                f"Could not extract version from Edge Server version string: '{input}'"
+            )
+            version = "unknown"
+
+        try:
+            build = int(input[first_lparen + 1 : first_semicol])
+        except ValueError:
+            cbl_warning(
+                f"Could not parse build number from Edge Server version string: '{input}'"
+            )
+            build = 0
+
+        return (version, build)
 
 
 class BulkDocOperation(JSONSerializable):
@@ -229,8 +245,14 @@ class EdgeServer:
             assert isinstance(resp, dict)
             resp_dict = cast(dict, resp)
             raw_version = _get_typed_required(resp_dict, "version", str)
-            assert "/" in raw_version
-            return EdgeServerVersion(raw_version.split("/")[1])
+            if "/" in raw_version:
+                version_part = raw_version.rsplit("/", 1)[1]
+            else:
+                cbl_warning(
+                    f"Unexpected Edge Server version format (no '/' separator): '{raw_version}'"
+                )
+                version_part = raw_version
+            return EdgeServerVersion(version_part)
 
     async def get_all_documents(
         self,

--- a/client/src/cbltest/api/syncgateway.py
+++ b/client/src/cbltest/api/syncgateway.py
@@ -498,7 +498,20 @@ class SyncGatewayVersion(CouchbaseVersion):
         if first_lparen == -1 or first_semicol == -1:
             return ("unknown", 0)
 
-        return input[0:first_lparen], int(input[first_lparen + 1 : first_semicol])
+        version = input[0:first_lparen].strip()
+        if not version:
+            cbl_warning(f"Could not extract version from SGW version string: '{input}'")
+            version = "unknown"
+
+        try:
+            build = int(input[first_lparen + 1 : first_semicol])
+        except ValueError:
+            cbl_warning(
+                f"Could not parse build number from SGW version string: '{input}'"
+            )
+            build = 0
+
+        return (version, build)
 
 
 class DatabaseStatusResponse:
@@ -644,8 +657,14 @@ class _SyncGatewayBase:
             assert isinstance(resp, dict)
             resp_dict = cast(dict, resp)
             raw_version = _get_typed_required(resp_dict, "version", str)
-            assert "/" in raw_version
-            return SyncGatewayVersion(raw_version.split("/")[1])
+            if "/" in raw_version:
+                version_part = raw_version.rsplit("/", 1)[1]
+            else:
+                cbl_warning(
+                    f"Unexpected SGW version format (no '/' separator): '{raw_version}'"
+                )
+                version_part = raw_version
+            return SyncGatewayVersion(version_part)
 
     def tls_cert(self) -> str | None:
         if not self.secure:

--- a/client/src/cbltest/greenboarduploader.py
+++ b/client/src/cbltest/greenboarduploader.py
@@ -7,6 +7,7 @@ from couchbase.auth import PasswordAuthenticator
 from couchbase.cluster import Cluster
 from couchbase.options import ClusterOptions
 
+from cbltest.api.syncgateway import CouchbaseVersion
 from cbltest.logging import cbl_warning
 
 
@@ -54,7 +55,13 @@ class GreenboardUploader:
         """
         return self.__has_sgw_marker
 
-    def upload(self, platform: str, os_name: str, version: str, sgw_version: str):
+    def upload(
+        self,
+        platform: str,
+        os_name: str,
+        version: str,
+        sgw_version: CouchbaseVersion | None,
+    ):
         """
         Uploads the results using the specified platform and version.  The reason that they
         are specified here is because they are probably unknown at the time that this object
@@ -62,27 +69,43 @@ class GreenboardUploader:
 
         :param platform: The platform name (e.g. couchbase-lite-net) as specified by the test server
         :param version: The version string (e.g. 3.2.0-b0136, etc) as specified by the test server
+        :param sgw_version: The parsed SGW CouchbaseVersion object, or None if unavailable
         """
         if self.__overall_fail:
             cbl_warning("Overall result is failure, skipping upload...")
             return
 
-        version_to_parse = sgw_version if platform == "sync-gateway" else version
-        version_components = version_to_parse.split("-")
-
         parsed_version = "0.0.0"
         parsed_build = 0
+        sgw_version_str = "n/a"
 
-        if len(version_components) > 0 and version_components[0]:
-            parsed_version = version_components[0]
+        if sgw_version is not None:
+            sgw_ver = sgw_version.version
+            sgw_build = sgw_version.build_number
+            sgw_version_str = f"{sgw_ver}-{sgw_build}"
 
-        if len(version_components) > 1:
-            try:
-                # Handles build numbers like 'b1234' or just '1234'
-                parsed_build = int(version_components[1].lstrip("b"))
-            except ValueError:
-                # If the part after '-' is not a number, build remains 0
-                cbl_warning(f"Could not parse build number from '{version_to_parse}'")
+        if platform == "sync-gateway" and sgw_version is not None:
+            # For SGW jobs, use the SGW version directly from the parsed object
+            # to avoid the fragile serialize-then-reparse pattern.
+            parsed_version = (
+                sgw_version.version
+                if sgw_version.version and sgw_version.version != "unknown"
+                else "0.0.0"
+            )
+            parsed_build = sgw_version.build_number
+        else:
+            version_components = version.split("-")
+
+            if len(version_components) > 0 and version_components[0]:
+                parsed_version = version_components[0]
+
+            if len(version_components) > 1:
+                try:
+                    # Handles build numbers like 'b1234' or just '1234'
+                    parsed_build = int(version_components[1].lstrip("b"))
+                except ValueError:
+                    # If the part after '-' is not a number, build remains 0
+                    cbl_warning(f"Could not parse build number from '{version}'")
 
         auth = PasswordAuthenticator(self.__username, self.__password)
         opts = ClusterOptions(auth)
@@ -98,7 +121,7 @@ class GreenboardUploader:
             {
                 "build": parsed_build,
                 "version": parsed_version,
-                "sgwVersion": sgw_version,
+                "sgwVersion": sgw_version_str,
                 "failCount": self.__fail_count,
                 "passCount": self.__pass_count,
                 "platform": platform,

--- a/client/src/cbltest/plugins/greenboard_fixture.py
+++ b/client/src/cbltest/plugins/greenboard_fixture.py
@@ -1,6 +1,7 @@
 import pytest
 import pytest_asyncio
 from cbltest import CBLPyTest
+from cbltest.api.syncgateway import CouchbaseVersion
 from cbltest.greenboarduploader import GreenboardUploader
 from cbltest.logging import cbl_info, cbl_warning
 
@@ -43,7 +44,7 @@ async def greenboard(cblpytest: CBLPyTest, pytestconfig: pytest.Config):
     yield
 
     try:
-        sgw_version: str = "n/a"
+        sgw_version: CouchbaseVersion | None = None
         test_platform: str = "sync-gateway"
         os_name: str = "n/a"
         library_version: str = "n/a"
@@ -58,10 +59,7 @@ async def greenboard(cblpytest: CBLPyTest, pytestconfig: pytest.Config):
             if "systemName" in test_server_info.device:
                 os_name = test_server_info.device["systemName"]
         if len(cblpytest.sync_gateways) > 0:
-            sgw_version_parts = await cblpytest.sync_gateways[0].get_version()
-            sgw_version = (
-                f"{sgw_version_parts.version}-{sgw_version_parts.build_number}"
-            )
+            sgw_version = await cblpytest.sync_gateways[0].get_version()
         uploader.upload(test_platform, os_name, library_version, sgw_version)
     except Exception as e:
         cbl_warning(f"Failed to upload results to Greenboard: {e}")

--- a/client/tests/test_version_parsing.py
+++ b/client/tests/test_version_parsing.py
@@ -1,0 +1,85 @@
+"""Unit tests for CouchbaseVersion parsing (SyncGatewayVersion / EdgeServerVersion)
+and GreenboardUploader version handling."""
+
+from cbltest.api.edgeserver import EdgeServerVersion
+from cbltest.api.syncgateway import SyncGatewayVersion
+
+
+class TestSyncGatewayVersionParse:
+    """Tests for SyncGatewayVersion.parse()"""
+
+    def test_standard_3x_format(self):
+        v = SyncGatewayVersion("3.3.3(271;abc123)")
+        assert v.version == "3.3.3"
+        assert v.build_number == 271
+
+    def test_standard_4x_format(self):
+        v = SyncGatewayVersion("4.0.0(350;def456)")
+        assert v.version == "4.0.0"
+        assert v.build_number == 350
+
+    def test_missing_parentheses(self):
+        v = SyncGatewayVersion("4.0.0")
+        assert v.version == "unknown"
+        assert v.build_number == 0
+
+    def test_missing_semicolon(self):
+        v = SyncGatewayVersion("4.0.0(271)")
+        assert v.version == "unknown"
+        assert v.build_number == 0
+
+    def test_empty_version_before_lparen(self):
+        """Previously returned ("", 271) — now returns ("unknown", 271)."""
+        v = SyncGatewayVersion("(271;abc)")
+        assert v.version == "unknown"
+        assert v.build_number == 271
+
+    def test_non_numeric_build(self):
+        """Non-numeric build between ( and ; should not crash."""
+        v = SyncGatewayVersion("4.0.0(abc;def)")
+        assert v.version == "4.0.0"
+        assert v.build_number == 0
+
+    def test_version_with_spaces(self):
+        v = SyncGatewayVersion("4.0.0 (271;commit)")
+        assert v.version == "4.0.0"
+        assert v.build_number == 271
+
+    def test_empty_input(self):
+        v = SyncGatewayVersion("")
+        assert v.version == "unknown"
+        assert v.build_number == 0
+
+    def test_raw_preserved(self):
+        v = SyncGatewayVersion("3.3.3(271;abc)")
+        assert v.raw == "3.3.3(271;abc)"
+
+    def test_enterprise_edition_suffix(self):
+        """Handle version strings like '4.0.0(271;commit) EE'."""
+        v = SyncGatewayVersion("4.0.0(271;commit) EE")
+        assert v.version == "4.0.0"
+        assert v.build_number == 271
+
+
+class TestEdgeServerVersionParse:
+    """Tests for EdgeServerVersion.parse() — same logic as SyncGatewayVersion."""
+
+    def test_standard_format(self):
+        v = EdgeServerVersion("1.2.0(100;abc)")
+        assert v.version == "1.2.0"
+        assert v.build_number == 100
+
+    def test_empty_version_before_lparen(self):
+        v = EdgeServerVersion("(100;abc)")
+        assert v.version == "unknown"
+        assert v.build_number == 100
+
+    def test_non_numeric_build(self):
+        v = EdgeServerVersion("1.0.0(xyz;abc)")
+        assert v.version == "1.0.0"
+        assert v.build_number == 0
+
+    def test_no_parentheses(self):
+        v = EdgeServerVersion("1.0.0")
+        assert v.version == "unknown"
+        assert v.build_number == 0

--- a/jenkins/pipelines/QE/sgw/Jenkinsfile
+++ b/jenkins/pipelines/QE/sgw/Jenkinsfile
@@ -1,3 +1,16 @@
+def resolveProgetVersion(String product, String version, String label) {
+    def url = "http://proget.build.couchbase.com:8080/api/get_version?product=${product}&version=${version}&prerelease=true"
+    def resolved
+    if (isUnix()) {
+        resolved = sh(script: "curl -sf '${url}' | jq -r .version", returnStdout: true).trim()
+    } else {
+        resolved = powershell(script: "(Invoke-RestMethod '${url}').version", returnStdout: true).trim()
+    }
+    if (!resolved || resolved == 'null') { error "Could not resolve ${label} from '${version}'" }
+    echo "Resolved ${label}: ${resolved}"
+    return resolved
+}
+
 pipeline {
     agent none
     parameters {
@@ -13,23 +26,8 @@ pipeline {
                     if (params.CBL_VERSION == '') { error "CBL_VERSION is required" }
                     if (params.SGW_VERSION == '') { error "SGW_VERSION is required" }
 
-                    def progetBase = 'http://proget.build.couchbase.com:8080/api/get_version'
-
-                    def cblVersion = sh(
-                        script: "curl -sf '${progetBase}?product=couchbase-lite-${params.CBL_PLATFORM}&version=${params.CBL_VERSION}&prerelease=true' | jq -r .version",
-                        returnStdout: true
-                    ).trim()
-                    if (!cblVersion || cblVersion == 'null') { error "Could not resolve CBL_VERSION from '${params.CBL_VERSION}'" }
-                    echo "Resolved CBL_VERSION: ${cblVersion}"
-                    env.CBL_VERSION = cblVersion
-
-                    def sgwVersion = sh(
-                        script: "curl -sf '${progetBase}?product=sync-gateway&version=${params.SGW_VERSION}&prerelease=true' | jq -r .version",
-                        returnStdout: true
-                    ).trim()
-                    if (!sgwVersion || sgwVersion == 'null') { error "Could not resolve SGW_VERSION from '${params.SGW_VERSION}'" }
-                    echo "Resolved SGW_VERSION: ${sgwVersion}"
-                    env.SGW_VERSION = sgwVersion
+                    env.CBL_VERSION = resolveProgetVersion("couchbase-lite-${params.CBL_PLATFORM}", params.CBL_VERSION, 'CBL_VERSION')
+                    env.SGW_VERSION = resolveProgetVersion('sync-gateway', params.SGW_VERSION, 'SGW_VERSION')
 
                     currentBuild.displayName = "CBL:${env.CBL_VERSION} SGW:${env.SGW_VERSION} (#${currentBuild.number})"
                 }

--- a/jenkins/pipelines/QE/sgw/Jenkinsfile
+++ b/jenkins/pipelines/QE/sgw/Jenkinsfile
@@ -1,16 +1,37 @@
 pipeline {
     agent none
     parameters {
-        string(name: 'CBL_VERSION', defaultValue: '4.0.0', description: 'Couchbase Lite Version to use')
-        string(name: 'SGW_VERSION', defaultValue: '4.0.0', description: 'Sync Gateway Version to use')
+        string(name: 'CBL_VERSION', defaultValue: '4', description: 'Couchbase Lite Version to use')
+        string(name: 'CBL_PLATFORM', defaultValue: 'ios', description: 'Couchbase Lite Version to use')
+        string(name: 'SGW_VERSION', defaultValue: '4', description: 'Sync Gateway Version to use')
     }
     stages {
         stage('Init') {
+            agent any
             steps {
                 script {
                     if (params.CBL_VERSION == '') { error "CBL_VERSION is required" }
                     if (params.SGW_VERSION == '') { error "SGW_VERSION is required" }
-                    currentBuild.displayName = "CBL:${params.CBL_VERSION} SGW:${params.SGW_VERSION} (#${currentBuild.number})"
+
+                    def progetBase = 'http://proget.build.couchbase.com:8080/api/get_version'
+
+                    def cblVersion = sh(
+                        script: "curl -sf '${progetBase}?product=couchbase-lite-${params.CBL_PLATFORM}&version=${params.CBL_VERSION}&prerelease=true' | jq -r .version",
+                        returnStdout: true
+                    ).trim()
+                    if (!cblVersion || cblVersion == 'null') { error "Could not resolve CBL_VERSION from '${params.CBL_VERSION}'" }
+                    echo "Resolved CBL_VERSION: ${cblVersion}"
+                    env.CBL_VERSION = cblVersion
+
+                    def sgwVersion = sh(
+                        script: "curl -sf '${progetBase}?product=sync-gateway&version=${params.SGW_VERSION}&prerelease=true' | jq -r .version",
+                        returnStdout: true
+                    ).trim()
+                    if (!sgwVersion || sgwVersion == 'null') { error "Could not resolve SGW_VERSION from '${params.SGW_VERSION}'" }
+                    echo "Resolved SGW_VERSION: ${sgwVersion}"
+                    env.SGW_VERSION = sgwVersion
+
+                    currentBuild.displayName = "CBL:${env.CBL_VERSION} SGW:${env.SGW_VERSION} (#${currentBuild.number})"
                 }
             }
         }
@@ -19,7 +40,7 @@ pipeline {
                 build job: 'prebuild-test-server',
                 parameters: [
                     string(name: 'TS_PLATFORM', value: 'swift_ios'),
-                    string(name: 'CBL_VERSION', value: params.CBL_VERSION),
+                    string(name: 'CBL_VERSION', value: env.CBL_VERSION),
                 ],
                 wait: true,
                 propagate: true
@@ -37,7 +58,7 @@ pipeline {
                 sh "security unlock-keychain -p '${KEYCHAIN_PASSWORD}' ~/Library/Keychains/login.keychain-db"
                 echo "=== Run SGW Tests"
                 timeout(time: 90, unit: 'MINUTES') {
-                    sh "jenkins/pipelines/QE/sgw/test.sh ${params.CBL_VERSION} ${params.SGW_VERSION}"
+                    sh "jenkins/pipelines/QE/sgw/test.sh ${env.CBL_VERSION} ${env.SGW_VERSION}"
                 }
                 echo "=== SGW Tests Complete"
             }

--- a/jenkins/pipelines/QE/sgw/Jenkinsfile
+++ b/jenkins/pipelines/QE/sgw/Jenkinsfile
@@ -1,12 +1,16 @@
 def resolveProgetVersion(String product, String version, String label) {
     def url = "http://proget.build.couchbase.com:8080/api/get_version?product=${product}&version=${version}&prerelease=true"
+    echo "Resolving ${label}: ${url}"
     def resolved
     if (isUnix()) {
         resolved = sh(script: "curl -sf '${url}' | jq -r .version", returnStdout: true).trim()
     } else {
-        resolved = powershell(script: "(Invoke-RestMethod '${url}').version", returnStdout: true).trim()
+        resolved = powershell(script: """
+            try { (Invoke-RestMethod '${url}').version }
+            catch { Write-Error "ProGet request failed for ${label}: \$_"; exit 1 }
+        """.stripIndent(), returnStdout: true).trim()
     }
-    if (!resolved || resolved == 'null') { error "Could not resolve ${label} from '${version}'" }
+    if (!resolved || resolved == 'null') { error "Could not resolve ${label} from '${version}' (url: ${url})" }
     echo "Resolved ${label}: ${resolved}"
     return resolved
 }
@@ -15,12 +19,12 @@ pipeline {
     agent none
     parameters {
         string(name: 'CBL_VERSION', defaultValue: '4', description: 'Couchbase Lite Version to use')
-        string(name: 'CBL_PLATFORM', defaultValue: 'ios', description: 'Couchbase Lite Version to use')
+        string(name: 'CBL_PLATFORM', defaultValue: 'ios', description: 'Couchbase Lite platform for ProGet lookup')
         string(name: 'SGW_VERSION', defaultValue: '4', description: 'Sync Gateway Version to use')
     }
     stages {
         stage('Init') {
-            agent any
+            agent { label 'mac-mini-new' }
             steps {
                 script {
                     if (params.CBL_VERSION == '') { error "CBL_VERSION is required" }

--- a/jenkins/pipelines/QE/sgw/Jenkinsfile
+++ b/jenkins/pipelines/QE/sgw/Jenkinsfile
@@ -19,7 +19,6 @@ pipeline {
     agent none
     parameters {
         string(name: 'CBL_VERSION', defaultValue: '4', description: 'Couchbase Lite Version to use')
-        string(name: 'CBL_PLATFORM', defaultValue: 'ios', description: 'Couchbase Lite platform for ProGet lookup')
         string(name: 'SGW_VERSION', defaultValue: '4', description: 'Sync Gateway Version to use')
     }
     stages {
@@ -29,10 +28,8 @@ pipeline {
                 script {
                     if (params.CBL_VERSION == '') { error "CBL_VERSION is required" }
                     if (params.SGW_VERSION == '') { error "SGW_VERSION is required" }
-
-                    env.CBL_VERSION = resolveProgetVersion("couchbase-lite-${params.CBL_PLATFORM}", params.CBL_VERSION, 'CBL_VERSION')
+                    env.CBL_VERSION = resolveProgetVersion("couchbase-lite-ios", params.CBL_VERSION, 'CBL_VERSION')
                     env.SGW_VERSION = resolveProgetVersion('sync-gateway', params.SGW_VERSION, 'SGW_VERSION')
-
                     currentBuild.displayName = "CBL:${env.CBL_VERSION} SGW:${env.SGW_VERSION} (#${currentBuild.number})"
                 }
             }

--- a/jenkins/pipelines/QE/sgw/Jenkinsfile
+++ b/jenkins/pipelines/QE/sgw/Jenkinsfile
@@ -1,5 +1,5 @@
 def resolveProgetVersion(String product, String version, String label) {
-    def url = "http://proget.build.couchbase.com:8080/api/get_version?product=${product}&version=${version}&prerelease=true"
+    def url = "http://proget.build.couchbase.com:8080/api/latest_release?product=${product}&version=${version}&prerelease=true"
     echo "Resolving ${label}: ${url}"
     def resolved
     if (isUnix()) {
@@ -24,7 +24,7 @@ pipeline {
     }
     stages {
         stage('Init') {
-            agent { label 'mac-mini-new' }
+            agent any
             steps {
                 script {
                     if (params.CBL_VERSION == '') { error "CBL_VERSION is required" }

--- a/jenkins/pipelines/QE/sgw/Jenkinsfile
+++ b/jenkins/pipelines/QE/sgw/Jenkinsfile
@@ -18,7 +18,7 @@ def resolveProgetVersion(String product, String version, String label) {
 pipeline {
     agent none
     parameters {
-        string(name: 'CBL_VERSION', defaultValue: '4', description: 'Couchbase Lite Version to use')
+        string(name: 'CBL_VERSION', defaultValue: '3', description: 'Couchbase Lite Version to use')
         string(name: 'SGW_VERSION', defaultValue: '4', description: 'Sync Gateway Version to use')
     }
     stages {

--- a/jenkins/pipelines/QE/upg-sgw/Jenkinsfile
+++ b/jenkins/pipelines/QE/upg-sgw/Jenkinsfile
@@ -1,16 +1,29 @@
 pipeline {
     agent none
     parameters {
-        string(name: 'CBL_VERSION', defaultValue: '3.3.3', description: 'Couchbase Lite Version to use')
+        string(name: 'CBL_VERSION', defaultValue: '4', description: 'Couchbase Lite Version (major only auto-resolves via ProGet)')
+        string(name: 'CBL_PLATFORM', defaultValue: 'ios', description: 'Couchbase Lite platform for ProGet lookup')
         string(name: 'SGW_VERSIONS', defaultValue: '3.2.7 3.3.3 4.0.0', description: 'Sync Gateway Versions to upgrade across')
     }
     stages {
         stage('Init') {
+            agent any
             steps {
                 script {
                     if (params.CBL_VERSION == '') { error "CBL_VERSION is required" }
                     if (params.SGW_VERSIONS == '') { error "SGW_VERSIONS are required (atleast one)" }
-                    currentBuild.displayName = "CBL:${params.CBL_VERSION} SGW:${params.SGW_VERSIONS} (#${currentBuild.number})"
+
+                    def progetBase = 'http://proget.build.couchbase.com:8080/api/get_version'
+
+                    def cblVersion = sh(
+                        script: "curl -sf '${progetBase}?product=couchbase-lite-${params.CBL_PLATFORM}&version=${params.CBL_VERSION}&prerelease=true' | jq -r .version",
+                        returnStdout: true
+                    ).trim()
+                    if (!cblVersion || cblVersion == 'null') { error "Could not resolve CBL_VERSION from '${params.CBL_VERSION}'" }
+                    echo "Resolved CBL_VERSION: ${cblVersion}"
+                    env.CBL_VERSION = cblVersion
+
+                    currentBuild.displayName = "CBL:${env.CBL_VERSION} SGW:${params.SGW_VERSIONS} (#${currentBuild.number})"
                 }
             }
         }
@@ -19,7 +32,7 @@ pipeline {
                 build job: 'prebuild-test-server',
                 parameters: [
                     string(name: 'TS_PLATFORM', value: 'swift_ios'),
-                    string(name: 'CBL_VERSION', value: params.CBL_VERSION),
+                    string(name: 'CBL_VERSION', value: env.CBL_VERSION),
                 ],
                 wait: true,
                 propagate: true
@@ -37,7 +50,7 @@ pipeline {
                 sh "security unlock-keychain -p '${KEYCHAIN_PASSWORD}' ~/Library/Keychains/login.keychain-db"
                 echo "=== Run SGW Upgrades"
                 timeout(time: 90, unit: 'MINUTES') {
-                    sh "jenkins/pipelines/QE/upg-sgw/test.sh ${params.CBL_VERSION} ${params.SGW_VERSIONS}"
+                    sh "jenkins/pipelines/QE/upg-sgw/test.sh ${env.CBL_VERSION} ${params.SGW_VERSIONS}"
                 }
                 echo "=== SGW Upgrades Complete"
             }

--- a/jenkins/pipelines/QE/upg-sgw/Jenkinsfile
+++ b/jenkins/pipelines/QE/upg-sgw/Jenkinsfile
@@ -19,7 +19,6 @@ pipeline {
     agent none
     parameters {
         string(name: 'CBL_VERSION', defaultValue: '4', description: 'Couchbase Lite Version (major only auto-resolves via ProGet)')
-        string(name: 'CBL_PLATFORM', defaultValue: 'ios', description: 'Couchbase Lite platform for ProGet lookup')
         string(name: 'SGW_VERSIONS', defaultValue: '3.2.7 3.3.3 4.0.0', description: 'Sync Gateway Versions to upgrade across')
     }
     stages {
@@ -29,8 +28,7 @@ pipeline {
                 script {
                     if (params.CBL_VERSION == '') { error "CBL_VERSION is required" }
                     if (params.SGW_VERSIONS == '') { error "SGW_VERSIONS are required (atleast one)" }
-
-                    env.CBL_VERSION = resolveProgetVersion("couchbase-lite-${params.CBL_PLATFORM}", params.CBL_VERSION, 'CBL_VERSION')
+                    env.CBL_VERSION = resolveProgetVersion("couchbase-lite-ios", params.CBL_VERSION, 'CBL_VERSION')
                     currentBuild.displayName = "CBL:${env.CBL_VERSION} SGW:${params.SGW_VERSIONS} (#${currentBuild.number})"
                 }
             }

--- a/jenkins/pipelines/QE/upg-sgw/Jenkinsfile
+++ b/jenkins/pipelines/QE/upg-sgw/Jenkinsfile
@@ -1,5 +1,5 @@
 def resolveProgetVersion(String product, String version, String label) {
-    def url = "http://proget.build.couchbase.com:8080/api/get_version?product=${product}&version=${version}&prerelease=true"
+    def url = "http://proget.build.couchbase.com:8080/api/latest_release?product=${product}&version=${version}&prerelease=true"
     echo "Resolving ${label}: ${url}"
     def resolved
     if (isUnix()) {
@@ -24,7 +24,7 @@ pipeline {
     }
     stages {
         stage('Init') {
-            agent { label 'mac-mini-new' }
+            agent any
             steps {
                 script {
                     if (params.CBL_VERSION == '') { error "CBL_VERSION is required" }

--- a/jenkins/pipelines/QE/upg-sgw/Jenkinsfile
+++ b/jenkins/pipelines/QE/upg-sgw/Jenkinsfile
@@ -18,7 +18,7 @@ def resolveProgetVersion(String product, String version, String label) {
 pipeline {
     agent none
     parameters {
-        string(name: 'CBL_VERSION', defaultValue: '4', description: 'Couchbase Lite Version (major only auto-resolves via ProGet)')
+        string(name: 'CBL_VERSION', defaultValue: '3', description: 'Couchbase Lite Version (major only auto-resolves via ProGet)')
         string(name: 'SGW_VERSIONS', defaultValue: '3.2.7 3.3.3 4.0.0', description: 'Sync Gateway Versions to upgrade across')
     }
     stages {

--- a/jenkins/pipelines/QE/upg-sgw/Jenkinsfile
+++ b/jenkins/pipelines/QE/upg-sgw/Jenkinsfile
@@ -1,3 +1,16 @@
+def resolveProgetVersion(String product, String version, String label) {
+    def url = "http://proget.build.couchbase.com:8080/api/get_version?product=${product}&version=${version}&prerelease=true"
+    def resolved
+    if (isUnix()) {
+        resolved = sh(script: "curl -sf '${url}' | jq -r .version", returnStdout: true).trim()
+    } else {
+        resolved = powershell(script: "(Invoke-RestMethod '${url}').version", returnStdout: true).trim()
+    }
+    if (!resolved || resolved == 'null') { error "Could not resolve ${label} from '${version}'" }
+    echo "Resolved ${label}: ${resolved}"
+    return resolved
+}
+
 pipeline {
     agent none
     parameters {
@@ -13,16 +26,7 @@ pipeline {
                     if (params.CBL_VERSION == '') { error "CBL_VERSION is required" }
                     if (params.SGW_VERSIONS == '') { error "SGW_VERSIONS are required (atleast one)" }
 
-                    def progetBase = 'http://proget.build.couchbase.com:8080/api/get_version'
-
-                    def cblVersion = sh(
-                        script: "curl -sf '${progetBase}?product=couchbase-lite-${params.CBL_PLATFORM}&version=${params.CBL_VERSION}&prerelease=true' | jq -r .version",
-                        returnStdout: true
-                    ).trim()
-                    if (!cblVersion || cblVersion == 'null') { error "Could not resolve CBL_VERSION from '${params.CBL_VERSION}'" }
-                    echo "Resolved CBL_VERSION: ${cblVersion}"
-                    env.CBL_VERSION = cblVersion
-
+                    env.CBL_VERSION = resolveProgetVersion("couchbase-lite-${params.CBL_PLATFORM}", params.CBL_VERSION, 'CBL_VERSION')
                     currentBuild.displayName = "CBL:${env.CBL_VERSION} SGW:${params.SGW_VERSIONS} (#${currentBuild.number})"
                 }
             }

--- a/jenkins/pipelines/QE/upg-sgw/Jenkinsfile
+++ b/jenkins/pipelines/QE/upg-sgw/Jenkinsfile
@@ -1,12 +1,16 @@
 def resolveProgetVersion(String product, String version, String label) {
     def url = "http://proget.build.couchbase.com:8080/api/get_version?product=${product}&version=${version}&prerelease=true"
+    echo "Resolving ${label}: ${url}"
     def resolved
     if (isUnix()) {
         resolved = sh(script: "curl -sf '${url}' | jq -r .version", returnStdout: true).trim()
     } else {
-        resolved = powershell(script: "(Invoke-RestMethod '${url}').version", returnStdout: true).trim()
+        resolved = powershell(script: """
+            try { (Invoke-RestMethod '${url}').version }
+            catch { Write-Error "ProGet request failed for ${label}: \$_"; exit 1 }
+        """.stripIndent(), returnStdout: true).trim()
     }
-    if (!resolved || resolved == 'null') { error "Could not resolve ${label} from '${version}'" }
+    if (!resolved || resolved == 'null') { error "Could not resolve ${label} from '${version}' (url: ${url})" }
     echo "Resolved ${label}: ${resolved}"
     return resolved
 }
@@ -20,7 +24,7 @@ pipeline {
     }
     stages {
         stage('Init') {
-            agent any
+            agent { label 'mac-mini-new' }
             steps {
                 script {
                     if (params.CBL_VERSION == '') { error "CBL_VERSION is required" }

--- a/jenkins/pipelines/QE/upg-sgw/Jenkinsfile_rolling
+++ b/jenkins/pipelines/QE/upg-sgw/Jenkinsfile_rolling
@@ -1,16 +1,29 @@
 pipeline {
     agent none
     parameters {
-        string(name: 'CBL_VERSION', defaultValue: '3.3.3', description: 'Couchbase Lite Version to use')
+        string(name: 'CBL_VERSION', defaultValue: '3', description: 'Couchbase Lite Version (major only auto-resolves via ProGet)')
+        string(name: 'CBL_PLATFORM', defaultValue: 'ios', description: 'Couchbase Lite platform for ProGet lookup')
         string(name: 'SGW_VERSIONS', defaultValue: '3.2.7 3.3.3 3.3.4', description: 'Sync Gateway Versions to upgrade across')
     }
     stages {
         stage('Init') {
+            agent any
             steps {
                 script {
                     if (params.CBL_VERSION == '') { error "CBL_VERSION is required" }
                     if (params.SGW_VERSIONS == '') { error "SGW_VERSIONS are required (atleast one)" }
-                    currentBuild.displayName = "CBL:${params.CBL_VERSION} SGW:${params.SGW_VERSIONS} (#${currentBuild.number})"
+
+                    def progetBase = 'http://proget.build.couchbase.com:8080/api/get_version'
+
+                    def cblVersion = sh(
+                        script: "curl -sf '${progetBase}?product=couchbase-lite-${params.CBL_PLATFORM}&version=${params.CBL_VERSION}&prerelease=true' | jq -r .version",
+                        returnStdout: true
+                    ).trim()
+                    if (!cblVersion || cblVersion == 'null') { error "Could not resolve CBL_VERSION from '${params.CBL_VERSION}'" }
+                    echo "Resolved CBL_VERSION: ${cblVersion}"
+                    env.CBL_VERSION = cblVersion
+
+                    currentBuild.displayName = "CBL:${env.CBL_VERSION} SGW:${params.SGW_VERSIONS} (#${currentBuild.number})"
                 }
             }
         }
@@ -19,7 +32,7 @@ pipeline {
                 build job: 'prebuild-test-server',
                 parameters: [
                     string(name: 'TS_PLATFORM', value: 'swift_ios'),
-                    string(name: 'CBL_VERSION', value: params.CBL_VERSION),
+                    string(name: 'CBL_VERSION', value: env.CBL_VERSION),
                 ],
                 wait: true,
                 propagate: true
@@ -37,7 +50,7 @@ pipeline {
                 sh "security unlock-keychain -p '${KEYCHAIN_PASSWORD}' ~/Library/Keychains/login.keychain-db"
                 echo "=== Run SGW Upgrades"
                 timeout(time: 90, unit: 'MINUTES') {
-                    sh "jenkins/pipelines/QE/upg-sgw/test_rolling.sh ${params.CBL_VERSION} ${params.SGW_VERSIONS}"
+                    sh "jenkins/pipelines/QE/upg-sgw/test_rolling.sh ${env.CBL_VERSION} ${params.SGW_VERSIONS}"
                 }
                 echo "=== SGW Upgrades Complete"
             }

--- a/jenkins/pipelines/QE/upg-sgw/Jenkinsfile_rolling
+++ b/jenkins/pipelines/QE/upg-sgw/Jenkinsfile_rolling
@@ -1,3 +1,16 @@
+def resolveProgetVersion(String product, String version, String label) {
+    def url = "http://proget.build.couchbase.com:8080/api/get_version?product=${product}&version=${version}&prerelease=true"
+    def resolved
+    if (isUnix()) {
+        resolved = sh(script: "curl -sf '${url}' | jq -r .version", returnStdout: true).trim()
+    } else {
+        resolved = powershell(script: "(Invoke-RestMethod '${url}').version", returnStdout: true).trim()
+    }
+    if (!resolved || resolved == 'null') { error "Could not resolve ${label} from '${version}'" }
+    echo "Resolved ${label}: ${resolved}"
+    return resolved
+}
+
 pipeline {
     agent none
     parameters {
@@ -13,15 +26,7 @@ pipeline {
                     if (params.CBL_VERSION == '') { error "CBL_VERSION is required" }
                     if (params.SGW_VERSIONS == '') { error "SGW_VERSIONS are required (atleast one)" }
 
-                    def progetBase = 'http://proget.build.couchbase.com:8080/api/get_version'
-
-                    def cblVersion = sh(
-                        script: "curl -sf '${progetBase}?product=couchbase-lite-${params.CBL_PLATFORM}&version=${params.CBL_VERSION}&prerelease=true' | jq -r .version",
-                        returnStdout: true
-                    ).trim()
-                    if (!cblVersion || cblVersion == 'null') { error "Could not resolve CBL_VERSION from '${params.CBL_VERSION}'" }
-                    echo "Resolved CBL_VERSION: ${cblVersion}"
-                    env.CBL_VERSION = cblVersion
+                    env.CBL_VERSION = resolveProgetVersion("couchbase-lite-${params.CBL_PLATFORM}", params.CBL_VERSION, 'CBL_VERSION')
 
                     currentBuild.displayName = "CBL:${env.CBL_VERSION} SGW:${params.SGW_VERSIONS} (#${currentBuild.number})"
                 }

--- a/jenkins/pipelines/QE/upg-sgw/Jenkinsfile_rolling
+++ b/jenkins/pipelines/QE/upg-sgw/Jenkinsfile_rolling
@@ -1,5 +1,5 @@
 def resolveProgetVersion(String product, String version, String label) {
-    def url = "http://proget.build.couchbase.com:8080/api/get_version?product=${product}&version=${version}&prerelease=true"
+    def url = "http://proget.build.couchbase.com:8080/api/latest_release?product=${product}&version=${version}&prerelease=true"
     echo "Resolving ${label}: ${url}"
     def resolved
     if (isUnix()) {
@@ -24,7 +24,7 @@ pipeline {
     }
     stages {
         stage('Init') {
-            agent { label 'mac-mini-new' }
+            agent any
             steps {
                 script {
                     if (params.CBL_VERSION == '') { error "CBL_VERSION is required" }

--- a/jenkins/pipelines/QE/upg-sgw/Jenkinsfile_rolling
+++ b/jenkins/pipelines/QE/upg-sgw/Jenkinsfile_rolling
@@ -19,7 +19,6 @@ pipeline {
     agent none
     parameters {
         string(name: 'CBL_VERSION', defaultValue: '3', description: 'Couchbase Lite Version (major only auto-resolves via ProGet)')
-        string(name: 'CBL_PLATFORM', defaultValue: 'ios', description: 'Couchbase Lite platform for ProGet lookup')
         string(name: 'SGW_VERSIONS', defaultValue: '3.2.7 3.3.3 3.3.4', description: 'Sync Gateway Versions to upgrade across')
     }
     stages {
@@ -29,9 +28,7 @@ pipeline {
                 script {
                     if (params.CBL_VERSION == '') { error "CBL_VERSION is required" }
                     if (params.SGW_VERSIONS == '') { error "SGW_VERSIONS are required (atleast one)" }
-
-                    env.CBL_VERSION = resolveProgetVersion("couchbase-lite-${params.CBL_PLATFORM}", params.CBL_VERSION, 'CBL_VERSION')
-
+                    env.CBL_VERSION = resolveProgetVersion("couchbase-lite-ios", params.CBL_VERSION, 'CBL_VERSION')
                     currentBuild.displayName = "CBL:${env.CBL_VERSION} SGW:${params.SGW_VERSIONS} (#${currentBuild.number})"
                 }
             }

--- a/jenkins/pipelines/QE/upg-sgw/Jenkinsfile_rolling
+++ b/jenkins/pipelines/QE/upg-sgw/Jenkinsfile_rolling
@@ -1,12 +1,16 @@
 def resolveProgetVersion(String product, String version, String label) {
     def url = "http://proget.build.couchbase.com:8080/api/get_version?product=${product}&version=${version}&prerelease=true"
+    echo "Resolving ${label}: ${url}"
     def resolved
     if (isUnix()) {
         resolved = sh(script: "curl -sf '${url}' | jq -r .version", returnStdout: true).trim()
     } else {
-        resolved = powershell(script: "(Invoke-RestMethod '${url}').version", returnStdout: true).trim()
+        resolved = powershell(script: """
+            try { (Invoke-RestMethod '${url}').version }
+            catch { Write-Error "ProGet request failed for ${label}: \$_"; exit 1 }
+        """.stripIndent(), returnStdout: true).trim()
     }
-    if (!resolved || resolved == 'null') { error "Could not resolve ${label} from '${version}'" }
+    if (!resolved || resolved == 'null') { error "Could not resolve ${label} from '${version}' (url: ${url})" }
     echo "Resolved ${label}: ${resolved}"
     return resolved
 }
@@ -20,7 +24,7 @@ pipeline {
     }
     stages {
         stage('Init') {
-            agent any
+            agent { label 'mac-mini-new' }
             steps {
                 script {
                     if (params.CBL_VERSION == '') { error "CBL_VERSION is required" }


### PR DESCRIPTION
[CBG-5315](https://jira.issues.couchbase.com/browse/CBG-5315)

Using proget to parameterize the CBL version picking since its been a pain point for SGW jobs as they are run on a scheduled basis.

- This picks the CBL version via proget always
- Only SGW version via proget for sgw-functional pipeline.
- For SGW upgrade pipelines SGW version upgrade paths have to be predefined hence are not picked via proget.

[CBG-5315]: https://couchbasecloud.atlassian.net/browse/CBG-5315?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ