### PR TITLE
feat: Updated schema for SGW upgrade jobs' better visualization overall

### DIFF
--- a/client/src/cbltest/greenboarduploader.py
+++ b/client/src/cbltest/greenboarduploader.py
@@ -47,9 +47,8 @@ class GreenboardUploader:
                 self.__overall_fail = True
             return
 
-        # Mark that at least one test reached the "call" phase. Zero
-        # collected tests is treated as a deviation from intent — recorded
-        # as a failed iteration so the chart doesn't silently turn green.
+        # Used by record_upgrade_step to skip iterations where pytest
+        # collected zero tests (and no setup crash occurred).
         self.__test_ran = True
 
         if self.__overall_fail:
@@ -158,6 +157,16 @@ class GreenboardUploader:
         """
         upgrade_path = [v.strip() for v in upgrade_versions_str.split(",") if v.strip()]
 
+        # No tests collected AND no setup crash means nothing was ever
+        # attempted (e.g. wrong marker filter). Don't record an iteration
+        # — the chart shouldn't show a row for a run that never executed.
+        if not self.__test_ran and not self.__overall_fail:
+            cbl_info(
+                f"No tests ran for phase={phase!r}; skipping iteration "
+                "record (no upload contribution)"
+            )
+            return
+
         # Resolve the destination version of this iteration. Live SGW is
         # primary; on get_version() failure the caller passes None and we
         # fall back to the shell-exported step target so the dot still
@@ -179,12 +188,11 @@ class GreenboardUploader:
                 break
 
         # Any deviation from "tests ran and all passed" is a failure.
-        # Includes: a test failed (call phase), setup/teardown crashed
-        # (overall_fail), or pytest collected zero tests (test_ran False).
+        # Includes: a test failed (call phase) or setup/teardown crashed
+        # (overall_fail). Zero-collected was already short-circuited above.
         had_test_failures = self.__fail_count > 0
         setup_failure = self.__overall_fail
-        no_tests_collected = not self.__test_ran
-        failed = had_test_failures or setup_failure or no_tests_collected
+        failed = had_test_failures or setup_failure
 
         # Surface non-test-call failures as at least one failed count so
         # the top-level batch doc's failCount is correctly 1, not 0.

--- a/client/src/cbltest/greenboarduploader.py
+++ b/client/src/cbltest/greenboarduploader.py
@@ -1,4 +1,5 @@
 import json
+import os
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from uuid import uuid4
@@ -34,6 +35,7 @@ class GreenboardUploader:
         self.__fail_count = 0
         self.__pass_count = 0
         self.__overall_fail = False
+        self.__test_ran = False
         self.__has_sgw_marker = False
 
     @pytest.hookimpl(hookwrapper=True, tryfirst=True)
@@ -44,6 +46,11 @@ class GreenboardUploader:
             if report.failed:
                 self.__overall_fail = True
             return
+
+        # Mark that at least one test reached the "call" phase. Zero
+        # collected tests is treated as a deviation from intent — recorded
+        # as a failed iteration so the chart doesn't silently turn green.
+        self.__test_ran = True
 
         if self.__overall_fail:
             return
@@ -151,17 +158,39 @@ class GreenboardUploader:
         """
         upgrade_path = [v.strip() for v in upgrade_versions_str.split(",") if v.strip()]
 
+        # Resolve the destination version of this iteration. Live SGW is
+        # primary; on get_version() failure the caller passes None and we
+        # fall back to the shell-exported step target so the dot still
+        # maps to the right node on the chart. Last-resort is the planned
+        # final target.
         target_build = 0
-        current_version = upgrade_path[-1] if upgrade_path else "0.0.0"
-        if sgw_version is not None:
-            current_version = sgw_version.version or current_version
+        if sgw_version is not None and sgw_version.version:
+            current_version = sgw_version.version
             target_build = sgw_version.build_number
