### PR TITLE
Migrate remaining chaos/MTLS/CRUD tests for edge server

### DIFF
--- a/client/src/cbltest/api/edgeserver.py
+++ b/client/src/cbltest/api/edgeserver.py
@@ -168,9 +168,15 @@ class EdgeServer:
         self, scheme: str, url: str, port: int, auth: BasicAuth | None
     ) -> ClientSession:
         if self.__secure:
-            ssl_context = ssl.create_default_context()
+            CERT_DIR = Path.home() / ".cbl_certs"
+            ssl_context = ssl.create_default_context(cafile=CERT_DIR / "ca_cert.pem")
             ssl_context.check_hostname = False
-            ssl_context.verify_mode = ssl.CERT_NONE
+            if self.__mtls:
+                ssl_context.load_cert_chain(
+                    certfile=str(CERT_DIR / "client_cert.pem"),
+                    keyfile=str(CERT_DIR / "client_key.pem"),
+                )
+
             return ClientSession(
                 f"{scheme}{url}:{port}",
                 auth=auth,
@@ -1047,6 +1053,12 @@ class EdgeServer:
     async def reset_firewall(self):
         with self.__tracer.start_as_current_span("reset firewall"):
             await self._send_request("post", "firewall", session=self.__shell_session)
+
+    async def get_ca(self):
+        with self.__tracer.start_as_current_span("get_ca"):
+            return await self._send_request(
+                "get", "get-ca", session=self.__shell_session
+            )
 
     async def add_user(self, name, password, role="admin"):
         with self.__tracer.start_as_current_span("Add user"):

--- a/client/src/cbltest/api/edgeserver.py
+++ b/client/src/cbltest/api/edgeserver.py
@@ -1054,12 +1054,6 @@ class EdgeServer:
         with self.__tracer.start_as_current_span("reset firewall"):
             await self._send_request("post", "firewall", session=self.__shell_session)
 
-    async def get_ca(self):
-        with self.__tracer.start_as_current_span("get_ca"):
-            return await self._send_request(
-                "get", "get-ca", session=self.__shell_session
-            )
-
     async def add_user(self, name, password, role="admin"):
         with self.__tracer.start_as_current_span("Add user"):
             await self.kill_server()

--- a/client/src/cbltest/configparser.py
+++ b/client/src/cbltest/configparser.py
@@ -149,7 +149,7 @@ class EdgeServerInfo:
         repo_root = next(
             p
             for p in (Path(__file__).resolve(), *Path(__file__).resolve().parents)
-            if "-lite-tests" in p.name
+            if "-lite-tests" in p.name or "-edge-server-pipeline" in p.name
         )
         return repo_root
 

--- a/client/src/cbltest/configparser.py
+++ b/client/src/cbltest/configparser.py
@@ -149,7 +149,7 @@ class EdgeServerInfo:
         repo_root = next(
             p
             for p in (Path(__file__).resolve(), *Path(__file__).resolve().parents)
-            if p.name == "couchbase-lite-tests"
+            if "-lite-tests" in p.name
         )
         return repo_root
 

--- a/environment/aws/common/x509_certificate.py
+++ b/environment/aws/common/x509_certificate.py
@@ -114,7 +114,7 @@ def create_signed_cert(cn: str, ca: CertKeyPair):
         .public_key(key.public_key())
         .serial_number(random_serial_number())
         .not_valid_before(datetime.now(timezone.utc))
-        .not_valid_after(datetime.now(timezone.utc) + timedelta(days=1))
+        .not_valid_after(datetime.now(timezone.utc) + timedelta(days=365))
         .add_extension(
             ExtendedKeyUsage([ExtendedKeyUsageOID.SERVER_AUTH]),
             critical=False,
@@ -137,7 +137,7 @@ def create_client_cert(cn: str, ca: CertKeyPair):
         .public_key(key.public_key())
         .serial_number(random_serial_number())
         .not_valid_before(datetime.now(timezone.utc))
-        .not_valid_after(datetime.now(timezone.utc) + timedelta(days=1))
+        .not_valid_after(datetime.now(timezone.utc) + timedelta(days=365))
         .add_extension(
             ExtendedKeyUsage([ExtendedKeyUsageOID.CLIENT_AUTH]),
             critical=False,

--- a/environment/aws/common/x509_certificate.py
+++ b/environment/aws/common/x509_certificate.py
@@ -9,6 +9,7 @@ from cryptography.hazmat.primitives.serialization import (
     pkcs12,
 )
 from cryptography.x509 import (
+    BasicConstraints,
     Certificate,
     CertificateBuilder,
     ExtendedKeyUsage,
@@ -79,3 +80,69 @@ def create_self_signed_certificate(CN: str) -> CertKeyPair:
     )
 
     return CertKeyPair(leaf_certificate, private_key)
+
+
+def create_ca():
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+    subject = issuer = Name([NameAttribute(NameOID.COMMON_NAME, "EdgeTestCA")])
+
+    cert = (
+        CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(issuer)
+        .public_key(key.public_key())
+        .serial_number(random_serial_number())
+        .not_valid_before(datetime.now(timezone.utc))
+        .not_valid_after(datetime.now(timezone.utc) + timedelta(days=365))
+        .add_extension(BasicConstraints(ca=True, path_length=None), critical=True)
+        .sign(key, hashes.SHA256())
+    )
+
+    return CertKeyPair(cert, key)
+
+
+def create_signed_cert(cn: str, ca: CertKeyPair):
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+    subject = Name([NameAttribute(NameOID.COMMON_NAME, cn)])
+
+    cert = (
+        CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(ca.certificate.subject)
+        .public_key(key.public_key())
+        .serial_number(random_serial_number())
+        .not_valid_before(datetime.now(timezone.utc))
+        .not_valid_after(datetime.now(timezone.utc) + timedelta(days=1))
+        .add_extension(
+            ExtendedKeyUsage([ExtendedKeyUsageOID.SERVER_AUTH]),
+            critical=False,
+        )
+        .sign(ca.private_key, hashes.SHA256())
+    )
+
+    return CertKeyPair(cert, key)
+
+
+def create_client_cert(cn: str, ca: CertKeyPair):
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+    subject = Name([NameAttribute(NameOID.COMMON_NAME, cn)])
+
+    cert = (
+        CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(ca.certificate.subject)
+        .public_key(key.public_key())
+        .serial_number(random_serial_number())
+        .not_valid_before(datetime.now(timezone.utc))
+        .not_valid_after(datetime.now(timezone.utc) + timedelta(days=1))
+        .add_extension(
+            ExtendedKeyUsage([ExtendedKeyUsageOID.CLIENT_AUTH]),
+            critical=False,
+        )
+        .sign(ca.private_key, hashes.SHA256())
+    )
+
+    return CertKeyPair(cert, key)

--- a/environment/aws/es_setup/setup_edge_servers.py
+++ b/environment/aws/es_setup/setup_edge_servers.py
@@ -35,7 +35,11 @@ from tqdm import tqdm
 
 from environment.aws.common.io import LIGHT_GRAY, sftp_progress_bar
 from environment.aws.common.output import header
-from environment.aws.common.x509_certificate import create_self_signed_certificate
+from environment.aws.common.x509_certificate import (
+    create_ca,
+    create_client_cert,
+    create_signed_cert,
+)
 from environment.aws.topology_setup.setup_topology import TopologyConfig
 
 SCRIPT_DIR = Path(__file__).resolve().parent
@@ -257,17 +261,43 @@ def setup_server(
         )
 
     sftp_progress_bar(sftp, SCRIPT_DIR / "Caddyfile", "/home/ec2-user/Caddyfile")
-    cert = create_self_signed_certificate(hostname)
+    ca = create_ca()
+    ca_cert = ca.pem_bytes()
+    cert = create_signed_cert(hostname, ca)
     cert_pem = cert.pem_bytes()
     key_pem = cert.private_pem_bytes()
+    client = create_client_cert("test-client", ca)
+    client_cert = client.pem_bytes()
+    client_key = client.private_pem_bytes()
+
     with open("/tmp/es_key.pem", "wb") as f:
         f.write(key_pem)
 
     with open("/tmp/es_cert.pem", "wb") as f:
         f.write(cert_pem)
 
+    with open("/tmp/ca_cert.pem", "wb") as f:
+        f.write(ca_cert)
+
+    CERT_DIR = Path.home() / ".cbl_certs"
+    CERT_DIR.mkdir(exist_ok=True)
+
+    client_cert_path = CERT_DIR / "client_cert.pem"
+    client_key_path = CERT_DIR / "client_key.pem"
+    ca_cert_path = CERT_DIR / "ca_cert.pem"
+
+    with open(client_cert_path, "wb") as f:
+        f.write(client_cert)
+
+    with open(client_key_path, "wb") as f:
+        f.write(client_key)
+
+    with open(ca_cert_path, "wb") as f:
+        f.write(ca_cert)
+
     sftp_progress_bar(sftp, Path("/tmp/es_cert.pem"), "/home/ec2-user/cert/es_cert.pem")
     sftp_progress_bar(sftp, Path("/tmp/es_key.pem"), "/home/ec2-user/cert/es_key.pem")
+    sftp_progress_bar(sftp, Path("/tmp/ca_cert.pem"), "/home/ec2-user/cert/ca_cert.pem")
     sftp_progress_bar(
         sftp,
         SCRIPT_DIR / "config" / "config.json",

--- a/jenkins/pipelines/QE/es/Jenkinsfile
+++ b/jenkins/pipelines/QE/es/Jenkinsfile
@@ -1,0 +1,59 @@
+pipeline {
+    agent none
+    parameters {
+        string(name: 'ES_VERSION', defaultValue: '1.0.1', description: 'Edge Server version')
+        string(name: 'TEST_NAME', defaultValue: 'test_crud.py', description: 'Test file to run')
+        string(name: 'TOPOLOGY_NAME', defaultValue: 'es_sgw_topology.json', description: 'Topology file name')
+        string(name: 'SGW_VERSION', defaultValue: '', description: 'Sync Gateway version (leave empty to skip SGW/CBS provisioning)')
+        string(name: 'CBS_VERSION', defaultValue: '', description: 'Couchbase Server version (leave empty to skip SGW/CBS provisioning)')
+        string(name: 'TS_DATASET_VERSION', defaultValue: '4.0', description: 'The version of the dataset to use on the test servers')
+    }
+    stages {
+        stage('Init') {
+            steps {
+                script {
+                    if (params.ES_VERSION == '') { error "ES_VERSION is required" }
+                    if (params.TEST_NAME == '') { error "TEST_NAME is required" }
+                    currentBuild.displayName = "ES:${params.ES_VERSION} (#${currentBuild.number})"
+                    currentBuild.description = "SGW: ${params.SGW_VERSION ?: 'none'} | CBS: ${params.CBS_VERSION ?: 'none'}"
+                }
+            }
+        }
+        stage('Run Test') {
+            agent { label 'mac-mini-new' }
+            environment {
+                KEYCHAIN_PASSWORD = credentials('mobile-qe')
+                PATH = "/opt/homebrew/opt/python@3.10/bin:/opt/homebrew/bin:/usr/local/bin:${env.PATH}"
+                TS_ARTIFACTS_DIR = 'es'
+                TS_DATASET_VERSION = "${params.TS_DATASET_VERSION}"
+            }
+            steps {
+                // Unlock keychain:
+                sh 'security unlock-keychain -p ${KEYCHAIN_PASSWORD} ~/Library/Keychains/login.keychain-db'
+                echo "=== Run Edge server Tests"
+                timeout(time: 60, unit: 'MINUTES') {
+                    sh """
+                        jenkins/pipelines/QE/es/test.sh \
+                            ${params.ES_VERSION} \
+                            ${params.TEST_NAME} \
+                            ${params.TOPOLOGY_NAME} \
+                            ${params.SGW_VERSION} \
+                            ${params.CBS_VERSION} \
+                            ${params.TS_DATASET_VERSION}
+                    """
+                }
+                echo "=== Edge server Tests Complete"
+            }
+            post {
+                always {
+                    echo "=== Teardown Edge server Tests"
+                    timeout(time: 5, unit: 'MINUTES') {
+                        sh "jenkins/pipelines/QE/es/teardown.sh"
+                    }
+                    archiveArtifacts artifacts: 'tests/QE/es/**/*', fingerprint: true, allowEmptyArchive: true
+                    echo "=== Edge server Test Teardown Complete"
+                }
+            }
+        }
+    }
+}

--- a/jenkins/pipelines/QE/es/setup_test.py
+++ b/jenkins/pipelines/QE/es/setup_test.py
@@ -5,11 +5,15 @@ from pathlib import Path
 from typing import Any
 
 import click
+SCRIPT_DIR = Path(os.path.dirname(os.path.realpath(__file__)))
+
+if __name__ == "__main__":
+    sys.path.append(str(SCRIPT_DIR.parents[3]))
+    if isinstance(sys.stdout, TextIOWrapper):
+        sys.stdout.reconfigure(encoding="utf-8")
 
 from environment.aws.start_backend import script_entry as start_backend
 from environment.aws.topology_setup.setup_topology import TopologyConfig
-
-SCRIPT_DIR = Path(__file__).resolve().parent
 
 
 def generate_topology(

--- a/jenkins/pipelines/QE/es/setup_test.py
+++ b/jenkins/pipelines/QE/es/setup_test.py
@@ -4,6 +4,7 @@ import json
 import os
 import sys
 from pathlib import Path
+from io import TextIOWrapper
 from typing import Any
 
 import click

--- a/jenkins/pipelines/QE/es/setup_test.py
+++ b/jenkins/pipelines/QE/es/setup_test.py
@@ -3,11 +3,12 @@
 import json
 import os
 import sys
-from pathlib import Path
 from io import TextIOWrapper
+from pathlib import Path
 from typing import Any
 
 import click
+
 SCRIPT_DIR = Path(os.path.dirname(os.path.realpath(__file__)))
 
 if __name__ == "__main__":

--- a/jenkins/pipelines/QE/es/setup_test.py
+++ b/jenkins/pipelines/QE/es/setup_test.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 
 import json
+import os
+import sys
 from pathlib import Path
 from typing import Any
 

--- a/jenkins/pipelines/QE/es/test.sh
+++ b/jenkins/pipelines/QE/es/test.sh
@@ -8,6 +8,7 @@ TEST_NAME="${2:-test_crud.py}"
 TOPOLOGY_NAME="${3:-es_sgw_topology.json}"
 SGW_VERSION="${4:-}"
 CBS_VERSION="${5:-}"
+DATASET_VERSION="${5:-4.0}"
 TOPOLOGY_FILE="$SCRIPT_DIR/topologies/$TOPOLOGY_NAME"
 
 if [ -z "$SGW_VERSION" ]; then
@@ -25,7 +26,7 @@ echo "RUNNING COORDINATED TEST"
 pushd "${QE_TESTS_DIR}/edge_server" > /dev/null
 export COLUMNS=200
 
-if uv run pytest -v --no-header -W ignore::DeprecationWarning --config ../config.json "$TEST_NAME"; then
+if uv run pytest -v --no-header -W ignore::DeprecationWarning --config ../config.json --dataset-version "$DATASET_VERSION" "$TEST_NAME"; then
     echo "========== PYTEST OUTPUT END =========="
     echo ""
     echo "🎉 COORDINATED TEST PASSED!"

--- a/spec/tests/QE/edge_server/test_authentication.md
+++ b/spec/tests/QE/edge_server/test_authentication.md
@@ -12,9 +12,11 @@ Test basic authentication with valid, invalid, and anonymous credentials.
 4. Set invalid credentials and verify fetching active tasks fails.
 5. Disable auth (anonymous) and verify fetching active tasks fails.
 
-## test_valid_tls
+## test_valid_tls_mtls
 
-Test TLS configuration for Edge Server.
+Test TLS and MTLS configurations for Edge Server.
 
 1. Configure Edge Server with the `names` dataset using TLS config.
 2. Fetch server version information and verify the call succeeds.
+3. Re-configure Edge Server with the `names` dataset using MTLS config.
+4. Fetch server version information and verify the call succeeds.

--- a/spec/tests/QE/edge_server/test_chaos_scenarios.md
+++ b/spec/tests/QE/edge_server/test_chaos_scenarios.md
@@ -33,4 +33,29 @@ Test multi-edge synchronization and recovery with chained replications.
 9. Kill Edge Server 1, update documents via Edge Servers 2/3, and verify replication.
 10. Kill Edge Servers 1 and 3, update documents via Edge Server 2, and verify replication.
 
+## test_edge_server_offline_sync_and_recovery
 
+Test the offline synchronization and recovery capabilities of a chained Edge Server topology.
+
+1. Configure Edge Server 1 to replicate from Sync Gateway for the `travel` dataset.
+2. Configure Edge Server 2 to replicate from Edge Server 1.
+3. Configure Edge Server 3 to replicate from Edge Server 2.
+4. Wait for replication to become idle across all Edge Servers.
+5. Delete all documents in the `travel.hotels` collection on Edge Server 3 using a bulk delete.
+6. Wait for replication to become idle, then kill Edge Server 3.
+7. Verify the documents are deleted in Edge Server 1, Edge Server 2, and Sync Gateway.
+8. Restart Edge Server 3 and wait for it to come online.
+9. Create 10,000 documents in `travel.hotels` via bulk create on Edge Server 3.
+10. Verify documents are created on Edge Server 3 and wait for replication to become idle.
+11. Kill Edge Server 3 again.
+12. Verify the created documents propagated successfully to Edge Server 2, Edge Server 1, and Sync Gateway.
+
+## test_edge_server_with_concurrent_rest_requests
+
+Test the stability and consistency of Edge Server under a randomized concurrent REST CRUD workload.
+
+1. Configure Edge Server with a database named `db`.
+2. Seed the database with 10,000 documents using bulk create operations.
+3. Verify the initial document load is successful and document counts match.
+4. Run a randomized CRUD workload for 1,000 iterations containing a mix of create, update, delete, and read operations.
+5. Perform final data consistency validation by verifying the documents on Edge Server match the expected state tracked locally.

--- a/spec/tests/QE/edge_server/test_chaos_scenarios.md
+++ b/spec/tests/QE/edge_server/test_chaos_scenarios.md
@@ -47,8 +47,7 @@ Test the offline synchronization and recovery capabilities of a chained Edge Ser
 8. Restart Edge Server 3 and wait for it to come online.
 9. Create 10,000 documents in `travel.hotels` via bulk create on Edge Server 3.
 10. Verify documents are created on Edge Server 3 and wait for replication to become idle.
-11. Kill Edge Server 3 again.
-12. Verify the created documents propagated successfully to Edge Server 2, Edge Server 1, and Sync Gateway.
+11. Verify the created documents propagated successfully to Edge Server 2, Edge Server 1, and Sync Gateway.
 
 ## test_edge_server_with_concurrent_rest_requests
 

--- a/spec/tests/QE/edge_server/test_crud.md
+++ b/spec/tests/QE/edge_server/test_crud.md
@@ -49,3 +49,15 @@ Test CRUD operations with document expiry (TTL).
 2. Create a document with TTL=20 seconds and verify retrieval fails after expiry.
 3. Create a document with TTL=50 seconds, update it with TTL=20 seconds, and verify retrieval fails after expiry.
 4. Create a document with TTL=60 seconds and delete it, then verify retrieval fails.
+
+## test_multiple_doc_crud
+
+Test bulk CRUD operations combining document creations, updates, and deletions in a single request.
+
+1. Configure Edge Server with the `names` database.
+2. Fetch existing documents to prepare a list of bulk changes.
+3. Prepare a bulk operation containing 10 document creations, 10 document updates, and 10 document deletions.
+4. Execute the bulk document operations on the Edge Server.
+5. Fetch the specifically created documents by key and verify all 10 exist.
+6. Fetch the updated documents by key and verify they exist with updated revisions.
+7. Fetch the deleted documents by key and verify they are no longer returned.

--- a/tests/QE/edge_server/config/test_mtls_config.json
+++ b/tests/QE/edge_server/config/test_mtls_config.json
@@ -1,0 +1,30 @@
+{
+    "$schema": "https://packages.couchbase.com/couchbase-edge-server/config_schema.json",
+    "interface": "0.0.0.0:59840",
+    "enable_anonymous_users": true,
+    "databases": {
+        "names":
+        {
+            "path": "/home/ec2-user/database/names.cblite2",
+            "create": true,
+            "enable_adhoc_queries": true,
+            "enable_client_writes": true,
+            "enable_client_sync": true
+        }
+    },
+  "https": {
+    "tls_cert_path": "/home/ec2-user/cert/es_cert.pem",
+    "tls_key_path": "/home/ec2-user/cert/es_key.pem",
+    "client_cert_path": "/home/ec2-user/cert/ca_cert.pem"
+  },
+  "logging": {
+        "console": false,
+        "file": {
+            "dir": "/home/ec2-user/log",
+            "format": "text"
+        },
+        "domains": {
+            "Listener": "info"
+        }
+    }
+}

--- a/tests/QE/edge_server/test_authentication.py
+++ b/tests/QE/edge_server/test_authentication.py
@@ -45,11 +45,19 @@ class TestAuthentication(CBLTestClass):
         assert failed, "No auth did not fail as expected"
 
     @pytest.mark.asyncio(loop_scope="session")
-    async def test_valid_tls(self, cblpytest: CBLPyTest, dataset_path: Path) -> None:
+    async def test_valid_tls_mtls(
+        self, cblpytest: CBLPyTest, dataset_path: Path
+    ) -> None:
         self.mark_test_step("test_valid_tls")
         edge_server = await cblpytest.edge_servers[0].configure_dataset(
             db_name="names", config_file=f"{SCRIPT_DIR}/config/test_tls_config.json"
         )
-        self.mark_test_step("get server information")
+        self.mark_test_step("get server information with TLS")
+        version = await edge_server.get_version()
+        self.mark_test_step(f"VERSION:{version}")
+        edge_server = await cblpytest.edge_servers[0].configure_dataset(
+            db_name="names", config_file=f"{SCRIPT_DIR}/config/test_mtls_config.json"
+        )
+        self.mark_test_step("get server information with TLS")
         version = await edge_server.get_version()
         self.mark_test_step(f"VERSION:{version}")

--- a/tests/QE/edge_server/test_authentication.py
+++ b/tests/QE/edge_server/test_authentication.py
@@ -54,10 +54,10 @@ class TestAuthentication(CBLTestClass):
         )
         self.mark_test_step("get server information with TLS")
         version = await edge_server.get_version()
-        self.mark_test_step(f"VERSION:{version}")
+        assert len(version.version) > 4, "invalid version fetched"
         edge_server = await cblpytest.edge_servers[0].configure_dataset(
             db_name="names", config_file=f"{SCRIPT_DIR}/config/test_mtls_config.json"
         )
-        self.mark_test_step("get server information with TLS")
+        self.mark_test_step("get server information with mTLS")
         version = await edge_server.get_version()
-        self.mark_test_step(f"VERSION:{version}")
+        assert len(version.version) > 4, "invalid version fetched"

--- a/tests/QE/edge_server/test_chaos_scenarios.py
+++ b/tests/QE/edge_server/test_chaos_scenarios.py
@@ -382,9 +382,6 @@ class TestEdgeServerChaos(CBLTestClass):
         await edge_server2.wait_for_idle()
         await edge_server3.wait_for_idle()
 
-        self.mark_test_step("Kill Edge Server 3 again")
-        await edge_server3.kill_server()
-
         self.mark_test_step("Verify create propagated to ES2, ES1, SGW")
         edge2_docs = await edge_server2.get_all_documents(
             "travel", collection="travel.hotels"
@@ -479,8 +476,8 @@ class TestEdgeServerChaos(CBLTestClass):
                     assert local_doc.get(key) == value
                 return True
 
-        except Exception as e:
-            return {"error": str(e), "optype": optype, "doc_id": doc_id}
+        except Exception:
+            return False
 
     @pytest.mark.asyncio(loop_scope="session")
     async def test_edge_server_with_concurrent_rest_requests(
@@ -504,7 +501,7 @@ class TestEdgeServerChaos(CBLTestClass):
         ]
         await edge_server.bulk_doc_op(bulk_ops, db_name="db")
 
-        self.mark_test_step("Verify initial document load")
+        self.mark_test_step("Verify initial document count of 10000")
         all_docs = await edge_server.get_all_documents(db_name="db")
         assert len(all_docs.rows) == docgen.size
 
@@ -514,7 +511,6 @@ class TestEdgeServerChaos(CBLTestClass):
         self.mark_test_step("Run randomized CRUD workload")
         for i in range(1000):
             op = random.choice(operations)
-            self.mark_test_step(f"Iteration {i}: {op}")
             assert await self.perform_operation(
                 edge_server,
                 op,
@@ -526,7 +522,9 @@ class TestEdgeServerChaos(CBLTestClass):
                 revmap=revmap,
             )
 
-        self.mark_test_step("Final consistency validation")
+        self.mark_test_step(
+            "Final consistency validation- actual document count vs expected document count"
+        )
         final_docs = await edge_server.get_all_documents(db_name="db")
         assert len(final_docs.rows) == len(docs), "Final document count mismatch"
 

--- a/tests/QE/edge_server/test_chaos_scenarios.py
+++ b/tests/QE/edge_server/test_chaos_scenarios.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import random
+import uuid
 from pathlib import Path
 
 import pytest
@@ -269,3 +270,253 @@ class TestEdgeServerChaos(CBLTestClass):
             edge1_docs.revmap,
             docs_list,
         )
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_edge_server_offline_sync_and_recovery(
+        self, cblpytest, dataset_path
+    ) -> None:
+        self.mark_test_step("Edge Server Offline Sync and Recovery")
+        cloud = cblpytest.simple_cloud()
+        await cloud.configure_dataset(dataset_path, "travel")
+        sgw = cblpytest.sync_gateways[0]
+        source_db = sgw.replication_url("travel")
+
+        self.mark_test_step("Configure Edge Server with travel dataset")
+        config_path = f"{SCRIPT_DIR}/config/test_sgw_edge_server.json"
+        with open(config_path, "r") as file:
+            config = json.load(file)
+        config["replications"][0]["source"] = source_db
+        with open(config_path, "w") as file:
+            json.dump(config, file, indent=4)
+        edge_server1 = await cblpytest.edge_servers[0].configure_dataset(
+            db_name="travel", config_file=config_path
+        )
+
+        config_path2 = f"{SCRIPT_DIR}/config/test_edge_to_edge_server.json"
+        source_db = edge_server1.replication_url("travel")
+        with open(config_path2, "r") as file:
+            config = json.load(file)
+        config["replications"][0]["source"] = source_db
+        with open(config_path2, "w") as file:
+            json.dump(config, file, indent=4)
+        edge_server2 = await cblpytest.edge_servers[1].configure_dataset(
+            db_name="travel", config_file=config_path2
+        )
+
+        source_db = edge_server2.replication_url("travel")
+        config["replications"][0]["source"] = source_db
+        with open(config_path2, "w") as file:
+            json.dump(config, file, indent=4)
+        edge_server3 = await cblpytest.edge_servers[2].configure_dataset(
+            db_name="travel", config_file=config_path2
+        )
+
+        self.mark_test_step("Monitor replication progress")
+        await edge_server1.wait_for_idle()
+        await edge_server2.wait_for_idle()
+        await edge_server3.wait_for_idle()
+
+        self.mark_test_step("Delete all docs in collection travel.hotels in es3")
+        all_docs = await edge_server3.get_all_documents(
+            db_name="travel", collection="travel.hotels"
+        )
+        revmap = all_docs.revmap
+        bulk_ops = [
+            BulkDocOperation({"_deleted": True}, _id=doc_id, rev=rev, optype="delete")
+            for doc_id, rev in revmap.items()
+        ]
+        await edge_server3.bulk_doc_op(bulk_ops, "travel", "travel", "hotels")
+        await edge_server1.wait_for_idle()
+        await edge_server2.wait_for_idle()
+        await edge_server3.wait_for_idle()
+        await edge_server3.kill_server()
+
+        self.mark_test_step("Verify document deleted")
+        edge2_docs = await edge_server2.get_all_documents(
+            "travel", collection="travel.hotels"
+        )
+        edge1_docs = await edge_server1.get_all_documents(
+            "travel", collection="travel.hotels"
+        )
+        sgw_docs = await sgw.get_all_documents(
+            "travel", scope="travel", collection="hotels"
+        )
+
+        assert (
+            len(edge1_docs.rows) == len(sgw_docs.rows) == len(edge2_docs.rows) == 0
+        ), (
+            f"Collection hotels count mismatch in len(edge1_docs.rows): {len(edge1_docs.rows)} ,  len(sgw_docs.rows): {len(sgw_docs.rows)}, len(edge2_docs.rows):  {len(edge2_docs.rows)}"
+        )
+
+        self.mark_test_step("Start ES3")
+        await edge_server3.start_server()
+        await asyncio.sleep(100)
+
+        self.mark_test_step("Test document inserts")
+        docgen = JSONGenerator(seed=10, size=10000)
+        create_docs = docgen.generate_all_documents()
+        bulk_ops = [
+            BulkDocOperation(body=doc, _id=id, optype="create")
+            for id, doc in create_docs.items()
+        ]
+        await edge_server3.bulk_doc_op(bulk_ops, "travel", "travel", "hotels")
+
+        self.mark_test_step("Verify document inserted")
+        all_docs = await edge_server3.get_all_documents(
+            db_name="travel", collection="travel.hotels"
+        )
+        assert len(all_docs.rows) == docgen.size, "Inserted document count mismatch"
+        await edge_server1.wait_for_idle()
+        await edge_server2.wait_for_idle()
+        await edge_server3.wait_for_idle()
+
+        await edge_server3.kill_server()
+
+        self.mark_test_step("Verify create propagated to ES2, Es1, SGW")
+        edge2_docs = await edge_server2.get_all_documents(
+            "travel", collection="travel.hotels"
+        )
+        edge1_docs = await edge_server1.get_all_documents(
+            "travel", collection="travel.hotels"
+        )
+        sgw_docs = await sgw.get_all_documents(
+            "travel", scope="travel", collection="hotels"
+        )
+
+        assert (
+            len(edge1_docs.rows)
+            == len(sgw_docs.rows)
+            == len(edge2_docs.rows)
+            == docgen.size
+        ), (
+            f"Collection hotels count mismatch in len(edge1_docs.rows): {len(edge1_docs.rows)} ,  len(sgw_docs.rows): {len(sgw_docs.rows)}, len(edge2_docs.rows):  {len(edge2_docs.rows)} and {docgen.size}"
+        )
+
+    async def perform_operation(
+        self, client, optype, docs_dict, docgen, db_name, scope, collection, revmap
+    ):
+        """Perform async CRUD operation based on random optype"""
+        doc_id = None
+
+        # Nothing to operate on (except create)
+        if optype != "create" and not docs_dict:
+            return True
+
+        try:
+            if optype == "create":
+                doc_id = str(uuid.uuid4())
+                new_doc = docgen.generate_document(doc_id)
+
+                response = await client.put_document_with_id(
+                    document=new_doc,
+                    db_name=db_name,
+                    scope=scope,
+                    collection=collection,
+                    doc_id=doc_id,
+                )
+
+                if response.get("ok"):
+                    docs_dict[doc_id] = new_doc
+                    revmap[doc_id] = response.get("rev")
+                return response.get("ok", False)
+
+            # Pick existing doc
+            doc_id = random.choice(list(docs_dict.keys()))
+
+            if optype == "update" and doc_id in revmap:
+                updated_doc = docgen.update_document(docs_dict[doc_id], doc_id)
+
+                response = await client.put_document_with_id(
+                    doc_id=doc_id,
+                    document=updated_doc,
+                    db_name=db_name,
+                    scope=scope,
+                    collection=collection,
+                    rev=revmap[doc_id],
+                )
+
+                if response.get("ok"):
+                    docs_dict[doc_id] = updated_doc
+                    revmap[doc_id] = response.get("rev")
+                return response.get("ok", False)
+
+            if optype == "delete" and doc_id in revmap:
+                response = await client.delete_document(
+                    doc_id,
+                    revid=revmap[doc_id],
+                    db_name=db_name,
+                    scope=scope,
+                    collection=collection,
+                )
+
+                if response.get("ok"):
+                    docs_dict.pop(doc_id, None)
+                    revmap.pop(doc_id, None)
+                return response.get("ok", False)
+
+            if optype == "read":
+                remote_doc = await client.get_document(
+                    db_name=db_name, scope=scope, collection=collection, doc_id=doc_id
+                )
+                local_doc = docs_dict.get(doc_id)
+                if not local_doc:
+                    return True  # deleted concurrently
+
+                for key, value in remote_doc.body.items():
+                    assert local_doc.get(key) == value
+                return True
+
+        except Exception as e:
+            return {"error": str(e), "optype": optype, "doc_id": doc_id}
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_edge_server_with_concurrent_rest_requests(
+        self, cblpytest, dataset_path
+    ) -> None:
+        self.mark_test_step("Edge Server with concurrent REST CRUD operations")
+
+        edge_server = await cblpytest.edge_servers[0].configure_dataset(
+            db_name="db",
+            config_file=f"{SCRIPT_DIR}/config/test_edge_server_with_multiple_rest_clients.json",
+        )
+
+        docgen = JSONGenerator(seed=10, size=10000)
+        docs = docgen.generate_all_documents()
+
+        # Seed database
+        bulk_ops = [
+            BulkDocOperation(body=doc, _id=doc_id, optype="create")
+            for doc_id, doc in docs.items()
+        ]
+        await edge_server.bulk_doc_op(bulk_ops, db_name="db")
+
+        self.mark_test_step("Verify initial document load")
+        all_docs = await edge_server.get_all_documents(db_name="db")
+        assert len(all_docs.rows) == docgen.size
+
+        revmap = all_docs.revmap
+        operations = ["create", "update", "delete", "read"]
+
+        self.mark_test_step("Run randomized CRUD workload")
+        for i in range(1000):
+            op = random.choice(operations)
+            self.mark_test_step(f"Iteration {i}: {op}")
+            assert await self.perform_operation(
+                edge_server,
+                op,
+                docs,
+                docgen,
+                db_name="db",
+                scope="",
+                collection="",
+                revmap=revmap,
+            )
+
+        self.mark_test_step("Final consistency validation")
+        final_docs = await edge_server.get_all_documents(db_name="db")
+        assert len(final_docs.rows) == len(docs), "Final document count mismatch"
+
+        for row in final_docs.rows:
+            assert docs.get(row.id), (
+                f"ID {row.id} exists on Edge server but not in local dict"
+            )

--- a/tests/QE/edge_server/test_chaos_scenarios.py
+++ b/tests/QE/edge_server/test_chaos_scenarios.py
@@ -281,7 +281,7 @@ class TestEdgeServerChaos(CBLTestClass):
         sgw = cblpytest.sync_gateways[0]
         source_db = sgw.replication_url("travel")
 
-        self.mark_test_step("Configure Edge Server with travel dataset")
+        self.mark_test_step("Configure Edge Server 1 to replicate from Sync Gateway for the `travel` dataset")
         config_path = f"{SCRIPT_DIR}/config/test_sgw_edge_server.json"
         with open(config_path, "r") as file:
             config = json.load(file)
@@ -291,7 +291,7 @@ class TestEdgeServerChaos(CBLTestClass):
         edge_server1 = await cblpytest.edge_servers[0].configure_dataset(
             db_name="travel", config_file=config_path
         )
-
+        self.mark_test_step("Configure Edge Server 2 to replicate from Edge Server 1")
         config_path2 = f"{SCRIPT_DIR}/config/test_edge_to_edge_server.json"
         source_db = edge_server1.replication_url("travel")
         with open(config_path2, "r") as file:
@@ -302,7 +302,7 @@ class TestEdgeServerChaos(CBLTestClass):
         edge_server2 = await cblpytest.edge_servers[1].configure_dataset(
             db_name="travel", config_file=config_path2
         )
-
+        self.mark_test_step("Configure Edge Server 3 to replicate from Edge Server 2")
         source_db = edge_server2.replication_url("travel")
         config["replications"][0]["source"] = source_db
         with open(config_path2, "w") as file:
@@ -311,7 +311,7 @@ class TestEdgeServerChaos(CBLTestClass):
             db_name="travel", config_file=config_path2
         )
 
-        self.mark_test_step("Monitor replication progress")
+        self.mark_test_step("Wait for replication to become idle across all Edge Servers")
         await edge_server1.wait_for_idle()
         await edge_server2.wait_for_idle()
         await edge_server3.wait_for_idle()
@@ -326,12 +326,14 @@ class TestEdgeServerChaos(CBLTestClass):
             for doc_id, rev in revmap.items()
         ]
         await edge_server3.bulk_doc_op(bulk_ops, "travel", "travel", "hotels")
+        self.mark_test_step("Wait for replication to become idle and validate deletes")
         await edge_server1.wait_for_idle()
         await edge_server2.wait_for_idle()
         await edge_server3.wait_for_idle()
+        self.mark_test_step("Kill Edge Server 3")
         await edge_server3.kill_server()
 
-        self.mark_test_step("Verify document deleted")
+        self.mark_test_step("Verify the documents are deleted in Edge Server 1, Edge Server 2, and Sync Gateway")
         edge2_docs = await edge_server2.get_all_documents(
             "travel", collection="travel.hotels"
         )
@@ -348,11 +350,11 @@ class TestEdgeServerChaos(CBLTestClass):
             f"Collection hotels count mismatch in len(edge1_docs.rows): {len(edge1_docs.rows)} ,  len(sgw_docs.rows): {len(sgw_docs.rows)}, len(edge2_docs.rows):  {len(edge2_docs.rows)}"
         )
 
-        self.mark_test_step("Start ES3")
+        self.mark_test_step("Restart Edge Server 3 and wait for it to come online")
         await edge_server3.start_server()
         await asyncio.sleep(100)
 
-        self.mark_test_step("Test document inserts")
+        self.mark_test_step("Create 10,000 documents in `travel.hotels` on Edge Server 3")
         docgen = JSONGenerator(seed=10, size=10000)
         create_docs = docgen.generate_all_documents()
         bulk_ops = [
@@ -361,7 +363,7 @@ class TestEdgeServerChaos(CBLTestClass):
         ]
         await edge_server3.bulk_doc_op(bulk_ops, "travel", "travel", "hotels")
 
-        self.mark_test_step("Verify document inserted")
+        self.mark_test_step("Verify documents are created on Edge Server 3 and wait for replication to become idle")
         all_docs = await edge_server3.get_all_documents(
             db_name="travel", collection="travel.hotels"
         )
@@ -370,9 +372,10 @@ class TestEdgeServerChaos(CBLTestClass):
         await edge_server2.wait_for_idle()
         await edge_server3.wait_for_idle()
 
+        self.mark_test_step("Kill Edge Server 3 again")
         await edge_server3.kill_server()
 
-        self.mark_test_step("Verify create propagated to ES2, Es1, SGW")
+        self.mark_test_step("Verify create propagated to ES2, ES1, SGW")
         edge2_docs = await edge_server2.get_all_documents(
             "travel", collection="travel.hotels"
         )
@@ -479,6 +482,7 @@ class TestEdgeServerChaos(CBLTestClass):
             db_name="db",
             config_file=f"{SCRIPT_DIR}/config/test_edge_server_with_multiple_rest_clients.json",
         )
