### PR TITLE
Fix C-iOS prebuild not propagating xcodebuild failures

### DIFF
--- a/environment/aws/topology_setup/test_server_platforms/c_register.py
+++ b/environment/aws/topology_setup/test_server_platforms/c_register.py
@@ -30,9 +30,7 @@ import platform
 import shutil
 import subprocess
 from abc import abstractmethod
-from io import BytesIO
 from pathlib import Path
-from typing import cast
 
 import click
 
@@ -249,17 +247,22 @@ class CTestServer_iOS(CTestServer):
             env=env,
             cwd=C_TEST_SERVER_DIR / "platforms" / "ios",
             stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
         ) as xcodebuild_proc:
-            with subprocess.Popen(
-                ["xcpretty"], stdin=xcodebuild_proc.stdout, env=env
-            ) as xcpretty_proc:
-                # Close the stdout of the first process to allow it to receive a SIGPIPE if the second process exits
-                cast(BytesIO, xcodebuild_proc.stdout).close()
+            assert xcodebuild_proc.stdout is not None
 
-                xcpretty_proc.wait()
-                if xcpretty_proc.returncode != 0:
-                    raise RuntimeError("Build failed")
+            with subprocess.Popen(
+                ["xcpretty"],
+                stdin=xcodebuild_proc.stdout,
+                env=env,
+            ) as xcpretty_proc:
+                xcodebuild_proc.stdout.close()
+
+                xcpretty_rc = xcpretty_proc.wait()
+                xcodebuild_rc = xcodebuild_proc.wait()
+
+        if xcodebuild_rc != 0 or xcpretty_rc != 0:
+            raise RuntimeError("Build failed")
 
     @property
     def latestbuilds_path(self) -> str:

--- a/environment/aws/topology_setup/test_server_platforms/swift_register.py
+++ b/environment/aws/topology_setup/test_server_platforms/swift_register.py
@@ -25,9 +25,7 @@ Functions:
 import os
 import shutil
 import subprocess
-from io import BytesIO
 from pathlib import Path
-from typing import cast
 
 from environment.aws.common.io import unzip_directory, zip_directory
 from environment.aws.common.output import header
@@ -154,17 +152,22 @@ class SwiftTestServer_iOS(SwiftTestServer):
             env=env,
             cwd=SWIFT_TEST_SERVER_DIR,
             stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
         ) as xcodebuild_proc:
-            with subprocess.Popen(
-                ["xcpretty"], stdin=xcodebuild_proc.stdout, env=env
-            ) as xcpretty_proc:
-                # Close the stdout of the first process to allow it to receive a SIGPIPE if the second process exits
-                cast(BytesIO, xcodebuild_proc.stdout).close()
+            assert xcodebuild_proc.stdout is not None
 
-                xcpretty_proc.wait()
-                if xcpretty_proc.returncode != 0:
-                    raise RuntimeError("Build failed")
+            with subprocess.Popen(
+                ["xcpretty"],
+                stdin=xcodebuild_proc.stdout,
+                env=env,
+            ) as xcpretty_proc:
+                xcodebuild_proc.stdout.close()
+
+                xcpretty_rc = xcpretty_proc.wait()
+                xcodebuild_rc = xcodebuild_proc.wait()
+
+        if xcodebuild_rc != 0 or xcpretty_rc != 0:
+            raise RuntimeError("Build failed")
 
     def create_bridge(self, **kwargs) -> PlatformBridge:
         """


### PR DESCRIPTION
* Merge xcodebuild stderr into stdout so xcpretty shows errors.
* Wait for both xcodebuild and xcpretty to finish.
* Raise an error if either process exits with a non-zero status.