### PR TITLE
Make Sync Gateway version comparison robust for dev builds

### DIFF
--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "opentelemetry-sdk==1.29.0",
     "opentelemetry-semantic-conventions==0.50b0",
     "packaging==24.2",
+    "pydantic>=2.13.3",
     "pyjson5==1.6.8",
     "pytest==9.0.2",
     "pytest-asyncio==1.3.0",

--- a/client/src/cbltest/api/syncgateway.py
+++ b/client/src/cbltest/api/syncgateway.py
@@ -678,7 +678,7 @@ class _SyncGatewayBase:
             return ret_val
 
     async def supports_version_vectors(self) -> bool:
-        """Returns whether the Sync Gateway instance supports version vectors (i.e. is 3.0 or later)"""
+        """Returns whether the Sync Gateway instance supports version vectors (i.e. is 4.0 or later)"""
         version = await self.get_version()
         return packaging.version.parse(version.version) >= packaging.version.parse(
             "4.0"
@@ -692,7 +692,8 @@ class _SyncGatewayBase:
         # In a dev build /_status "version" does not contain major.minor so use model.vendor.version
         if model.vendor.version in model.version:
             sg_version = SyncGatewayVersion(model.version)
-        sg_version = SyncGatewayVersion(model.vendor.version)
+        else:
+            sg_version = SyncGatewayVersion(model.vendor.version)
         assert packaging.version.parse(sg_version.version), (
             "Failed to parse Sync Gateway version from /_status response {model}"
         )

--- a/client/src/cbltest/api/syncgateway.py
+++ b/client/src/cbltest/api/syncgateway.py
@@ -694,9 +694,13 @@ class _SyncGatewayBase:
             sg_version = SyncGatewayVersion(model.version)
         else:
             sg_version = SyncGatewayVersion(model.vendor.version)
-        assert packaging.version.parse(sg_version.version), (
-            "Failed to parse Sync Gateway version from /_status response {model}"
-        )
+        try:
+            packaging.version.parse(sg_version.version)
+        except packaging.version.InvalidVersion as exc:
+            raise CblTestError(
+                "Failed to parse Sync Gateway version from /_status response: {resp}\n"
+                f"version={model.version}"
+            ) from exc
         return sg_version
 
     def tls_cert(self) -> str | None:

--- a/client/src/cbltest/api/syncgateway.py
+++ b/client/src/cbltest/api/syncgateway.py
@@ -7,11 +7,13 @@ from pathlib import Path
 from typing import Any, cast
 from urllib.parse import urljoin
 
+import packaging.version
 import requests
 import tenacity
 from aiohttp import BasicAuth, ClientError, ClientSession, ClientTimeout, TCPConnector
 from aiohttp.client_exceptions import ClientConnectorError
 from opentelemetry.trace import get_tracer
+from pydantic import BaseModel
 
 from cbltest.api.error import CblSyncGatewayBadResponseError, CblTestError
 from cbltest.api.jsonserializable import JSONDictionary, JSONSerializable
@@ -486,6 +488,9 @@ class CouchbaseVersion(ABC):
         self.__version = parsed[0]
         self.__build_number = parsed[1]
 
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}({self.__raw})"
+
 
 class SyncGatewayVersion(CouchbaseVersion):
     """
@@ -496,7 +501,7 @@ class SyncGatewayVersion(CouchbaseVersion):
         first_lparen = input.find("(")
         first_semicol = input.find(";")
         if first_lparen == -1 or first_semicol == -1:
-            return ("unknown", 0)
+            return input, 0
 
         version = input[0:first_lparen].strip()
         if not version:
@@ -512,6 +517,24 @@ class SyncGatewayVersion(CouchbaseVersion):
             build = 0
 
         return (version, build)
+
+
+class SyncGatewayStatusVendor(BaseModel):
+    """
+    Output of vendor field of /_status endpoint of Sync Gateway
+    """
+
+    name: str
+    version: str
+
+
+class SyncGatewayStatusResponse(BaseModel):
+    """
+    Output of GET /_status endpoint of Sync Gateway
+    """
+
+    version: str  # this version does not always include the full build number if it is a dev build
+    vendor: SyncGatewayStatusVendor
 
 
 class DatabaseStatusResponse:
@@ -553,12 +576,13 @@ class _SyncGatewayBase:
         password: str,
         port: int,
         secure: bool = False,
+        public_port: int = 4984,
     ):
         scheme = "https://" if secure else "http://"
         ws_scheme = "wss://" if secure else "ws://"
         self.__http_url = f"{scheme}{url}:{port}"
-        # Replication always uses public port 4984
-        self.__replication_url = f"{ws_scheme}{url}:4984"
+        self.__public_port = public_port
+        self.__replication_url = f"{ws_scheme}{url}:{public_port}"
         self._tracer = get_tracer(__name__, VERSION)
         self.__secure: bool = secure
         self.__hostname: str = url
@@ -580,6 +604,11 @@ class _SyncGatewayBase:
     def port(self) -> int:
         """Gets the HTTP API port of the Sync Gateway instance"""
         return self.__port
+
+    @property
+    def public_port(self) -> int:
+        """Gets the public API port of the Sync Gateway instance"""
+        return self.__public_port
 
     @property
     def secure(self) -> bool:
@@ -648,23 +677,26 @@ class _SyncGatewayBase:
 
             return ret_val
 
-    async def get_version(self) -> CouchbaseVersion:
-        # Telemetry not really important for this call
-        async with self._create_session(
-            self.secure, self.scheme, self.hostname, 4984, None
-        ) as s:
-            resp = await self._send_request("get", "/", session=s)
-            assert isinstance(resp, dict)
-            resp_dict = cast(dict, resp)
-            raw_version = _get_typed_required(resp_dict, "version", str)
-            if "/" in raw_version:
-                version_part = raw_version.rsplit("/", 1)[1]
-            else:
-                cbl_warning(
-                    f"Unexpected SGW version format (no '/' separator): '{raw_version}'"
-                )
-                version_part = raw_version
-            return SyncGatewayVersion(version_part)
+    async def supports_version_vectors(self) -> bool:
+        """Returns whether the Sync Gateway instance supports version vectors (i.e. is 3.0 or later)"""
+        version = await self.get_version()
+        return packaging.version.parse(version.version) >= packaging.version.parse(
+            "4.0"
+        )
+
+    async def get_version(self) -> SyncGatewayVersion:
+        """Return version of Sync Gateway"""
+        resp = await self._send_request("get", "/_status")
+        assert isinstance(resp, dict)
+        model = SyncGatewayStatusResponse.model_validate(resp)
+        # In a dev build /_status "version" does not contain major.minor so use model.vendor.version
+        if model.vendor.version in model.version:
+            sg_version = SyncGatewayVersion(model.version)
+        sg_version = SyncGatewayVersion(model.vendor.version)
+        assert packaging.version.parse(sg_version.version), (
+            "Failed to parse Sync Gateway version from /_status response {model}"
+        )
+        return sg_version
 
     def tls_cert(self) -> str | None:
         if not self.secure:
@@ -1355,7 +1387,7 @@ class _SyncGatewayBase:
         params = {"rev": revision}
 
         async with self._create_session(
-            self.secure, self.scheme, self.hostname, 4984, auth
+            self.secure, self.scheme, self.hostname, self.public_port, auth
         ) as session:
             return await self._send_request("GET", path, params=params, session=session)
 
@@ -1621,8 +1653,7 @@ class SyncGateway(_SyncGatewayBase):
         :param secure: Whether to use TLS/HTTPS
         :param public_port: Public API port (default 4984)
         """