+        self.mark_test_step("Seed the database with 10,000 documents")
 
         docgen = JSONGenerator(seed=10, size=10000)
         docs = docgen.generate_all_documents()

--- a/tests/QE/edge_server/test_chaos_scenarios.py
+++ b/tests/QE/edge_server/test_chaos_scenarios.py
@@ -281,7 +281,9 @@ class TestEdgeServerChaos(CBLTestClass):
         sgw = cblpytest.sync_gateways[0]
         source_db = sgw.replication_url("travel")
 
-        self.mark_test_step("Configure Edge Server 1 to replicate from Sync Gateway for the `travel` dataset")
+        self.mark_test_step(
+            "Configure Edge Server 1 to replicate from Sync Gateway for the `travel` dataset"
+        )
         config_path = f"{SCRIPT_DIR}/config/test_sgw_edge_server.json"
         with open(config_path, "r") as file:
             config = json.load(file)
@@ -311,7 +313,9 @@ class TestEdgeServerChaos(CBLTestClass):
             db_name="travel", config_file=config_path2
         )
 
-        self.mark_test_step("Wait for replication to become idle across all Edge Servers")
+        self.mark_test_step(
+            "Wait for replication to become idle across all Edge Servers"
+        )
         await edge_server1.wait_for_idle()
         await edge_server2.wait_for_idle()
         await edge_server3.wait_for_idle()
