### PR TITLE
Disable verify_lfs_checkout on linux

### DIFF
--- a/client/src/cbltest/utils.py
+++ b/client/src/cbltest/utils.py
@@ -1,6 +1,7 @@
 import json
 import os
 import subprocess
+import sys
 import time
 from collections.abc import Callable
 from typing import Any, TypeVar, cast
@@ -46,10 +47,10 @@ def verify_lfs_checkout() -> None:
     """
     This function is used to verify that the LFS files are being properly checked out.
     """
-    if os.name == "nt":
-        # This check, for whatever reason, is entirely unreliable on Windows.  The command itself returns
-        # what I expect, but the checkout field is always false when invoking from python,
-        # even when the files are properly checked out
+    if os.name == "nt" or sys.platform.startswith("linux"):
+        # This check, for whatever reason, is entirely unreliable on Windows and linux.
+        # The command itself returns what I expect, but the checkout field is always false
+        # when invoking from python, even when the files are properly checked out
         return
 
     try:


### PR DESCRIPTION
Linux has the same problem as windows. The checkout field is false why the lfs files (dataset files) are checked out correctly. I need this now to be able to verify the RC libraries.