-        super().__init__(url, username, password, port, secure)
-        self.__public_port = public_port
+        super().__init__(url, username, password, port, secure, public_port)
         r = requests.get(
             f"{self.scheme}{url}:{port}/_config",
             auth=(username, password),
@@ -1866,11 +1897,11 @@ class SyncGateway(_SyncGatewayBase):
         :param config_name: Name of the config file (without .json extension).
         :raises Exception: If the start fails
         """
-        # Check if SGW is already running by probing the public endpoint (4984)
+        # Check if SGW is already running by probing the public endpoint
         try:
             # Use a short timeout to distinguish "not running" from "slow"
             async with self._create_session(
-                self.secure, self.scheme, self.hostname, 4984, None
+                self.secure, self.scheme, self.hostname, self.public_port, None
             ) as session:
                 async with session.get("/", timeout=ClientTimeout(total=5)) as resp:
                     if resp.status == 200:
@@ -2002,7 +2033,7 @@ class SyncGateway(_SyncGatewayBase):
             self.hostname,
             username,
             password,
-            port=self.__public_port,
+            port=self.public_port,
             secure=self.secure,
         )
 
@@ -2143,4 +2174,4 @@ class SyncGatewayUserClient(_SyncGatewayBase):
         :param port: Public API port (default 4984)
         :param secure: Whether to use TLS/HTTPS
         """
-        super().__init__(url, username, password, port, secure)
+        super().__init__(url, username, password, port, secure, port)

--- a/client/src/cbltest/api/syncgateway.py
+++ b/client/src/cbltest/api/syncgateway.py
@@ -498,25 +498,28 @@ class SyncGatewayVersion(CouchbaseVersion):
     """
 
     def parse(self, input: str) -> tuple[str, int]:
-        first_lparen = input.find("(")
-        first_semicol = input.find(";")
-        if first_lparen == -1 or first_semicol == -1:
-            return input, 0
-
-        version = input[0:first_lparen].strip()
-        if not version:
+        m = re.match(r"^[^(\n]+", input)
+        if m:
+            version = m.group().strip()
+        else:
             cbl_warning(f"Could not extract version from SGW version string: '{input}'")
             version = "unknown"
 
-        try:
-            build = int(input[first_lparen + 1 : first_semicol])
-        except ValueError:
+        m = re.search(r"(?<=\()([^;)]+)", input)
+        if m:
+            try:
+                build = int(m.group())
+            except ValueError as e:
+                cbl_warning(
+                    f"Could not parse build number {m.group()} from SGW version string: '{input}': {e}"
+                )
+                build = 0
+        else:
             cbl_warning(
                 f"Could not parse build number from SGW version string: '{input}'"
             )
             build = 0
-
-        return (version, build)
+        return version, build
 
 
 class SyncGatewayStatusVendor(BaseModel):

--- a/client/src/cbltest/api/syncgateway.py
+++ b/client/src/cbltest/api/syncgateway.py
@@ -498,13 +498,23 @@ class SyncGatewayVersion(CouchbaseVersion):
     """
 
     def parse(self, input: str) -> tuple[str, int]:
-        m = re.match(r"^[^(\n]+", input)
+        # Version parsing can be different for dev builds and release builds. In a dev build, it is possible to miss a build number.
+        #
+        # Example input:
+        #   Couchbase Sync Gateway/4.0.0(350;def456)
+        #   4.0.0(350;def456)
+        #   4.0.0
+
+        # extract everything between an optional / and an option ( to represent a major.minor.patch build number
+        m = re.search(r"(?:^|/)([\d\.]+)(?=\s*\(|$)", input)
+        # (?:^|/)(?P<v>[\d\.]+)(?:\s*\(|$)", input)
         if m:
-            version = m.group().strip()
+            version = m.group(1).strip()
         else:
             cbl_warning(f"Could not extract version from SGW version string: '{input}'")
             version = "unknown"
 
+        # extract everything between ( and a ; character to guess at a build number
         m = re.search(r"(?<=\()([^;)]+)", input)
         if m:
             try:
@@ -579,13 +589,12 @@ class _SyncGatewayBase:
         password: str,
         port: int,
         secure: bool = False,
-        public_port: int = 4984,
     ):
         scheme = "https://" if secure else "http://"
         ws_scheme = "wss://" if secure else "ws://"
         self.__http_url = f"{scheme}{url}:{port}"
-        self.__public_port = public_port
-        self.__replication_url = f"{ws_scheme}{url}:{public_port}"
+        # Replication always uses public port 4984
+        self.__replication_url = f"{ws_scheme}{url}:4984"
         self._tracer = get_tracer(__name__, VERSION)
         self.__secure: bool = secure
         self.__hostname: str = url
@@ -607,11 +616,6 @@ class _SyncGatewayBase:
     def port(self) -> int:
         """Gets the HTTP API port of the Sync Gateway instance"""
         return self.__port
-
-    @property
-    def public_port(self) -> int:
-        """Gets the public API port of the Sync Gateway instance"""
-        return self.__public_port
 
     @property
     def secure(self) -> bool:
@@ -692,7 +696,24 @@ class _SyncGatewayBase:
         resp = await self._send_request("get", "/_status")
         assert isinstance(resp, dict)
         model = SyncGatewayStatusResponse.model_validate(resp)
-        # In a dev build /_status "version" does not contain major.minor so use model.vendor.version
+
+        # In the case of a dev build, it is not possible to determine a build number, but there is a
+        # major.minor version.
+        # There only backward compatible difference is if "vendor.version" substring is contained in "version""
+
+        # In a production build, the output:
+        #
+        # "vendor": {
+        #    "version": "4.0"
+        # },
+        # "version": "Couchbase Sync Gateway/4.0.4(8;release) EE"
+        #
+        # In a dev build, the output:
+        #
+        # "vendor": {
+        #    "version": "4.0"
+        # },
+        # "version": "Couchbase Sync Gateway/() EE"
         if model.vendor.version in model.version:
             sg_version = SyncGatewayVersion(model.version)
         else:
@@ -1395,7 +1416,7 @@ class _SyncGatewayBase:
         params = {"rev": revision}
 
         async with self._create_session(
-            self.secure, self.scheme, self.hostname, self.public_port, auth
+            self.secure, self.scheme, self.hostname, 4984, auth
         ) as session:
             return await self._send_request("GET", path, params=params, session=session)
 
@@ -1661,7 +1682,8 @@ class SyncGateway(_SyncGatewayBase):
         :param secure: Whether to use TLS/HTTPS
         :param public_port: Public API port (default 4984)
         """
-        super().__init__(url, username, password, port, secure, public_port)
+        super().__init__(url, username, password, port, secure)
+        self.__public_port = public_port
         r = requests.get(
             f"{self.scheme}{url}:{port}/_config",
             auth=(username, password),
@@ -1905,11 +1927,11 @@ class SyncGateway(_SyncGatewayBase):
         :param config_name: Name of the config file (without .json extension).
         :raises Exception: If the start fails
         """