@@ -333,7 +337,9 @@ class TestEdgeServerChaos(CBLTestClass):
         self.mark_test_step("Kill Edge Server 3")
         await edge_server3.kill_server()
 
-        self.mark_test_step("Verify the documents are deleted in Edge Server 1, Edge Server 2, and Sync Gateway")
+        self.mark_test_step(
+            "Verify the documents are deleted in Edge Server 1, Edge Server 2, and Sync Gateway"
+        )
         edge2_docs = await edge_server2.get_all_documents(
             "travel", collection="travel.hotels"
         )
@@ -354,7 +360,9 @@ class TestEdgeServerChaos(CBLTestClass):
         await edge_server3.start_server()
         await asyncio.sleep(100)
 
-        self.mark_test_step("Create 10,000 documents in `travel.hotels` on Edge Server 3")
+        self.mark_test_step(
+            "Create 10,000 documents in `travel.hotels` on Edge Server 3"
+        )
         docgen = JSONGenerator(seed=10, size=10000)
         create_docs = docgen.generate_all_documents()
         bulk_ops = [
@@ -363,7 +371,9 @@ class TestEdgeServerChaos(CBLTestClass):
         ]
         await edge_server3.bulk_doc_op(bulk_ops, "travel", "travel", "hotels")
 
-        self.mark_test_step("Verify documents are created on Edge Server 3 and wait for replication to become idle")
+        self.mark_test_step(
+            "Verify documents are created on Edge Server 3 and wait for replication to become idle"
+        )
         all_docs = await edge_server3.get_all_documents(
             db_name="travel", collection="travel.hotels"
         )