+        else:
+            current_version = os.environ.get("SGW_VERSION_UNDER_TEST") or (
+                upgrade_path[-1] if upgrade_path else "0.0.0"
+            )
 
         upgrade_from = "initial"
         for i, v in enumerate(upgrade_path):
             if v == current_version and i > 0:
                 upgrade_from = upgrade_path[i - 1]
                 break
+
+        # Any deviation from "tests ran and all passed" is a failure.
+        # Includes: a test failed (call phase), setup/teardown crashed
+        # (overall_fail), or pytest collected zero tests (test_ran False).
+        had_test_failures = self.__fail_count > 0
+        setup_failure = self.__overall_fail
+        no_tests_collected = not self.__test_ran
+        failed = had_test_failures or setup_failure or no_tests_collected
+
+        # Surface non-test-call failures as at least one failed count so
+        # the top-level batch doc's failCount is correctly 1, not 0.
+        fail_count = self.__fail_count
+        if failed and fail_count == 0:
+            fail_count = 1
 
         iteration = {
             "phase": phase,
@@ -170,8 +199,8 @@ class GreenboardUploader:
             "upgradeTo": current_version,
             "build": target_build,
             "passCount": self.__pass_count,
-            "failCount": self.__fail_count,
-            "failed": self.__overall_fail or self.__fail_count > 0,
+            "failCount": fail_count,
+            "failed": failed,
         }
 
         path = Path(results_file)

--- a/client/src/cbltest/greenboarduploader.py
+++ b/client/src/cbltest/greenboarduploader.py
@@ -1,4 +1,6 @@
+import json
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from uuid import uuid4
 
 import pytest
@@ -125,57 +127,146 @@ class GreenboardUploader:
             }
         )
 