-        # Check if SGW is already running by probing the public endpoint
+        # Check if SGW is already running by probing the public endpoint (4984)
         try:
             # Use a short timeout to distinguish "not running" from "slow"
             async with self._create_session(
-                self.secure, self.scheme, self.hostname, self.public_port, None
+                self.secure, self.scheme, self.hostname, 4984, None
             ) as session:
                 async with session.get("/", timeout=ClientTimeout(total=5)) as resp:
                     if resp.status == 200:
@@ -2041,7 +2063,7 @@ class SyncGateway(_SyncGatewayBase):
             self.hostname,
             username,
             password,
-            port=self.public_port,
+            port=self.__public_port,
             secure=self.secure,
         )
 
@@ -2182,4 +2204,4 @@ class SyncGatewayUserClient(_SyncGatewayBase):
         :param port: Public API port (default 4984)
         :param secure: Whether to use TLS/HTTPS
         """
-        super().__init__(url, username, password, port, secure, port)
+        super().__init__(url, username, password, port, secure)

--- a/client/tests/test_version_parsing.py
+++ b/client/tests/test_version_parsing.py
@@ -1,6 +1,7 @@
 """Unit tests for CouchbaseVersion parsing (SyncGatewayVersion / EdgeServerVersion)
 and GreenboardUploader version handling."""
 
+import packaging.version
 import pytest
 from cbltest.api.edgeserver import EdgeServerVersion
 from cbltest.api.syncgateway import SyncGatewayVersion
@@ -13,14 +14,32 @@ class TestSyncGatewayVersionParse:
         "version_string, expected_version, expected_build",
         [
             ("3.3.3(271;abc123)", "3.3.3", 271),
+            ("3.3.3 (271;abc123)", "3.3.3", 271),
             ("4.0.0(350;def456)", "4.0.0", 350),
+            ("4.0.0 (350;def456)", "4.0.0", 350),
             ("4.0.0", "4.0.0", 0),
             ("4.0.0(271)", "4.0.0", 271),
+            ("4.0.0 (271)", "4.0.0", 271),
             ("(271;abc)", "unknown", 271),
             ("4.0.0(abc;def)", "4.0.0", 0),
+            ("4.0.0 (abc;def)", "4.0.0", 0),
+            ("4.0.0(271;commit)", "4.0.0", 271),
             ("4.0.0 (271;commit)", "4.0.0", 271),
             ("", "unknown", 0),
             ("4.0.0(271;commit) EE", "4.0.0", 271),
+            ("Couchbase Sync Gateway/3.3.3(271;abc123)", "3.3.3", 271),
+            ("Couchbase Sync Gateway/3.3.3 (271;abc123)", "3.3.3", 271),
+            ("Couchbase Sync Gateway/4.0.0(350;def456)", "4.0.0", 350),
+            ("Couchbase Sync Gateway/4.0.0 (350;def456)", "4.0.0", 350),
+            ("Couchbase Sync Gateway/4.0.0", "4.0.0", 0),
+            ("Couchbase Sync Gateway/4.0.0(271)", "4.0.0", 271),
+            ("Couchbase Sync Gateway/4.0.0 (271)", "4.0.0", 271),
+            ("Couchbase Sync Gateway/(271;abc)", "unknown", 271),
+            ("Couchbase Sync Gateway/ (271;abc)", "unknown", 271),
+            ("Couchbase Sync Gateway/4.0.0(abc;def)", "4.0.0", 0),
+            ("Couchbase Sync Gateway/4.0.0 (abc;def)", "4.0.0", 0),
+            ("Couchbase Sync Gateway/4.0.0 (271;commit)", "4.0.0", 271),
+            ("Couchbase Sync Gateway/4.0.0(271;commit) EE", "4.0.0", 271),
         ],
     )
     def test_parse(self, version_string, expected_version, expected_build):
@@ -28,6 +47,8 @@ class TestSyncGatewayVersionParse:
         assert v.version == expected_version
         assert v.build_number == expected_build
         assert v.raw == version_string
+        if v.version != "unknown":
+            packaging.version.parse(v.version)
 
 
 class TestEdgeServerVersionParse:

--- a/client/tests/test_version_parsing.py
+++ b/client/tests/test_version_parsing.py
@@ -1,6 +1,7 @@
 """Unit tests for CouchbaseVersion parsing (SyncGatewayVersion / EdgeServerVersion)
 and GreenboardUploader version handling."""
 
+import pytest
 from cbltest.api.edgeserver import EdgeServerVersion
 from cbltest.api.syncgateway import SyncGatewayVersion
 
@@ -8,78 +9,40 @@ from cbltest.api.syncgateway import SyncGatewayVersion
 class TestSyncGatewayVersionParse:
     """Tests for SyncGatewayVersion.parse()"""
 
-    def test_standard_3x_format(self):
-        v = SyncGatewayVersion("3.3.3(271;abc123)")
-        assert v.version == "3.3.3"
-        assert v.build_number == 271
-
-    def test_standard_4x_format(self):
-        v = SyncGatewayVersion("4.0.0(350;def456)")
-        assert v.version == "4.0.0"
-        assert v.build_number == 350
-
-    def test_missing_parentheses(self):
-        v = SyncGatewayVersion("4.0.0")
-        assert v.version == "unknown"
-        assert v.build_number == 0
-
-    def test_missing_semicolon(self):
-        v = SyncGatewayVersion("4.0.0(271)")
-        assert v.version == "unknown"
-        assert v.build_number == 0
-
-    def test_empty_version_before_lparen(self):
-        """Previously returned ("", 271) — now returns ("unknown", 271)."""
-        v = SyncGatewayVersion("(271;abc)")
-        assert v.version == "unknown"
-        assert v.build_number == 271
-
-    def test_non_numeric_build(self):
-        """Non-numeric build between ( and ; should not crash."""
-        v = SyncGatewayVersion("4.0.0(abc;def)")
-        assert v.version == "4.0.0"
-        assert v.build_number == 0
-
-    def test_version_with_spaces(self):
-        v = SyncGatewayVersion("4.0.0 (271;commit)")
-        assert v.version == "4.0.0"
-        assert v.build_number == 271
-
-    def test_empty_input(self):
-        v = SyncGatewayVersion("")
-        assert v.version == "unknown"
-        assert v.build_number == 0
-
-    def test_raw_preserved(self):
-        v = SyncGatewayVersion("3.3.3(271;abc)")
-        assert v.raw == "3.3.3(271;abc)"
-
-    def test_enterprise_edition_suffix(self):
-        """Handle version strings like '4.0.0(271;commit) EE'."""
-        v = SyncGatewayVersion("4.0.0(271;commit) EE")
-        assert v.version == "4.0.0"
-        assert v.build_number == 271
+    @pytest.mark.parametrize(
+        "version_string, expected_version, expected_build",
+        [
+            ("3.3.3(271;abc123)", "3.3.3", 271),
+            ("4.0.0(350;def456)", "4.0.0", 350),
+            ("4.0.0", "4.0.0", 0),
+            ("4.0.0(271)", "4.0.0", 271),
+            ("(271;abc)", "unknown", 271),
+            ("4.0.0(abc;def)", "4.0.0", 0),
+            ("4.0.0 (271;commit)", "4.0.0", 271),
+            ("", "unknown", 0),
+            ("4.0.0(271;commit) EE", "4.0.0", 271),
+        ],
+    )
+    def test_parse(self, version_string, expected_version, expected_build):
+        v = SyncGatewayVersion(version_string)
+        assert v.version == expected_version
+        assert v.build_number == expected_build
+        assert v.raw == version_string
 
 
 class TestEdgeServerVersionParse:
     """Tests for EdgeServerVersion.parse() — same logic as SyncGatewayVersion."""
 
-    def test_standard_format(self):
-        v = EdgeServerVersion("1.2.0(100;abc)")
-        assert v.version == "1.2.0"
-        assert v.build_number == 100
-
-    def test_empty_version_before_lparen(self):
-        v = EdgeServerVersion("(100;abc)")
-        assert v.version == "unknown"
-        assert v.build_number == 100
-
-    def test_non_numeric_build(self):
-        v = EdgeServerVersion("1.0.0(xyz;abc)")
-        assert v.version == "1.0.0"
-        assert v.build_number == 0
-
-    def test_no_parentheses(self):
-        v = EdgeServerVersion("1.0.0")
-        assert v.version == "unknown"
-        assert v.build_number == 0
+    @pytest.mark.parametrize(
+        "version_string, expected_version, expected_build",
+        [
+            ("1.2.0(100;abc)", "1.2.0", 100),
+            ("(100;abc)", "unknown", 100),
+            ("1.0.0(xyz;abc)", "1.0.0", 0),
+            ("1.0.0", "unknown", 0),
+        ],
+    )
+    def test_parse(self, version_string, expected_version, expected_build):
+        v = EdgeServerVersion(version_string)
+        assert v.version == expected_version
+        assert v.build_number == expected_build

--- a/tests/QE/test_multiple_servers.py
+++ b/tests/QE/test_multiple_servers.py
@@ -6,7 +6,6 @@ import requests
 from cbltest import CBLPyTest
 from cbltest.api.cbltestclass import CBLTestClass
 from cbltest.api.syncgateway import DocumentUpdateEntry, ISGRPayload, PutDatabasePayload
-from packaging.version import Version
 
 
 def _check_node_in_cluster(cbs_hostname: str, cluster_nodes: list) -> tuple[bool, bool]:
@@ -138,9 +137,7 @@ class TestMultipleServers(CBLTestClass):
         original_revs = {row.id: row.revision for row in all_docs.rows}
         original_vvs = {}
 
-        sgw_version_obj = await sg.get_version()
-        sgw_version = Version(sgw_version_obj.version)
-        supports_version_vectors = sgw_version >= Version("4.0.0")
+        supports_version_vectors = await sg.supports_version_vectors()
         if supports_version_vectors:
             changes_initial = await sg_user.get_changes(sg_db, version_type="cv")
             original_vvs = {

--- a/tests/QE/test_replication_multiple_clients.py
+++ b/tests/QE/test_replication_multiple_clients.py
@@ -150,9 +150,7 @@ class TestReplicationMultipleClients(CBLTestClass):
                 f"Invalid revision format for {row.id}: {row.revision}"
             )
 
-        sgw_version_obj = await sg.get_version()
-        sgw_version = Version(sgw_version_obj.version)
-        supports_version_vectors = sgw_version >= Version("4.0.0")
+        supports_version_vectors = await sg.supports_version_vectors()
         if supports_version_vectors:
             self.mark_test_step(
                 "Verify all documents have correct version vector format (SGW 4.0+)"

--- a/tests/QE/test_users_channels.py
+++ b/tests/QE/test_users_channels.py
@@ -5,7 +5,6 @@ import pytest
 from cbltest import CBLPyTest
 from cbltest.api.cbltestclass import CBLTestClass
 from cbltest.api.syncgateway import DocumentUpdateEntry, PutDatabasePayload
-from packaging.version import Version
 
 
 @pytest.mark.sgw
@@ -121,9 +120,7 @@ class TestUsersChannels(CBLTestClass):
                     f"Invalid revision format for {row.id}: {row.revision}"
                 )
 
-        sgw_version_obj = await sgs[0].get_version()
-        sgw_version = Version(sgw_version_obj.version)
-        supports_version_vectors = sgw_version >= Version("4.0.0")
+        supports_version_vectors = await sgs[0].supports_version_vectors()
         if supports_version_vectors:
             self.mark_test_step(
                 "Verify all documents have correct version vector format (SGW 4.0+)"

--- a/tests/QE/test_xattrs.py
+++ b/tests/QE/test_xattrs.py
@@ -7,7 +7,6 @@ from cbltest import CBLPyTest
 from cbltest.api.cbltestclass import CBLTestClass
 from cbltest.api.error import CblSyncGatewayBadResponseError
 from cbltest.api.syncgateway import DocumentUpdateEntry, PutDatabasePayload
-from packaging.version import Version
 
 
 @pytest.mark.sgw
@@ -86,9 +85,7 @@ class TestXattrs(CBLTestClass):
         assert sg_created_count == num_docs, (
             f"Expected {num_docs} SG docs, but found {sg_created_count}"
         )
-        sgw_version_obj = await sg.get_version()
-        sgw_version = Version(sgw_version_obj.version)
-        supports_version_vectors = sgw_version >= Version("4.0.0")
+        supports_version_vectors = await sg.supports_version_vectors()
         original_revisions = {row.id: row.revision for row in sg_all_docs.rows}
         if supports_version_vectors:
             original_vv = {row.id: row.cv for row in sg_all_docs.rows}
@@ -244,9 +241,7 @@ class TestXattrs(CBLTestClass):
             row.id: row.revision for row in sg_all_docs.rows
         }
 
-        sgw_version_obj = await sg.get_version()
-        sgw_version = Version(sgw_version_obj.version)
-        supports_version_vectors = sgw_version >= Version("4.0.0")
+        supports_version_vectors = await sg.supports_version_vectors()
         all_doc_version_vectors: dict[str, str | None] = {}
         if supports_version_vectors:
             self.mark_test_step("Store original version vectors for SG docs (optional)")

--- a/uv.lock
+++ b/uv.lock
@@ -108,6 +108,15 @@ wheels = [
 ]
 
 [[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
 name = "async-timeout"
 version = "5.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -182,6 +191,7 @@ dependencies = [
     { name = "opentelemetry-sdk" },
     { name = "opentelemetry-semantic-conventions" },
     { name = "packaging" },
+    { name = "pydantic" },
     { name = "pyjson5" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -203,6 +213,7 @@ requires-dist = [
     { name = "opentelemetry-sdk", specifier = "==1.29.0" },
     { name = "opentelemetry-semantic-conventions", specifier = "==0.50b0" },
     { name = "packaging", specifier = "==24.2" },
+    { name = "pydantic", specifier = ">=2.13.3" },
     { name = "pyjson5", specifier = "==1.6.8" },
     { name = "pytest", specifier = "==9.0.2" },
     { name = "pytest-asyncio", specifier = "==1.3.0" },
@@ -967,6 +978,107 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic"
+version = "2.13.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/e4/40d09941a2cebcb20609b86a559817d5b9291c49dd6f8c87e5feffbe703a/pydantic-2.13.3.tar.gz", hash = "sha256:af09e9d1d09f4e7fe37145c1f577e1d61ceb9a41924bf0094a36506285d0a84d", size = 844068, upload-time = "2026-04-20T14:46:43.632Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/0a/fd7d723f8f8153418fb40cf9c940e82004fce7e987026b08a68a36dd3fe7/pydantic-2.13.3-py3-none-any.whl", hash = "sha256:6db14ac8dfc9a1e57f87ea2c0de670c251240f43cb0c30a5130e9720dc612927", size = 471981, upload-time = "2026-04-20T14:46:41.402Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2a/ef/f7abb56c49382a246fd2ce9c799691e3c3e7175ec74b14d99e798bcddb1a/pydantic_core-2.46.3.tar.gz", hash = "sha256:41c178f65b8c29807239d47e6050262eb6bf84eb695e41101e62e38df4a5bc2c", size = 471412, upload-time = "2026-04-20T14:40:56.672Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/98/b50eb9a411e87483b5c65dba4fa430a06bac4234d3403a40e5a9905ebcd0/pydantic_core-2.46.3-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:1da3786b8018e60349680720158cc19161cc3b4bdd815beb0a321cd5ce1ad5b1", size = 2108971, upload-time = "2026-04-20T14:43:51.945Z" },
+    { url = "https://files.pythonhosted.org/packages/08/4b/f364b9d161718ff2217160a4b5d41ce38de60aed91c3689ebffa1c939d23/pydantic_core-2.46.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:cc0988cb29d21bf4a9d5cf2ef970b5c0e38d8d8e107a493278c05dc6c1dda69f", size = 1949588, upload-time = "2026-04-20T14:44:10.386Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/8b/30bd03ee83b2f5e29f5ba8e647ab3c456bf56f2ec72fdbcc0215484a0854/pydantic_core-2.46.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:27f9067c3bfadd04c55484b89c0d267981b2f3512850f6f66e1e74204a4e4ce3", size = 1975986, upload-time = "2026-04-20T14:43:57.106Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/54/13ccf954d84ec275d5d023d5786e4aa48840bc9f161f2838dc98e1153518/pydantic_core-2.46.3-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a642ac886ecf6402d9882d10c405dcf4b902abeb2972cd5fb4a48c83cd59279a", size = 2055830, upload-time = "2026-04-20T14:44:15.499Z" },
+    { url = "https://files.pythonhosted.org/packages/be/0e/65f38125e660fdbd72aa858e7dfae893645cfa0e7b13d333e174a367cd23/pydantic_core-2.46.3-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:79f561438481f28681584b89e2effb22855e2179880314bcddbf5968e935e807", size = 2222340, upload-time = "2026-04-20T14:41:51.353Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/88/f3ab7739efe0e7e80777dbb84c59eb98518e3f57ea433206194c2e425272/pydantic_core-2.46.3-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:57a973eae4665352a47cf1a99b4ee864620f2fe663a217d7a8da68a1f3a5bfda", size = 2280727, upload-time = "2026-04-20T14:41:30.461Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/6d/c228219080817bec4982f9531cadb18da6aaa770fdeb114f49c237ac2c9f/pydantic_core-2.46.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83d002b97072a53ea150d63e0a3adfae5670cef5aa8a6e490240e482d3b22e57", size = 2092158, upload-time = "2026-04-20T14:44:07.305Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/b1/525a16711e7c6d61635fac3b0bd54600b5c5d9f60c6fc5aaab26b64a2297/pydantic_core-2.46.3-cp310-cp310-manylinux_2_31_riscv64.whl", hash = "sha256:b40ddd51e7c44b28cfaef746c9d3c506d658885e0a46f9eeef2ee815cbf8e045", size = 2116626, upload-time = "2026-04-20T14:42:34.118Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/7c/17d30673351439a6951bf54f564cf2443ab00ae264ec9df00e2efd710eb5/pydantic_core-2.46.3-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ac5ec7fb9b87f04ee839af2d53bcadea57ded7d229719f56c0ed895bff987943", size = 2160691, upload-time = "2026-04-20T14:41:14.023Z" },
+    { url = "https://files.pythonhosted.org/packages/86/66/af8adbcbc0886ead7f1a116606a534d75a307e71e6e08226000d51b880d2/pydantic_core-2.46.3-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:a3b11c812f61b3129c4905781a2601dfdfdea5fe1e6c1cfb696b55d14e9c054f", size = 2182543, upload-time = "2026-04-20T14:40:48.886Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/37/6de71e0f54c54a4190010f57deb749e1ddf75c568ada3b1320b70067f121/pydantic_core-2.46.3-cp310-cp310-musllinux_1_1_armv7l.whl", hash = "sha256:1108da631e602e5b3c38d6d04fe5bb3bfa54349e6918e3ca6cf570b2e2b2f9d4", size = 2324513, upload-time = "2026-04-20T14:42:36.121Z" },
+    { url = "https://files.pythonhosted.org/packages/51/b1/9fc74ce94f603d5ef59ff258ca9c2c8fb902fb548d340a96f77f4d1c3b7f/pydantic_core-2.46.3-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:de885175515bcfa98ae618c1df7a072f13d179f81376c8007112af20567fd08a", size = 2361853, upload-time = "2026-04-20T14:43:24.886Z" },
+    { url = "https://files.pythonhosted.org/packages/40/d0/4c652fc592db35f100279ee751d5a145aca1b9a7984b9684ba7c1b5b0535/pydantic_core-2.46.3-cp310-cp310-win32.whl", hash = "sha256:d11058e3201527d41bc6b545c79187c9e4bf85e15a236a6007f0e991518882b7", size = 1980465, upload-time = "2026-04-20T14:44:46.239Z" },
+    { url = "https://files.pythonhosted.org/packages/27/b8/a920453c38afbe1f355e1ea0b0d94a0a3e0b0879d32d793108755fa171d5/pydantic_core-2.46.3-cp310-cp310-win_amd64.whl", hash = "sha256:3612edf65c8ea67ac13616c4d23af12faef1ae435a8a93e5934c2a0cbbdd1fd6", size = 2073884, upload-time = "2026-04-20T14:43:01.201Z" },
+    { url = "https://files.pythonhosted.org/packages/22/a2/1ba90a83e85a3f94c796b184f3efde9c72f2830dcda493eea8d59ba78e6d/pydantic_core-2.46.3-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:ab124d49d0459b2373ecf54118a45c28a1e6d4192a533fbc915e70f556feb8e5", size = 2106740, upload-time = "2026-04-20T14:41:20.932Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/f6/99ae893c89a0b9d3daec9f95487aa676709aa83f67643b3f0abaf4ab628a/pydantic_core-2.46.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:cca67d52a5c7a16aed2b3999e719c4bcf644074eac304a5d3d62dd70ae7d4b2c", size = 1948293, upload-time = "2026-04-20T14:43:42.115Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/b8/2e8e636dc9e3f16c2e16bf0849e24be82c5ee82c603c65fc0326666328fc/pydantic_core-2.46.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5c024e08c0ba23e6fd68c771a521e9d6a792f2ebb0fa734296b36394dc30390e", size = 1973222, upload-time = "2026-04-20T14:41:57.841Z" },
+    { url = "https://files.pythonhosted.org/packages/34/36/0e730beec4d83c5306f417afbd82ff237d9a21e83c5edf675f31ed84c1fe/pydantic_core-2.46.3-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6645ce7eec4928e29a1e3b3d5c946621d105d3e79f0c9cddf07c2a9770949287", size = 2053852, upload-time = "2026-04-20T14:40:43.077Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f0/3071131f47e39136a17814576e0fada9168569f7f8c0e6ac4d1ede6a4958/pydantic_core-2.46.3-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a712c7118e6c5ea96562f7b488435172abb94a3c53c22c9efc1412264a45cbbe", size = 2221134, upload-time = "2026-04-20T14:43:03.349Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/a9/a2dc023eec5aa4b02a467874bad32e2446957d2adcab14e107eab502e978/pydantic_core-2.46.3-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:69a868ef3ff206343579021c40faf3b1edc64b1cc508ff243a28b0a514ccb050", size = 2279785, upload-time = "2026-04-20T14:41:19.285Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/44/93f489d16fb63fbd41c670441536541f6e8cfa1e5a69f40bc9c5d30d8c90/pydantic_core-2.46.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cc7e8c32db809aa0f6ea1d6869ebc8518a65d5150fdfad8bcae6a49ae32a22e2", size = 2089404, upload-time = "2026-04-20T14:43:10.108Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/78/8692e3aa72b2d004f7a5d937f1dfdc8552ba26caf0bec75f342c40f00dec/pydantic_core-2.46.3-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:3481bd1341dc85779ee506bc8e1196a277ace359d89d28588a9468c3ecbe63fa", size = 2114898, upload-time = "2026-04-20T14:44:51.475Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/62/e83133f2e7832532060175cebf1f13748f4c7e7e7165cdd1f611f174494b/pydantic_core-2.46.3-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8690eba565c6d68ffd3a8655525cbdd5246510b44a637ee2c6c03a7ebfe64d3c", size = 2157856, upload-time = "2026-04-20T14:43:46.64Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/ec/6a500e3ad7718ee50583fae79c8651f5d37e3abce1fa9ae177ae65842c53/pydantic_core-2.46.3-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:4de88889d7e88d50d40ee5b39d5dac0bcaef9ba91f7e536ac064e6b2834ecccf", size = 2180168, upload-time = "2026-04-20T14:42:00.302Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/53/8267811054b1aa7fc1dc7ded93812372ef79a839f5e23558136a6afbfde1/pydantic_core-2.46.3-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:e480080975c1ef7f780b8f99ed72337e7cc5efea2e518a20a692e8e7b278eb8b", size = 2322885, upload-time = "2026-04-20T14:41:05.253Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/c1/1c0acdb3aa0856ddc4ecc55214578f896f2de16f400cf51627eb3c26c1c4/pydantic_core-2.46.3-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:de3a5c376f8cd94da9a1b8fd3dd1c16c7a7b216ed31dc8ce9fd7a22bf13b836e", size = 2360328, upload-time = "2026-04-20T14:41:43.991Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/d0/ef39cd0f4a926814f360e71c1adeab48ad214d9727e4deb48eedfb5bce1a/pydantic_core-2.46.3-cp311-cp311-win32.whl", hash = "sha256:fc331a5314ffddd5385b9ee9d0d2fee0b13c27e0e02dad71b1ae5d6561f51eeb", size = 1979464, upload-time = "2026-04-20T14:43:12.215Z" },
+    { url = "https://files.pythonhosted.org/packages/18/9c/f41951b0d858e343f1cf09398b2a7b3014013799744f2c4a8ad6a3eec4f2/pydantic_core-2.46.3-cp311-cp311-win_amd64.whl", hash = "sha256:b5b9c6cf08a8a5e502698f5e153056d12c34b8fb30317e0c5fd06f45162a6346", size = 2070837, upload-time = "2026-04-20T14:41:47.707Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/1e/264a17cd582f6ed50950d4d03dd5fefd84e570e238afe1cb3e25cf238769/pydantic_core-2.46.3-cp311-cp311-win_arm64.whl", hash = "sha256:5dfd51cf457482f04ec49491811a2b8fd5b843b64b11eecd2d7a1ee596ea78a6", size = 2053647, upload-time = "2026-04-20T14:42:27.535Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/cb/5b47425556ecc1f3fe18ed2a0083188aa46e1dd812b06e406475b3a5d536/pydantic_core-2.46.3-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:b11b59b3eee90a80a36701ddb4576d9ae31f93f05cb9e277ceaa09e6bf074a67", size = 2101946, upload-time = "2026-04-20T14:40:52.581Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/4f/2fb62c2267cae99b815bbf4a7b9283812c88ca3153ef29f7707200f1d4e5/pydantic_core-2.46.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:af8653713055ea18a3abc1537fe2ebc42f5b0bbb768d1eb79fd74eb47c0ac089", size = 1951612, upload-time = "2026-04-20T14:42:42.996Z" },
+    { url = "https://files.pythonhosted.org/packages/50/6e/b7348fd30d6556d132cddd5bd79f37f96f2601fe0608afac4f5fb01ec0b3/pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:75a519dab6d63c514f3a81053e5266c549679e4aa88f6ec57f2b7b854aceb1b0", size = 1977027, upload-time = "2026-04-20T14:42:02.001Z" },
+    { url = "https://files.pythonhosted.org/packages/82/11/31d60ee2b45540d3fb0b29302a393dbc01cd771c473f5b5147bcd353e593/pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a6cd87cb1575b1ad05ba98894c5b5c96411ef678fa2f6ed2576607095b8d9789", size = 2063008, upload-time = "2026-04-20T14:44:17.952Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/db/3a9d1957181b59258f44a2300ab0f0be9d1e12d662a4f57bb31250455c52/pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f80a55484b8d843c8ada81ebf70a682f3f00a3d40e378c06cf17ecb44d280d7d", size = 2233082, upload-time = "2026-04-20T14:40:57.934Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/e1/3277c38792aeb5cfb18c2f0c5785a221d9ff4e149abbe1184d53d5f72273/pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3861f1731b90c50a3266316b9044f5c9b405eecb8e299b0a7120596334e4fe9c", size = 2304615, upload-time = "2026-04-20T14:42:12.584Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/d5/e3d9717c9eba10855325650afd2a9cba8e607321697f18953af9d562da2f/pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fb528e295ed31570ac3dcc9bfdd6e0150bc11ce6168ac87a8082055cf1a67395", size = 2094380, upload-time = "2026-04-20T14:43:05.522Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/20/abac35dedcbfd66c6f0b03e4e3564511771d6c9b7ede10a362d03e110d9b/pydantic_core-2.46.3-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:367508faa4973b992b271ba1494acaab36eb7e8739d1e47be5035fb1ea225396", size = 2135429, upload-time = "2026-04-20T14:41:55.549Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/a5/41bfd1df69afad71b5cf0535055bccc73022715ad362edbc124bc1e021d7/pydantic_core-2.46.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5ad3c826fe523e4becf4fe39baa44286cff85ef137c729a2c5e269afbfd0905d", size = 2174582, upload-time = "2026-04-20T14:41:45.96Z" },
+    { url = "https://files.pythonhosted.org/packages/79/65/38d86ea056b29b2b10734eb23329b7a7672ca604df4f2b6e9c02d4ee22fe/pydantic_core-2.46.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:ec638c5d194ef8af27db69f16c954a09797c0dc25015ad6123eb2c73a4d271ca", size = 2187533, upload-time = "2026-04-20T14:40:55.367Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/55/a1129141678a2026badc539ad1dee0a71d06f54c2f06a4bd68c030ac781b/pydantic_core-2.46.3-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:28ed528c45446062ee66edb1d33df5d88828ae167de76e773a3c7f64bd14e976", size = 2332985, upload-time = "2026-04-20T14:44:13.05Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/60/cb26f4077719f709e54819f4e8e1d43f4091f94e285eb6bd21e1190a7b7c/pydantic_core-2.46.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:aed19d0c783886d5bd86d80ae5030006b45e28464218747dcf83dabfdd092c7b", size = 2373670, upload-time = "2026-04-20T14:41:53.421Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/7e/c3f21882bdf1d8d086876f81b5e296206c69c6082551d776895de7801fa0/pydantic_core-2.46.3-cp312-cp312-win32.whl", hash = "sha256:06d5d8820cbbdb4147578c1fe7ffcd5b83f34508cb9f9ab76e807be7db6ff0a4", size = 1966722, upload-time = "2026-04-20T14:44:30.588Z" },
+    { url = "https://files.pythonhosted.org/packages/57/be/6b5e757b859013ebfbd7adba02f23b428f37c86dcbf78b5bb0b4ffd36e99/pydantic_core-2.46.3-cp312-cp312-win_amd64.whl", hash = "sha256:c3212fda0ee959c1dd04c60b601ec31097aaa893573a3a1abd0a47bcac2968c1", size = 2072970, upload-time = "2026-04-20T14:42:54.248Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/f8/a989b21cc75e9a32d24192ef700eea606521221a89faa40c919ce884f2b1/pydantic_core-2.46.3-cp312-cp312-win_arm64.whl", hash = "sha256:f1f8338dd7a7f31761f1f1a3c47503a9a3b34eea3c8b01fa6ee96408affb5e72", size = 2035963, upload-time = "2026-04-20T14:44:20.4Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/3c/9b5e8eb9821936d065439c3b0fb1490ffa64163bfe7e1595985a47896073/pydantic_core-2.46.3-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:12bc98de041458b80c86c56b24df1d23832f3e166cbaff011f25d187f5c62c37", size = 2102109, upload-time = "2026-04-20T14:41:24.219Z" },
+    { url = "https://files.pythonhosted.org/packages/91/97/1c41d1f5a19f241d8069f1e249853bcce378cdb76eec8ab636d7bc426280/pydantic_core-2.46.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:85348b8f89d2c3508b65b16c3c33a4da22b8215138d8b996912bb1532868885f", size = 1951820, upload-time = "2026-04-20T14:42:14.236Z" },
+    { url = "https://files.pythonhosted.org/packages/30/b4/d03a7ae14571bc2b6b3c7b122441154720619afe9a336fa3a95434df5e2f/pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1105677a6df914b1fb71a81b96c8cce7726857e1717d86001f29be06a25ee6f8", size = 1977785, upload-time = "2026-04-20T14:42:31.648Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/0c/4086f808834b59e3c8f1aa26df8f4b6d998cdcf354a143d18ef41529d1fe/pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:87082cd65669a33adeba5470769e9704c7cf026cc30afb9cc77fd865578ebaad", size = 2062761, upload-time = "2026-04-20T14:40:37.093Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/71/a649be5a5064c2df0db06e0a512c2281134ed2fcc981f52a657936a7527c/pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:60e5f66e12c4f5212d08522963380eaaeac5ebd795826cfd19b2dfb0c7a52b9c", size = 2232989, upload-time = "2026-04-20T14:42:59.254Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/7756e75763e810b3a710f4724441d1ecc5883b94aacb07ca71c5fb5cfb69/pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b6cdf19bf84128d5e7c37e8a73a0c5c10d51103a650ac585d42dd6ae233f2b7f", size = 2303975, upload-time = "2026-04-20T14:41:32.287Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/35/68a762e0c1e31f35fa0dac733cbd9f5b118042853698de9509c8e5bf128b/pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:031bb17f4885a43773c8c763089499f242aee2ea85cf17154168775dccdecf35", size = 2095325, upload-time = "2026-04-20T14:42:47.685Z" },
+    { url = "https://files.pythonhosted.org/packages/77/bf/1bf8c9a8e91836c926eae5e3e51dce009bf495a60ca56060689d3df3f340/pydantic_core-2.46.3-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:bcf2a8b2982a6673693eae7348ef3d8cf3979c1d63b54fca7c397a635cc68687", size = 2133368, upload-time = "2026-04-20T14:41:22.766Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/50/87d818d6bab915984995157ceb2380f5aac4e563dddbed6b56f0ed057aba/pydantic_core-2.46.3-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:28e8cf2f52d72ced402a137145923a762cbb5081e48b34312f7a0c8f55928ec3", size = 2173908, upload-time = "2026-04-20T14:42:52.044Z" },
+    { url = "https://files.pythonhosted.org/packages/91/88/a311fb306d0bd6185db41fa14ae888fb81d0baf648a761ae760d30819d33/pydantic_core-2.46.3-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:17eaface65d9fc5abb940003020309c1bf7a211f5f608d7870297c367e6f9022", size = 2186422, upload-time = "2026-04-20T14:43:29.55Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/79/28fd0d81508525ab2054fef7c77a638c8b5b0afcbbaeee493cf7c3fef7e1/pydantic_core-2.46.3-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:93fd339f23408a07e98950a89644f92c54d8729719a40b30c0a30bb9ebc55d23", size = 2332709, upload-time = "2026-04-20T14:42:16.134Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/21/795bf5fe5c0f379308b8ef19c50dedab2e7711dbc8d0c2acf08f1c7daa05/pydantic_core-2.46.3-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:23cbdb3aaa74dfe0837975dbf69b469753bbde8eacace524519ffdb6b6e89eb7", size = 2372428, upload-time = "2026-04-20T14:41:10.974Z" },
+    { url = "https://files.pythonhosted.org/packages/45/b3/ed14c659cbe7605e3ef063077680a64680aec81eb1a04763a05190d49b7f/pydantic_core-2.46.3-cp313-cp313-win32.whl", hash = "sha256:610eda2e3838f401105e6326ca304f5da1e15393ae25dacae5c5c63f2c275b13", size = 1965601, upload-time = "2026-04-20T14:41:42.128Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/bb/adb70d9a762ddd002d723fbf1bd492244d37da41e3af7b74ad212609027e/pydantic_core-2.46.3-cp313-cp313-win_amd64.whl", hash = "sha256:68cc7866ed863db34351294187f9b729964c371ba33e31c26f478471c52e1ed0", size = 2071517, upload-time = "2026-04-20T14:43:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/52/eb/66faefabebfe68bd7788339c9c9127231e680b11906368c67ce112fdb47f/pydantic_core-2.46.3-cp313-cp313-win_arm64.whl", hash = "sha256:f64b5537ac62b231572879cd08ec05600308636a5d63bcbdb15063a466977bec", size = 2035802, upload-time = "2026-04-20T14:43:38.507Z" },
+    { url = "https://files.pythonhosted.org/packages/66/7f/03dbad45cd3aa9083fbc93c210ae8b005af67e4136a14186950a747c6874/pydantic_core-2.46.3-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:9715525891ed524a0a1eb6d053c74d4d4ad5017677fb00af0b7c2644a31bae46", size = 2105683, upload-time = "2026-04-20T14:42:19.779Z" },
+    { url = "https://files.pythonhosted.org/packages/26/22/4dc186ac8ea6b257e9855031f51b62a9637beac4d68ac06bee02f046f836/pydantic_core-2.46.3-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:9d2f400712a99a013aff420ef1eb9be077f8189a36c1e3ef87660b4e1088a874", size = 1940052, upload-time = "2026-04-20T14:43:59.274Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/ca/d376391a5aff1f2e8188960d7873543608130a870961c2b6b5236627c116/pydantic_core-2.46.3-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bd2aab0e2e9dc2daf36bd2686c982535d5e7b1d930a1344a7bb6e82baab42a76", size = 1988172, upload-time = "2026-04-20T14:41:17.469Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/6b/523b9f85c23788755d6ab949329de692a2e3a584bc6beb67fef5e035aa9d/pydantic_core-2.46.3-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4e9d76736da5f362fabfeea6a69b13b7f2be405c6d6966f06b2f6bfff7e64531", size = 2128596, upload-time = "2026-04-20T14:40:41.707Z" },
+    { url = "https://files.pythonhosted.org/packages/34/42/f426db557e8ab2791bc7562052299944a118655496fbff99914e564c0a94/pydantic_core-2.46.3-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:b12dd51f1187c2eb489af8e20f880362db98e954b54ab792fa5d92e8bcc6b803", size = 2091877, upload-time = "2026-04-20T14:43:27.091Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/4f/86a832a9d14df58e663bfdf4627dc00d3317c2bd583c4fb23390b0f04b8e/pydantic_core-2.46.3-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:f00a0961b125f1a47af7bcc17f00782e12f4cd056f83416006b30111d941dfa3", size = 1932428, upload-time = "2026-04-20T14:40:45.781Z" },
+    { url = "https://files.pythonhosted.org/packages/11/1a/fe857968954d93fb78e0d4b6df5c988c74c4aaa67181c60be7cfe327c0ca/pydantic_core-2.46.3-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:57697d7c056aca4bbb680200f96563e841a6386ac1129370a0102592f4dddff5", size = 1997550, upload-time = "2026-04-20T14:44:02.425Z" },
+    { url = "https://files.pythonhosted.org/packages/17/eb/9d89ad2d9b0ba8cd65393d434471621b98912abb10fbe1df08e480ba57b5/pydantic_core-2.46.3-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd35aa21299def8db7ef4fe5c4ff862941a9a158ca7b63d61e66fe67d30416b4", size = 2137657, upload-time = "2026-04-20T14:42:45.149Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/da/99d40830684f81dec901cac521b5b91c095394cc1084b9433393cde1c2df/pydantic_core-2.46.3-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:13afdd885f3d71280cf286b13b310ee0f7ccfefd1dbbb661514a474b726e2f25", size = 2107973, upload-time = "2026-04-20T14:42:06.175Z" },
+    { url = "https://files.pythonhosted.org/packages/99/a5/87024121818d75bbb2a98ddbaf638e40e7a18b5e0f5492c9ca4b1b316107/pydantic_core-2.46.3-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:f91c0aff3e3ee0928edd1232c57f643a7a003e6edf1860bc3afcdc749cb513f3", size = 1947191, upload-time = "2026-04-20T14:43:14.319Z" },
+    { url = "https://files.pythonhosted.org/packages/60/62/0c1acfe10945b83a6a59d19fbaa92f48825381509e5701b855c08f13db76/pydantic_core-2.46.3-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6529d1d128321a58d30afcc97b49e98836542f68dd41b33c2e972bb9e5290536", size = 2123791, upload-time = "2026-04-20T14:43:22.766Z" },
+    { url = "https://files.pythonhosted.org/packages/75/3e/3b2393b4c8f44285561dc30b00cf307a56a2eff7c483a824db3b8221ca51/pydantic_core-2.46.3-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:975c267cff4f7e7272eacbe50f6cc03ca9a3da4c4fbd66fffd89c94c1e311aa1", size = 2153197, upload-time = "2026-04-20T14:44:27.932Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/75/5af02fb35505051eee727c061f2881c555ab4f8ddb2d42da715a42c9731b/pydantic_core-2.46.3-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:2b8e4f2bbdf71415c544b4b1138b8060db7b6611bc927e8064c769f64bed651c", size = 2181073, upload-time = "2026-04-20T14:43:20.729Z" },
+    { url = "https://files.pythonhosted.org/packages/10/92/7e0e1bd9ca3c68305db037560ca2876f89b2647deb2f8b6319005de37505/pydantic_core-2.46.3-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:e61ea8e9fff9606d09178f577ff8ccdd7206ff73d6552bcec18e1033c4254b85", size = 2315886, upload-time = "2026-04-20T14:44:04.826Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/d8/101655f27eaf3e44558ead736b2795d12500598beed4683f279396fa186e/pydantic_core-2.46.3-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:b504bda01bafc69b6d3c7a0c7f039dcf60f47fab70e06fe23f57b5c75bdc82b8", size = 2360528, upload-time = "2026-04-20T14:40:47.431Z" },
+    { url = "https://files.pythonhosted.org/packages/07/0f/1c34a74c8d07136f0d729ffe5e1fdab04fbdaa7684f61a92f92511a84a15/pydantic_core-2.46.3-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:b00b76f7142fc60c762ce579bd29c8fa44aaa56592dd3c54fab3928d0d4ca6ff", size = 2184144, upload-time = "2026-04-20T14:42:57Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1286,11 +1398,23 @@ wheels = [
 
 [[package]]
 name = "typing-extensions"
-version = "4.12.2"
+version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/df/db/f35a00659bc03fec321ba8bce9420de607a1d37f8342eee1863174c69557/typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8", size = 85321, upload-time = "2024-06-07T18:52:15.995Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d", size = 37438, upload-time = "2024-06-07T18:52:13.582Z" },
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Goal: Allow code that uses `supports_version_vectors()` to pass with Sync Gateway dev builds, right now it throws an exception because `get_version` returns `"unknown"` for dev builds

Sync Gateway has some unfortunate behavior around reporting version numbers for dev builds. This is probably a bug in Sync Gateway but a dev build and a release build return different values.

For a dev build:

```
    "vendor": {
        "name": "Couchbase Sync Gateway",
        "version": "4.1"
    },
    "version": "Couchbase Sync Gateway/mybranch(9fb8653) EE"
```

For a release build:

```
    "vendor": {
        "name": "Couchbase Sync Gateway",
        "version": "4.0"
    },
    "version": "Couchbase Sync Gateway/4.0.4(8;release) EE"
```

Therefore, try to use `version` so that the version number has build number but fall back to `vendor.version` for dev builds. We probably never want to upload this to greenboard and if we did we'd want something to actually say the commit hash but that doesn't work with the build number being integer typed. I'm not trying to fix that problem in this ticket though.

@borrrden, looking for your input on whether you are OK using pydantic for json parsing.
@vipbhardwaj, I ran most of the QE tests but you should make sure this code works before I break Jenkins by mistake.