--- a/tests/QE/edge_server/test_crud.py
+++ b/tests/QE/edge_server/test_crud.py
@@ -190,7 +190,9 @@ class TestCrud(CBLTestClass):
             config_file=f"{SCRIPT_DIR}/config/adhoc_disabled_config.json",
         )
 
-        self.mark_test_step("Fetch existing documents to prepare a list of bulk changes")
+        self.mark_test_step(
+            "Fetch existing documents to prepare a list of bulk changes"
+        )
         db_name = "names"
         all_docs = await edge_server.get_all_documents(db_name=db_name)
 

--- a/tests/QE/edge_server/test_crud.py
+++ b/tests/QE/edge_server/test_crud.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import pytest
 from cbltest import CBLPyTest
 from cbltest.api.cbltestclass import CBLTestClass
+from cbltest.api.edgeserver import BulkDocOperation
 
 SCRIPT_DIR = str(Path(__file__).parent)
 
@@ -177,3 +178,63 @@ class TestCrud(CBLTestClass):
             self.mark_test_step(
                 f"Deleted doc successfully threw exception on retrieval: {e}"
             )
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_multiple_doc_crud(
+        self, cblpytest: CBLPyTest, dataset_path: Path
+    ) -> None:
+        self.mark_test_step("test_multiple_doc_crud")
+
+        edge_server = await cblpytest.edge_servers[0].configure_dataset(
+            db_name="names",
+            config_file=f"{SCRIPT_DIR}/config/adhoc_disabled_config.json",
+        )
+
+        self.mark_test_step("Prepare multiple CRUD operations")
+        db_name = "names"
+        all_docs = await edge_server.get_all_documents(db_name=db_name)
+
+        bulk_changes = []
+        created, deleted, updated = [], [], []
+
+        for i in range(1, 11):
+            new_id = f"doc_{i + 200}"
+            bulk_changes.append(BulkDocOperation(_id=new_id, body={"rev": 1, "idx": i}))
+            created.append(new_id)
+
+            bulk_changes.append(
+                BulkDocOperation(
+                    _id=all_docs.rows[i].id,
+                    body={},
+                    rev=all_docs.rows[i].revid,
+                    optype="delete",
+                )
+            )
+            deleted.append(all_docs.rows[i].id)
+
+            bulk_changes.append(
+                BulkDocOperation(
+                    _id=all_docs.rows[i + 50].id,
+                    body={"rev": 2, "idx": i + 50},
+                    rev=all_docs.rows[i + 50].revid,
+                    optype="update",
+                )
+            )
+            updated.append(all_docs.rows[i + 50].id)
+
+        self.mark_test_step("Execute bulk document operations")
+        await edge_server.bulk_doc_op(docs=bulk_changes, db_name=db_name)
+
+        self.mark_test_step("Verify created documents")
+        create_task = await edge_server.get_all_documents(db_name=db_name, keys=created)
+        assert len(create_task) == 10, "Created documents missing"
+
+        self.mark_test_step("Verify updated documents")
+        update_task = await edge_server.get_all_documents(db_name=db_name, keys=updated)
+        assert len(update_task) == 10, "Updated documents missing"
+        for row in update_task.rows:
+            assert row.revid.startswith("2")
+
+        self.mark_test_step("Verify deleted documents")
+        delete_task = await edge_server.get_all_documents(db_name=db_name, keys=deleted)
+        assert len(delete_task) == 0, "Deleted documents still exist"