-    def upload_upgrade_step(
+    def record_upgrade_step(
         self,
+        results_file: str,
         sgw_version: CouchbaseVersion | None,
         upgrade_versions_str: str,
+        phase: str | None,
+        node_index: str | None,
     ) -> None:
-        """Upload results for a single upgrade step.
+        """Append this iteration's result to a JSON state file.
 
-        Infers ``upgradeFrom`` by finding the current SGW version's position
-        in the upgrade path. The previous entry is the source; if it's the
-        first entry, ``upgradeFrom`` is "initial".
+        The aggregated batch document is uploaded later (once per upgrade
+        run) by ``upload_upgrade_batch``. Failed iterations are recorded
+        too so the UI can surface where in the upgrade sequence the
+        failure occurred.
 
-        :param sgw_version: The current SGW version (target of this step)
+        :param results_file: Path to the JSON state file to append to
+        :param sgw_version: Current SGW version (target of this step)
         :param upgrade_versions_str: Comma-separated ordered version list
+        :param phase: SGW_UPGRADE_PHASE env value (e.g. "initial",
+            "rolling_node_0", "complete")
+        :param node_index: SGW_UPGRADED_NODE_INDEX env value, if any
         """
-        if self.__overall_fail:
-            cbl_warning("Overall result is failure, skipping upload...")
-            return
-
         upgrade_path = [v.strip() for v in upgrade_versions_str.split(",") if v.strip()]
 
-        # Target version: from the running SGW or last in upgrade path
-        target_version = upgrade_path[-1] if upgrade_path else "0.0.0"
         target_build = 0
-        current_version = target_version
+        current_version = upgrade_path[-1] if upgrade_path else "0.0.0"
         if sgw_version is not None:
-            current_version = sgw_version.version or target_version
-            target_version = upgrade_path[-1] if upgrade_path else current_version
+            current_version = sgw_version.version or current_version
             target_build = sgw_version.build_number
 
-        # Infer upgradeFrom by finding current version in the path
         upgrade_from = "initial"
         for i, v in enumerate(upgrade_path):
             if v == current_version and i > 0:
                 upgrade_from = upgrade_path[i - 1]
                 break
 
+        iteration = {
+            "phase": phase,
+            "nodeIndex": int(node_index) if node_index is not None else None,
+            "upgradeFrom": upgrade_from,
+            "upgradeTo": current_version,
+            "build": target_build,
+            "passCount": self.__pass_count,
+            "failCount": self.__fail_count,
+            "failed": self.__overall_fail or self.__fail_count > 0,
+        }
+
+        path = Path(results_file)
+        if path.exists():
+            try:
+                state = json.loads(path.read_text())
+            except (json.JSONDecodeError, OSError) as e:
+                cbl_warning(f"Could not read existing results file {path}: {e}")
+                state = {}
+        else:
+            state = {}
+
+        state.setdefault("upgradePath", upgrade_path)
+        state.setdefault("iterations", []).append(iteration)
+        path.write_text(json.dumps(state, indent=2))
+        cbl_info(
+            f"Upgrade step recorded ({phase}): {upgrade_from} → {current_version} "
+            f"(pass={self.__pass_count}, fail={self.__fail_count})"
+        )
+
+    def upload_upgrade_batch(self, results_file: str) -> None:
+        """Upload one aggregate document for the whole upgrade run.
+
+        Reads the iterations recorded by ``record_upgrade_step`` and emits
+        a single greenboard doc summarising the run. If any iteration
+        failed, ``failedAt`` points at the first failed iteration so the
+        UI can show where in the sequence the run broke.
+        """
+        path = Path(results_file)
+        if not path.exists():
+            cbl_warning(f"No upgrade results file at {path}; nothing to upload")
+            return
+
+        try:
+            state = json.loads(path.read_text())
+        except (json.JSONDecodeError, OSError) as e:
+            cbl_warning(f"Could not parse upgrade results file {path}: {e}")
+            return
+
+        iterations = state.get("iterations", [])
+        if not iterations:
+            cbl_warning(
+                f"Upgrade results file {path} has no iterations; skipping upload"
+            )
+            return
+
+        upgrade_path = state.get("upgradePath", [])
+        # version is always the planned final target so the UI's
+        # "filter by target version" picks up this run even when execution
+        # stopped early at an intermediate version.
+        target_version = (
+            upgrade_path[-1]
+            if upgrade_path
+            else iterations[-1].get("upgradeTo", "0.0.0")
+        )
+
+        failed_at = None
+        for i in iterations:
+            if i.get("failed"):
+                failed_at = {
+                    "phase": i.get("phase"),
+                    "upgradeFrom": i.get("upgradeFrom"),
+                    "upgradeTo": i.get("upgradeTo"),
+                    "nodeIndex": i.get("nodeIndex"),
+                }
+                break
+
+        # One upgrade batch == one upgrade test from the UI's POV. Bars are
+        # built by the UI by aggregating across past runs that share
+        # (version, upgradePath); per-run pass/fail is therefore 1/0.
+        if failed_at is None:
+            pass_count, fail_count = 1, 0
+            target_build = iterations[-1].get("build", 0)
+        else:
+            pass_count, fail_count = 0, 1
+            # The planned target build was never reached; per-iteration
+            # `build` fields preserve what was actually running at each step.
+            target_build = 0
+
         self._upload_document(
             {
                 "build": target_build,
                 "version": target_version,
                 "upgradePath": upgrade_path,
-                "upgradeFrom": upgrade_from,
-                "upgradeTo": current_version,
-                "failCount": self.__fail_count,
-                "passCount": self.__pass_count,
+                "iterations": iterations,
+                "passCount": pass_count,
+                "failCount": fail_count,
+                "failedAt": failed_at,
                 "platform": "sgw-upgrade",
             }
         )
         cbl_info(
-            f"Upgrade step uploaded: {upgrade_from} → {current_version} "
-            f"(pass={self.__pass_count}, fail={self.__fail_count})"
+            f"Upgrade batch uploaded: path={'->'.join(upgrade_path)} "
+            f"target={target_version} pass={pass_count} fail={fail_count} "
+            f"failedAt={failed_at}"
         )
 
     def _upload_document(self, doc: dict) -> None:

--- a/client/src/cbltest/plugins/greenboard_fixture.py
+++ b/client/src/cbltest/plugins/greenboard_fixture.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 import pytest_asyncio
 from cbltest import CBLPyTest
@@ -49,11 +51,26 @@ async def greenboard(cblpytest: CBLPyTest, pytestconfig: pytest.Config):
     try:
         upgrade_versions_str = pytestconfig.getoption("--upgrade-versions")
         if upgrade_versions_str:
-            # Upgrade job — upload this step's result directly
-            sgw_version: CouchbaseVersion | None = None
-            if len(cblpytest.sync_gateways) > 0:
-                sgw_version = await cblpytest.sync_gateways[0].get_version()
-            uploader.upload_upgrade_step(sgw_version, upgrade_versions_str)
+            # Upgrade job — record this iteration's result to a state file.
+            # The aggregate batch document is uploaded once at the end of
+            # the upgrade run by jenkins/pipelines/QE/upg-sgw/upload_greenboard_batch.py.
+            results_file = os.environ.get("SGW_UPGRADE_RESULTS_FILE")
+            if not results_file:
+                cbl_warning(
+                    "SGW_UPGRADE_RESULTS_FILE not set; upgrade iteration "
+                    "result will not be recorded"
+                )
+            else:
+                sgw_version: CouchbaseVersion | None = None
+                if len(cblpytest.sync_gateways) > 0:
+                    sgw_version = await cblpytest.sync_gateways[0].get_version()
+                uploader.record_upgrade_step(
+                    results_file,
+                    sgw_version,
+                    upgrade_versions_str,
+                    os.environ.get("SGW_UPGRADE_PHASE"),
+                    os.environ.get("SGW_UPGRADED_NODE_INDEX"),
+                )
         else:
             sgw_version: CouchbaseVersion | None = None
             test_platform: str = "sync-gateway"

--- a/client/src/cbltest/plugins/greenboard_fixture.py
+++ b/client/src/cbltest/plugins/greenboard_fixture.py
@@ -59,9 +59,20 @@ async def greenboard(cblpytest: CBLPyTest, pytestconfig: pytest.Config):
             results_file = os.environ.get(
                 "SGW_UPGRADE_RESULTS_FILE", "/tmp/sgw_upgrade_results.json"
             )
+            # During rolling phases the SGW node under upgrade may be
+            # destroyed/restarting and get_version() will raise. We must
+            # still record the iteration (with sgw_version=None) so the
+            # failure shows up as a red dot on the track chart instead
+            # of being silently dropped.
             sgw_version: CouchbaseVersion | None = None
             if len(cblpytest.sync_gateways) > 0:
-                sgw_version = await cblpytest.sync_gateways[0].get_version()
+                try:
+                    sgw_version = await cblpytest.sync_gateways[0].get_version()
+                except Exception as ve:
+                    cbl_warning(
+                        f"Could not fetch SGW version for upgrade record: {ve}; "
+                        "recording iteration with sgw_version=None"
+                    )
             uploader.record_upgrade_step(
                 results_file,
                 sgw_version,

--- a/client/src/cbltest/plugins/greenboard_fixture.py
+++ b/client/src/cbltest/plugins/greenboard_fixture.py
@@ -54,23 +54,21 @@ async def greenboard(cblpytest: CBLPyTest, pytestconfig: pytest.Config):
             # Upgrade job — record this iteration's result to a state file.
             # The aggregate batch document is uploaded once at the end of
             # the upgrade run by jenkins/pipelines/QE/upg-sgw/upload_greenboard_batch.py.
-            results_file = os.environ.get("SGW_UPGRADE_RESULTS_FILE")
-            if not results_file:
-                cbl_warning(
-                    "SGW_UPGRADE_RESULTS_FILE not set; upgrade iteration "
-                    "result will not be recorded"
-                )
-            else:
-                sgw_version: CouchbaseVersion | None = None
-                if len(cblpytest.sync_gateways) > 0:
-                    sgw_version = await cblpytest.sync_gateways[0].get_version()
-                uploader.record_upgrade_step(
-                    results_file,
-                    sgw_version,
-                    upgrade_versions_str,
-                    os.environ.get("SGW_UPGRADE_PHASE"),
-                    os.environ.get("SGW_UPGRADED_NODE_INDEX"),
-                )
+            # Default matches the shell wrapper's path so direct pytest
+            # invocations still record correctly.
+            results_file = os.environ.get(
+                "SGW_UPGRADE_RESULTS_FILE", "/tmp/sgw_upgrade_results.json"
+            )
+            sgw_version: CouchbaseVersion | None = None
+            if len(cblpytest.sync_gateways) > 0:
+                sgw_version = await cblpytest.sync_gateways[0].get_version()
+            uploader.record_upgrade_step(
+                results_file,
+                sgw_version,
+                upgrade_versions_str,
+                os.environ.get("SGW_UPGRADE_PHASE"),
+                os.environ.get("SGW_UPGRADED_NODE_INDEX"),
+            )
         else:
             sgw_version: CouchbaseVersion | None = None
             test_platform: str = "sync-gateway"

--- a/jenkins/pipelines/QE/sgw/Jenkinsfile
+++ b/jenkins/pipelines/QE/sgw/Jenkinsfile
@@ -7,7 +7,10 @@ def resolveProgetVersion(String product, String version, String label) {
     echo "Resolving ${label}: ${url}"
     def resolved
     if (isUnix()) {
-        resolved = sh(script: "curl -sf '${url}' | jq -r .version", returnStdout: true).trim()
+        resolved = powershell(script: """
+            try { (Invoke-RestMethod '${url}').version }
+            catch { Write-Error "ProGet request failed for ${label}: \$_"; exit 1 }
+        """.stripIndent(), returnStdout: true).trim()
     } else {
         resolved = powershell(script: """
             try { (Invoke-RestMethod '${url}').version }

--- a/jenkins/pipelines/QE/upg-sgw/Jenkinsfile
+++ b/jenkins/pipelines/QE/upg-sgw/Jenkinsfile
@@ -7,7 +7,11 @@ def resolveProgetVersion(String product, String version, String label) {
     echo "Resolving ${label}: ${url}"
     def resolved
     if (isUnix()) {
-        resolved = sh(script: "curl -sf '${url}' | jq -r .version", returnStdout: true).trim()
+        resolved = sh(
+              script: """curl -sf '${url}' | python3 -c 'import json,sys;
+          print(json.load(sys.stdin).get("version",""))'""",
+              returnStdout: true
+          ).trim()
     } else {
         resolved = powershell(script: """
             try { (Invoke-RestMethod '${url}').version }

--- a/jenkins/pipelines/QE/upg-sgw/Jenkinsfile
+++ b/jenkins/pipelines/QE/upg-sgw/Jenkinsfile
@@ -8,10 +8,9 @@ def resolveProgetVersion(String product, String version, String label) {
     def resolved
     if (isUnix()) {
         resolved = sh(
-              script: """curl -sf '${url}' | python3 -c 'import json,sys;
-          print(json.load(sys.stdin).get("version",""))'""",
-              returnStdout: true
-          ).trim()
+            script: "curl -sf '${url}' | python3 -c 'import json,sys; print(json.load(sys.stdin).get(\"version\",\"\"))'",
+            returnStdout: true
+        ).trim()
     } else {
         resolved = powershell(script: """
             try { (Invoke-RestMethod '${url}').version }

--- a/jenkins/pipelines/QE/upg-sgw/Jenkinsfile_rolling
+++ b/jenkins/pipelines/QE/upg-sgw/Jenkinsfile_rolling
@@ -7,7 +7,11 @@ def resolveProgetVersion(String product, String version, String label) {
     echo "Resolving ${label}: ${url}"
     def resolved
     if (isUnix()) {
-        resolved = sh(script: "curl -sf '${url}' | jq -r .version", returnStdout: true).trim()
+        resolved = sh(
+              script: """curl -sf '${url}' | python3 -c 'import json,sys;
+          print(json.load(sys.stdin).get("version",""))'""",
+              returnStdout: true
+          ).trim()
     } else {
         resolved = powershell(script: """
             try { (Invoke-RestMethod '${url}').version }

--- a/jenkins/pipelines/QE/upg-sgw/Jenkinsfile_rolling
+++ b/jenkins/pipelines/QE/upg-sgw/Jenkinsfile_rolling
@@ -8,10 +8,9 @@ def resolveProgetVersion(String product, String version, String label) {
     def resolved
     if (isUnix()) {
         resolved = sh(
-              script: """curl -sf '${url}' | python3 -c 'import json,sys;
-          print(json.load(sys.stdin).get("version",""))'""",
-              returnStdout: true
-          ).trim()
+            script: "curl -sf '${url}' | python3 -c 'import json,sys; print(json.load(sys.stdin).get(\"version\",\"\"))'",
+            returnStdout: true
+        ).trim()
     } else {
         resolved = powershell(script: """
             try { (Invoke-RestMethod '${url}').version }

--- a/jenkins/pipelines/QE/upg-sgw/test.sh
+++ b/jenkins/pipelines/QE/upg-sgw/test.sh
@@ -3,6 +3,44 @@
 trap 'echo "$BASH_COMMAND (line $LINENO) failed, exiting..."; exit 1' ERR
 set -euo pipefail
 
+# Aggregated greenboard upload: per-iteration results are written to this
+# file by the greenboard pytest fixture; a single batch document is
+# uploaded on script exit (success or failure).
+export SGW_UPGRADE_RESULTS_FILE="${SGW_UPGRADE_RESULTS_FILE:-/tmp/sgw_upgrade_results.json}"
+rm -f "$SGW_UPGRADE_RESULTS_FILE"
+
+function upload_batch_results() {
+    local exit_code=$?
+    echo ">>> EXIT trap: greenboard batch upload (script exit=$exit_code)"
+    if [ ! -f "$SGW_UPGRADE_RESULTS_FILE" ]; then
+        echo ">>> No upgrade results file at $SGW_UPGRADE_RESULTS_FILE; skipping batch upload"
+        return $exit_code
+    fi
+    if [ -z "${QE_TESTS_DIR:-}" ] || [ -z "${SCRIPT_DIR:-}" ]; then
+        echo ">>> Paths not initialized (QE_TESTS_DIR/SCRIPT_DIR); skipping batch upload"
+        return $exit_code
+    fi
+    echo ">>> Recorded iterations (${SGW_UPGRADE_RESULTS_FILE}):"
+    cat "$SGW_UPGRADE_RESULTS_FILE" || true
+    echo ""
+    echo ">>> Uploading aggregated greenboard batch result..."
+    pushd "$QE_TESTS_DIR" > /dev/null || return $exit_code
+    set +e
+    uv run "$SCRIPT_DIR/upload_greenboard_batch.py" \
+        --config config.json \
+        --results-file "$SGW_UPGRADE_RESULTS_FILE"
+    upload_rc=$?
+    set -e
+    if [ $upload_rc -ne 0 ]; then
+        echo ">>> ERROR: greenboard batch upload failed with exit code $upload_rc"
+    else
+        echo ">>> Greenboard batch upload completed."
+    fi
+    popd > /dev/null || true
+    return $exit_code
+}
+trap upload_batch_results EXIT
+
 function usage() {
     echo "Usage: $0 <version> <sgw_version_1> [<sgw_version_2> ... <sgw_version_N>] [--setup-only]"
     echo "  <cbl_version>: The Couchbase Server version to test against."
@@ -53,6 +91,8 @@ fi
 # Run initial tests
 echo ">>> Running tests for initial setup with SGW: $CURRENT_SGW_VERSION ..."
 export SGW_VERSION_UNDER_TEST="$CURRENT_SGW_VERSION"
+export SGW_UPGRADE_PHASE="initial"
+unset SGW_UPGRADED_NODE_INDEX 2>/dev/null || true
 pushd $QE_TESTS_DIR > /dev/null
 uv run pytest -s -v --no-header -W ignore::DeprecationWarning --config config.json -m upg_sgw \
     --upgrade-versions "$UPGRADE_VERSIONS" \
@@ -86,6 +126,8 @@ for ((i=1; i<${#SGW_VERSIONS[@]}; i++)); do
 
     echo ">>> Running tests after upgrading to SGW: $CURRENT_SGW_VERSION ..."
     export SGW_VERSION_UNDER_TEST="$CURRENT_SGW_VERSION"
+    export SGW_UPGRADE_PHASE="upgrade_to_$CURRENT_SGW_VERSION"
+    export SGW_PREVIOUS_VERSION="$PREVIOUS_SGW_VERSION"
     pushd $QE_TESTS_DIR > /dev/null
     uv run pytest -s -v --no-header -W ignore::DeprecationWarning --config config.json -m upg_sgw \
         --upgrade-versions "$UPGRADE_VERSIONS" \

--- a/jenkins/pipelines/QE/upg-sgw/test_rolling.sh
+++ b/jenkins/pipelines/QE/upg-sgw/test_rolling.sh
@@ -11,20 +11,31 @@ rm -f "$SGW_UPGRADE_RESULTS_FILE"
 
 function upload_batch_results() {
     local exit_code=$?
+    echo ">>> EXIT trap: greenboard batch upload (script exit=$exit_code)"
     if [ ! -f "$SGW_UPGRADE_RESULTS_FILE" ]; then
         echo ">>> No upgrade results file at $SGW_UPGRADE_RESULTS_FILE; skipping batch upload"
         return $exit_code
     fi
     if [ -z "${QE_TESTS_DIR:-}" ] || [ -z "${SCRIPT_DIR:-}" ]; then
-        echo ">>> Paths not initialized; skipping batch upload"
+        echo ">>> Paths not initialized (QE_TESTS_DIR/SCRIPT_DIR); skipping batch upload"
         return $exit_code
     fi
-    echo ">>> Uploading aggregated greenboard batch result (exit=$exit_code)..."
+    echo ">>> Recorded iterations (${SGW_UPGRADE_RESULTS_FILE}):"
+    cat "$SGW_UPGRADE_RESULTS_FILE" || true
+    echo ""
+    echo ">>> Uploading aggregated greenboard batch result..."
     pushd "$QE_TESTS_DIR" > /dev/null || return $exit_code
+    set +e
     uv run "$SCRIPT_DIR/upload_greenboard_batch.py" \
         --config config.json \
-        --results-file "$SGW_UPGRADE_RESULTS_FILE" || \
-        echo ">>> WARNING: greenboard batch upload failed"
+        --results-file "$SGW_UPGRADE_RESULTS_FILE"
+    upload_rc=$?
+    set -e
+    if [ $upload_rc -ne 0 ]; then
+        echo ">>> ERROR: greenboard batch upload failed with exit code $upload_rc"
+    else
+        echo ">>> Greenboard batch upload completed."
+    fi
     popd > /dev/null || true
     return $exit_code
 }

--- a/jenkins/pipelines/QE/upg-sgw/test_rolling.sh
+++ b/jenkins/pipelines/QE/upg-sgw/test_rolling.sh
@@ -3,6 +3,33 @@
 trap 'echo "$BASH_COMMAND (line $LINENO) failed, exiting..."; exit 1' ERR
 set -euo pipefail
 
+# Aggregated greenboard upload: per-iteration results are written to this
+# file by the greenboard pytest fixture, and a single batch document is
+# uploaded on script exit (success or failure).
+export SGW_UPGRADE_RESULTS_FILE="${SGW_UPGRADE_RESULTS_FILE:-/tmp/sgw_upgrade_results.json}"
+rm -f "$SGW_UPGRADE_RESULTS_FILE"
+
+function upload_batch_results() {
+    local exit_code=$?
+    if [ ! -f "$SGW_UPGRADE_RESULTS_FILE" ]; then
+        echo ">>> No upgrade results file at $SGW_UPGRADE_RESULTS_FILE; skipping batch upload"
+        return $exit_code
+    fi
+    if [ -z "${QE_TESTS_DIR:-}" ] || [ -z "${SCRIPT_DIR:-}" ]; then
+        echo ">>> Paths not initialized; skipping batch upload"
+        return $exit_code
+    fi
+    echo ">>> Uploading aggregated greenboard batch result (exit=$exit_code)..."
+    pushd "$QE_TESTS_DIR" > /dev/null || return $exit_code
+    uv run "$SCRIPT_DIR/upload_greenboard_batch.py" \
+        --config config.json \
+        --results-file "$SGW_UPGRADE_RESULTS_FILE" || \
+        echo ">>> WARNING: greenboard batch upload failed"
+    popd > /dev/null || true
+    return $exit_code
+}
+trap upload_batch_results EXIT
+
 function usage() {
     echo "Usage: $0 <cbl_version> <sgw_version_1> [<sgw_version_2> ... <sgw_version_N>] [--setup-only]"
     echo "  <cbl_version>: The Couchbase Lite version to test against."

--- a/jenkins/pipelines/QE/upg-sgw/upload_greenboard_batch.py
+++ b/jenkins/pipelines/QE/upg-sgw/upload_greenboard_batch.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Upload one aggregate greenboard document for a rolling SGW upgrade run.
+
+Reads per-iteration results recorded by the greenboard pytest fixture and
+emits a single doc to greenboard with the full iteration history plus a
+``failedAt`` marker pointing at the first failed step (if any).
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import click
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if __name__ == "__main__":
+    sys.path.append(str(SCRIPT_DIR.parents[3]))
+
+from cbltest.greenboarduploader import GreenboardUploader  # noqa: E402
+
+
+@click.command()
+@click.option("--config", "config_path", required=True, type=click.Path(exists=True))
+@click.option("--results-file", required=True, type=click.Path())
+def cli_entry(config_path: str, results_file: str) -> None:
+    cfg = json.loads(Path(config_path).read_text())
+    gb = cfg.get("greenboard")
+    if not gb:
+        click.echo("No greenboard section in config; nothing to upload.", err=True)
+        return
+
+    if not Path(results_file).exists():
+        click.echo(
+            f"Results file {results_file} does not exist; nothing to upload.",
+            err=True,
+        )
+        return
+
+    uploader = GreenboardUploader(gb["hostname"], gb["username"], gb["password"])
+    uploader.upload_upgrade_batch(results_file)
+
+
+if __name__ == "__main__":
+    cli_entry()


### PR DESCRIPTION
[CBG-5369](https://jira.issues.couchbase.com/browse/CBG-5369)

There is a need to change the visualization for SGW Upgrade test runs shown up on greenboard because the upgrade path and the source and target versions make it very much different from the traditional bar-graph way of viewing the passed and failed tests. I am still working on the POC and finalizing something similar to Ben's idea.

This PR involves the schema changes for the same, it will have a bit more commits before I assign an human reviewer to it.

[CBG-5369]: https://couchbasecloud.atlassian.net/browse/CBG-5369?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