--- a/tests/QE/edge_server/test_crud.py
+++ b/tests/QE/edge_server/test_crud.py
@@ -183,8 +183,6 @@ class TestCrud(CBLTestClass):
     async def test_multiple_doc_crud(
         self, cblpytest: CBLPyTest, dataset_path: Path
     ) -> None:
-        self.mark_test_step("test_multiple_doc_crud")
-
         edge_server = await cblpytest.edge_servers[0].configure_dataset(
             db_name="names",
             config_file=f"{SCRIPT_DIR}/config/adhoc_disabled_config.json",
@@ -225,19 +223,18 @@ class TestCrud(CBLTestClass):
             )
             updated.append(all_docs.rows[i + 50].id)
 
-        self.mark_test_step("Execute bulk document operations")
+        self.mark_test_step(
+            "Execute bulk document operations, verify creations, updates and deletions - actual document count vs expected doc count"
+        )
         await edge_server.bulk_doc_op(docs=bulk_changes, db_name=db_name)
 
-        self.mark_test_step("Validate the specifically created documents")
         create_task = await edge_server.get_all_documents(db_name=db_name, keys=created)
         assert len(create_task) == 10, "Created documents missing"
 
-        self.mark_test_step("Validate the specifically updated documents")
         update_task = await edge_server.get_all_documents(db_name=db_name, keys=updated)
         assert len(update_task) == 10, "Updated documents missing"
         for row in update_task.rows:
             assert row.revid.startswith("2")
 
-        self.mark_test_step("Validate the specifically deleted documents")
         delete_task = await edge_server.get_all_documents(db_name=db_name, keys=deleted)
         assert len(delete_task) == 0, "Deleted documents still exist"

--- a/tests/QE/edge_server/test_crud.py
+++ b/tests/QE/edge_server/test_crud.py
@@ -190,12 +190,13 @@ class TestCrud(CBLTestClass):
             config_file=f"{SCRIPT_DIR}/config/adhoc_disabled_config.json",
         )
 
-        self.mark_test_step("Prepare multiple CRUD operations")
+        self.mark_test_step("Fetch existing documents to prepare a list of bulk changes")
         db_name = "names"
         all_docs = await edge_server.get_all_documents(db_name=db_name)
 
         bulk_changes = []
         created, deleted, updated = [], [], []
+        self.mark_test_step("Prepare a bulk CRUD operation")
 
         for i in range(1, 11):
             new_id = f"doc_{i + 200}"
@@ -225,16 +226,16 @@ class TestCrud(CBLTestClass):
         self.mark_test_step("Execute bulk document operations")
         await edge_server.bulk_doc_op(docs=bulk_changes, db_name=db_name)
 
-        self.mark_test_step("Verify created documents")
+        self.mark_test_step("Validate the specifically created documents")
         create_task = await edge_server.get_all_documents(db_name=db_name, keys=created)
         assert len(create_task) == 10, "Created documents missing"
 
-        self.mark_test_step("Verify updated documents")
+        self.mark_test_step("Validate the specifically updated documents")
         update_task = await edge_server.get_all_documents(db_name=db_name, keys=updated)
         assert len(update_task) == 10, "Updated documents missing"
         for row in update_task.rows:
             assert row.revid.startswith("2")
 
-        self.mark_test_step("Verify deleted documents")
+        self.mark_test_step("Validate the specifically deleted documents")
         delete_task = await edge_server.get_all_documents(db_name=db_name, keys=deleted)
         assert len(delete_task) == 0, "Deleted documents still exist"


### PR DESCRIPTION
- Introduced CA-based TLS and mTLS support
- Added certificate generation utilities and updated ES setup to provision CA, server, and client certs
- Added mTLS test coverage
- Added chaos tests: test_edge_server_offline_sync_and_recovery and test_edge_server_with_concurrent_rest_requests
- Added Bulk doc CRUD test
