### PR TITLE
Added fixes needed for QE Jenkins

### DIFF
--- a/jenkins/pipelines/QE/c/Jenkinsfile
+++ b/jenkins/pipelines/QE/c/Jenkinsfile
@@ -14,6 +14,7 @@ pipeline {
                 script {
                     if (params.CBL_VERSION == '') { error "CBL_VERSION is required" }
                     if (params.SGW_VERSION == '') { error "SGW_VERSION is required" }
+
                     currentBuild.displayName = "C CBL:${params.CBL_VERSION} (#${currentBuild.number})"
                     currentBuild.description = "SGW: ${params.SGW_VERSION}"
                 }
@@ -23,10 +24,10 @@ pipeline {
             steps {
                 script {
                     def platforms = [
-                        'c_macos', 'c_linux_x86_64'
+                        'c_macos', 'c_ios', 'c_android', 'c_windows', 'c_linux_x86_64'
                     ]
                     def parallelBuilds = [:]
-                    for (p in platforms) {
+                    for(p in platforms) {
                         def platform = p
                         parallelBuilds[platform] = {
                             build job: 'prebuild-test-server',
@@ -52,7 +53,6 @@ pipeline {
                     environment {
                         PATH = "/opt/homebrew/opt/python@3.10/bin:/opt/homebrew/bin:/usr/local/bin:${env.PATH}"
                         TS_ARTIFACTS_DIR = 'c_macos'
-                        TS_DATASET_VERSION = "${params.TS_DATASET_VERSION}"
                     }
                     steps {
                         withCredentials([string(credentialsId: 'mobile-qe', variable: 'KEYCHAIN_PASSWORD')]) {
@@ -75,8 +75,73 @@ pipeline {
                         }
                     }
                 }
+                stage('iOS') {
+                    agent { label 'mac-mini-new' }
+                    options {
+                        lock('mac-mini-new,00008101-000E0519020A001E')
+                    }
+                    environment {
+                        PATH = "/opt/homebrew/opt/python@3.10/bin:/opt/homebrew/bin:/usr/local/bin:${env.PATH}"
+                        TS_ARTIFACTS_DIR = 'c_ios'
+                    }
+                    steps {
+                        withCredentials([string(credentialsId: 'mobile-qe', variable: 'KEYCHAIN_PASSWORD')]) {
+                            sh 'security unlock-keychain -p ${KEYCHAIN_PASSWORD} ~/Library/Keychains/login.keychain-db'
+                        }
+                        echo "=== Run C iOS Tests"
+                        timeout(time: 120, unit: 'MINUTES') {
+                            sh "jenkins/pipelines/QE/c/run_test.sh ${params.CBL_VERSION} ios ${params.SGW_VERSION} ${params.TS_DATASET_VERSION}"
+                        }
+                        echo "=== C iOS Tests Complete"
+                    }
+                    post {
+                        always {
+                            echo "=== Teardown C iOS Tests"
+                            timeout(time: 5, unit: 'MINUTES') {
+                                sh 'jenkins/pipelines/QE/c/teardown.sh'
+                            }
+                            archiveArtifacts artifacts: 'tests/QE/c_ios/**/*', fingerprint: true, allowEmptyArchive: true
+                            echo "=== C iOS Test Teardown Complete"
+                        }
+                    }
+                }
+                stage('Android') {
+                    agent { label 'mac-mini-CBL-Android1' }
+                    options {
+                        lock('mac-mini-CBL-Android1,R5CT20FYA7R')
+                    }
+                    environment {
+                        ANDROID_HOME = "/Users/couchbase/Library/Android/sdk"
+                        JAVA_HOME = "/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home"
+                        PATH = "\$JAVA_HOME/bin:\$ANDROID_HOME/platform-tools:\$ANDROID_HOME/tools:\$ANDROID_HOME/tools/bin:/opt/homebrew/opt/python@3.10/bin:/opt/homebrew/bin:/usr/local/bin:${env.PATH}"
+                        TS_ARTIFACTS_DIR = 'c_android'
+                    }
+                    steps {
+                        withCredentials([string(credentialsId: 'mobile-qe', variable: 'KEYCHAIN_PASSWORD')]) {
+                            sh 'security unlock-keychain -p ${KEYCHAIN_PASSWORD} ~/Library/Keychains/login.keychain-db'
+                        }
+                        echo "=== Run C Android Tests"
+                        timeout(time: 120, unit: 'MINUTES') {
+                            sh "jenkins/pipelines/QE/c/run_test.sh ${params.CBL_VERSION} android ${params.SGW_VERSION} ${params.TS_DATASET_VERSION}"
+                        }
+                        echo "=== C Android Tests Complete"
+                    }
+                    post {
+                        always {
+                            echo "=== Teardown C Android Tests"
+                            timeout(time: 5, unit: 'MINUTES') {
+                                sh 'jenkins/pipelines/QE/c/teardown.sh'
+                            }
+                            archiveArtifacts artifacts: 'tests/QE/c_android/**/*', fingerprint: true, allowEmptyArchive: true
+                            echo "=== C Android Test Teardown Complete"
+                        }
+                    }
+                }
                 stage('Linux') {
                     agent { label 'linux-c' }
+                    options {
+                        lock('linux-c')
+                    }
                     environment {
                         TS_ARTIFACTS_DIR = 'c_linux'
                     }
@@ -95,6 +160,32 @@ pipeline {
                             }
                             archiveArtifacts artifacts: 'tests/QE/c_linux/**/*', fingerprint: true, allowEmptyArchive: true
                             echo "=== C Linux Test Teardown Complete"
+                        }
+                    }
+                }
+                stage('Windows') {
+                    agent { label 'net-windows' }
+                    options {
+                        lock('net-windows')
+                    }
+                    environment {
+                        TS_ARTIFACTS_DIR = 'c_windows'
+                    }
+                    steps {
+                        echo "=== Run C Windows Tests"
+                        timeout(time: 120, unit: 'MINUTES') {
+                            powershell "jenkins\\pipelines\\QE\\c\\run_test.ps1 -Version ${params.CBL_VERSION} -SgwVersion ${params.SGW_VERSION} -DatasetVersion ${params.TS_DATASET_VERSION}"
+                        }
+                        echo "=== C Windows Tests Complete"
+                    }
+                    post {
+                        always {
+                            echo "=== Teardown C Windows Tests"
+                            timeout(time: 5, unit: 'MINUTES') {
+                                powershell 'jenkins\\pipelines\\QE\\c\\teardown.ps1'
+                            }
+                            archiveArtifacts artifacts: 'tests\\QE\\c_windows\\**\\*', fingerprint: true, allowEmptyArchive: true
+                            echo "=== C Windows Test Teardown Complete"
                         }
                     }
                 }

--- a/jenkins/pipelines/QE/c/Jenkinsfile
+++ b/jenkins/pipelines/QE/c/Jenkinsfile
@@ -60,7 +60,7 @@ pipeline {
                         }
                         echo "=== Run C macOS Tests"
                         timeout(time: 120, unit: 'MINUTES') {
-                            sh "jenkins/pipelines/QE/c/run_test.sh ${params.CBL_VERSION} macos ${params.SGW_VERSION}"
+                            sh "jenkins/pipelines/QE/c/run_test.sh ${params.CBL_VERSION} macos ${params.SGW_VERSION} ${params.TS_DATASET_VERSION}"
                         }
                         echo "=== C macOS Tests Complete"
                     }

--- a/jenkins/pipelines/QE/c/Jenkinsfile
+++ b/jenkins/pipelines/QE/c/Jenkinsfile
@@ -2,8 +2,11 @@ pipeline {
     agent none
     parameters {
         string(name: 'CBL_VERSION', defaultValue: '3.3.0', description: 'Couchbase Lite Version (build number will be fetched if not provided)')
-        string(name: 'SGW_VERSION', defaultValue: '3.3.0', description: "The version of Sync Gateway to download")
+        string(name: 'SGW_VERSION', defaultValue: '3.3.0', description: 'The version of Sync Gateway to download')
         string(name: 'TS_DATASET_VERSION', defaultValue: '4.0', description: 'The version of the dataset to use on the test servers')
+    }
+    options {
+        timeout(time: 150, unit: 'MINUTES')
     }
     stages {
         stage('Init') {
@@ -11,8 +14,7 @@ pipeline {
                 script {
                     if (params.CBL_VERSION == '') { error "CBL_VERSION is required" }
                     if (params.SGW_VERSION == '') { error "SGW_VERSION is required" }
-
-                    currentBuild.displayName = "C Linux CBL:${params.CBL_VERSION} (#${currentBuild.number})"
+                    currentBuild.displayName = "C CBL:${params.CBL_VERSION} (#${currentBuild.number})"
                     currentBuild.description = "SGW: ${params.SGW_VERSION}"
                 }
             }
@@ -21,19 +23,16 @@ pipeline {
             steps {
                 script {
                     def platforms = [
-                        'c_windows', 'c_ios', 'c_android','c_linux_x86_64'
+                        'c_macos', 'c_linux_x86_64'
                     ]
                     def parallelBuilds = [:]
-                    for(p in platforms) {
-                        // Groovy stupidness.  Need to set a local variable here
-                        // to avoid late binding (all jobs use dotnet_macos).
+                    for (p in platforms) {
                         def platform = p
                         parallelBuilds[platform] = {
                             build job: 'prebuild-test-server',
                             parameters: [
                                 string(name: 'TS_PLATFORM', value: platform),
                                 string(name: 'CBL_VERSION', value: params.CBL_VERSION),
-                                string(name: 'CBL_BUILD', value: params.CBL_BUILD)
                             ],
                             wait: true,
                             propagate: true
@@ -43,110 +42,43 @@ pipeline {
                 }
             }
         }
-        stage('Tests') {
+        stage('Run Tests') {
             parallel {
-                stage('Windows') {
-                    agent { label 'net-windows' }
+                stage('macOS') {
+                    agent { label 'mac-mini-new' }
                     options {
-                        lock('net-windows')
+                        lock('mac-mini-new')
                     }
                     environment {
+                        PATH = "/opt/homebrew/opt/python@3.10/bin:/opt/homebrew/bin:/usr/local/bin:${env.PATH}"
+                        TS_ARTIFACTS_DIR = 'c_macos'
                         TS_DATASET_VERSION = "${params.TS_DATASET_VERSION}"
                     }
                     steps {
-                        echo "=== Run C Windows Tests"
-                        timeout(time: 120, unit: 'MINUTES') {
-                            bat '''
-                            "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" ^
-                            -NoProfile ^
-                            -ExecutionPolicy Bypass ^
-                            -File jenkins\\pipelines\\QE\\c\\run_test.ps1 ^
-                            -Version %CBL_VERSION% ^
-                            -SgwVersion %SGW_VERSION% ^
-                            -DatasetVersion %TS_DATASET_VERSION%
-                            '''
-                        }
-                        echo "=== C Windows Tests Complete"
-                    }
-                    post {
-                        always {
-                            echo "=== Teardown C Windows Tests"
-                            timeout(time: 5, unit: 'MINUTES') {
-                                bat '''
-                                "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" ^
-                                -NoProfile ^
-                                -ExecutionPolicy Bypass ^
-                                -File jenkins\\pipelines\\QE\\c\\teardown.ps1
-                                '''
-                            }
-                            archiveArtifacts artifacts: 'tests\\QE\\c_windows\\**\\*', fingerprint: true, allowEmptyArchive: true
-                            echo "=== C Windows Test Teardown Complete"
-                        }
-                    }
-                }
-                stage('Android') {
-                    agent { label 'qe-mac-india' }
-                    environment {
-                        KEYCHAIN_PASSWORD = credentials('mobile-qe-india')
-                        DOTNET_ROOT = "/opt/homebrew/opt/dotnet/libexec"
-                        PATH = "/opt/homebrew/opt/python@3.10/bin:/opt/homebrew/bin:/usr/local/bin:${env.PATH}:/Users/qe_mobile_india/Library/Android/sdk/cmdline-tools/latest/bin:/Users/qe_mobile_india/Library/Android/sdk/platform-tools:/Users/qe_mobile_india/Library/Android/sdk/emulator:${PATH}"
-                        AWS_PROFILE = "default"
-                        ANDROID_HOME = "/Users/qe_mobile_india/Library/Android/sdk"
-                    }
-                    steps {
-                        // Unlock keychain:
                         withCredentials([string(credentialsId: 'mobile-qe', variable: 'KEYCHAIN_PASSWORD')]) {
                             sh 'security unlock-keychain -p ${KEYCHAIN_PASSWORD} ~/Library/Keychains/login.keychain-db'
                         }
-                        echo "=== Run C Android Tests"
+                        echo "=== Run C macOS Tests"
                         timeout(time: 120, unit: 'MINUTES') {
-                            sh "jenkins/pipelines/QE/c/run_test.sh ${params.CBL_VERSION} android ${params.SGW_VERSION} ${params.TS_DATASET_VERSION}"
+                            sh "jenkins/pipelines/QE/c/run_test.sh ${params.CBL_VERSION} macos ${params.SGW_VERSION}"
                         }
-                        echo "=== C Android Tests Complete"
+                        echo "=== C macOS Tests Complete"
                     }
                     post {
                         always {
-                            echo "=== Teardown C Android Tests"
+                            echo "=== Teardown C macOS Tests"
                             timeout(time: 5, unit: 'MINUTES') {
                                 sh 'jenkins/pipelines/QE/c/teardown.sh'
                             }
-                            archiveArtifacts artifacts: 'tests/QE/c_android/**/*', fingerprint: true, allowEmptyArchive: true
-                            echo "=== C Android Test Teardown Complete"
+                            archiveArtifacts artifacts: 'tests/QE/c_macos/**/*', fingerprint: true, allowEmptyArchive: true
+                            echo "=== C macOS Test Teardown Complete"
                         }
                     }
                 }
-                stage('iOS') {
-                    agent { label 'qe-mac-india' }
-                    environment {
-                        KEYCHAIN_PASSWORD = credentials('mobile-qe-india')
-                        PATH = "/opt/homebrew/opt/python@3.10/bin:/opt/homebrew/bin:/usr/local/bin:${env.PATH}"
-                        TS_ARTIFACTS_DIR = 'ios'
-                        TS_DATASET_VERSION = "${params.TS_DATASET_VERSION}"
-                    }
-                    steps {
-                        // Unlock keychain:
-                        sh 'security unlock-keychain -p ${KEYCHAIN_PASSWORD} ~/Library/Keychains/login.keychain-db'
-                        echo "=== Run C iOS Tests"
-                        timeout(time: 120, unit: 'MINUTES') {
-                            sh "jenkins/pipelines/QE/c/run_test.sh ${params.CBL_VERSION} ios ${params.SGW_VERSION} ${params.TS_DATASET_VERSION}"
-                        }
-                        echo "=== C iOS Tests Complete"
-                    }
-                    post {
-                        always {
-                            echo "=== Teardown C iOS Tests"
-                            timeout(time: 5, unit: 'MINUTES') {
-                                sh 'jenkins/pipelines/QE/c/teardown.sh'
-                            }
-                            archiveArtifacts artifacts: 'tests/QE/c_ios/**/*', fingerprint: true, allowEmptyArchive: true
-                            echo "=== C iOS Test Teardown Complete"
-                        }
-                    }
-                }
-                stage('linux_x86_64') {
+                stage('Linux') {
                     agent { label 'linux-c' }
                     environment {
-                        TS_ARTIFACTS_DIR = 'c'
+                        TS_ARTIFACTS_DIR = 'c_linux'
                     }
                     steps {
                         echo "=== Run C Linux Tests"

--- a/jenkins/pipelines/QE/c/Jenkinsfile
+++ b/jenkins/pipelines/QE/c/Jenkinsfile
@@ -23,7 +23,7 @@ pipeline {
             steps {
                 script {
                     def platforms = [
-                        'c_macos', 'c_linux_x86_64'
+                        'c_macos', 'c_ios', 'c_android', 'c_windows', 'c_linux_x86_64'
                     ]
                     def parallelBuilds = [:]
                     for(p in platforms) {
@@ -71,6 +71,68 @@ pipeline {
                         }
                     }
                 }
+                stage('iOS') {
+                    agent { label 'mac-mini-new' }
+                    options {
+                        lock('00008101-000E0519020A001E')
+                    }
+                    environment {
+                        PATH = "/opt/homebrew/opt/python@3.10/bin:/opt/homebrew/bin:/usr/local/bin:${env.PATH}"
+                        TS_ARTIFACTS_DIR = 'c_ios'
+                    }
+                    steps {
+                        withCredentials([string(credentialsId: 'mobile-qe', variable: 'KEYCHAIN_PASSWORD')]) {
+                            sh 'security unlock-keychain -p ${KEYCHAIN_PASSWORD} ~/Library/Keychains/login.keychain-db'
+                        }
+                        echo "=== Run C iOS Tests"
+                        timeout(time: 120, unit: 'MINUTES') {
+                            sh "jenkins/pipelines/QE/c/run_test.sh ${params.CBL_VERSION} ios ${params.SGW_VERSION} ${params.TS_DATASET_VERSION}"
+                        }
+                        echo "=== C iOS Tests Complete"
+                    }
+                    post {
+                        always {
+                            echo "=== Teardown C iOS Tests"
+                            timeout(time: 5, unit: 'MINUTES') {
+                                sh 'jenkins/pipelines/QE/c/teardown.sh'
+                            }
+                            archiveArtifacts artifacts: 'tests/QE/c_ios/**/*', fingerprint: true, allowEmptyArchive: true
+                            echo "=== C iOS Test Teardown Complete"
+                        }
+                    }
+                }
+                stage('Android') {
+                    agent { label 'mac-mini-CBL-Android1' }
+                    options {
+                        lock('R5CT20FYA7R')
+                    }
+                    environment {
+                        ANDROID_HOME = "/Users/couchbase/Library/Android/sdk"
+                        JAVA_HOME = "/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home"
+                        PATH = "\$JAVA_HOME/bin:\$ANDROID_HOME/platform-tools:\$ANDROID_HOME/tools:\$ANDROID_HOME/tools/bin:/opt/homebrew/opt/python@3.10/bin:/opt/homebrew/bin:/usr/local/bin:${env.PATH}"
+                        TS_ARTIFACTS_DIR = 'c_android'
+                    }
+                    steps {
+                        withCredentials([string(credentialsId: 'mobile-qe', variable: 'KEYCHAIN_PASSWORD')]) {
+                            sh 'security unlock-keychain -p ${KEYCHAIN_PASSWORD} ~/Library/Keychains/login.keychain-db'
+                        }
+                        echo "=== Run C Android Tests"
+                        timeout(time: 120, unit: 'MINUTES') {
+                            sh "jenkins/pipelines/QE/c/run_test.sh ${params.CBL_VERSION} android ${params.SGW_VERSION} ${params.TS_DATASET_VERSION}"
+                        }
+                        echo "=== C Android Tests Complete"
+                    }
+                    post {
+                        always {
+                            echo "=== Teardown C Android Tests"
+                            timeout(time: 5, unit: 'MINUTES') {
+                                sh 'jenkins/pipelines/QE/c/teardown.sh'
+                            }
+                            archiveArtifacts artifacts: 'tests/QE/c_android/**/*', fingerprint: true, allowEmptyArchive: true
+                            echo "=== C Android Test Teardown Complete"
+                        }
+                    }
+                }
                 stage('Linux') {
                     agent { label 'linux-c' }
                     environment {
@@ -91,6 +153,29 @@ pipeline {
                             }
                             archiveArtifacts artifacts: 'tests/QE/c_linux/**/*', fingerprint: true, allowEmptyArchive: true
                             echo "=== C Linux Test Teardown Complete"
+                        }
+                    }
+                }
+                stage('Windows') {
+                    agent { label 'net-windows' }
+                    environment {
+                        TS_ARTIFACTS_DIR = 'c_windows'
+                    }
+                    steps {
+                        echo "=== Run C Windows Tests"
+                        timeout(time: 120, unit: 'MINUTES') {
+                            powershell "jenkins\\pipelines\\QE\\c\\run_test.ps1 -Version ${params.CBL_VERSION} -SgwVersion ${params.SGW_VERSION} -DatasetVersion ${params.TS_DATASET_VERSION}"
+                        }
+                        echo "=== C Windows Tests Complete"
+                    }
+                    post {
+                        always {
+                            echo "=== Teardown C Windows Tests"
+                            timeout(time: 5, unit: 'MINUTES') {
+                                powershell 'jenkins\\pipelines\\QE\\c\\teardown.ps1'
+                            }
+                            archiveArtifacts artifacts: 'tests\\QE\\c_windows\\**\\*', fingerprint: true, allowEmptyArchive: true
+                            echo "=== C Windows Test Teardown Complete"
                         }
                     }
                 }

--- a/jenkins/pipelines/QE/c/Jenkinsfile
+++ b/jenkins/pipelines/QE/c/Jenkinsfile
@@ -23,7 +23,7 @@ pipeline {
             steps {
                 script {
                     def platforms = [
-                        'c_macos', 'c_ios', 'c_android', 'c_windows', 'c_linux_x86_64'
+                        'c_macos', 'c_linux_x86_64'
                     ]
                     def parallelBuilds = [:]
                     for(p in platforms) {
@@ -71,68 +71,6 @@ pipeline {
                         }
                     }
                 }
-                stage('iOS') {
-                    agent { label 'mac-mini-new' }
-                    options {
-                        lock('00008101-000E0519020A001E')
-                    }
-                    environment {
-                        PATH = "/opt/homebrew/opt/python@3.10/bin:/opt/homebrew/bin:/usr/local/bin:${env.PATH}"
-                        TS_ARTIFACTS_DIR = 'c_ios'
-                    }
-                    steps {
-                        withCredentials([string(credentialsId: 'mobile-qe', variable: 'KEYCHAIN_PASSWORD')]) {
-                            sh 'security unlock-keychain -p ${KEYCHAIN_PASSWORD} ~/Library/Keychains/login.keychain-db'
-                        }
-                        echo "=== Run C iOS Tests"
-                        timeout(time: 120, unit: 'MINUTES') {
-                            sh "jenkins/pipelines/QE/c/run_test.sh ${params.CBL_VERSION} ios ${params.SGW_VERSION} ${params.TS_DATASET_VERSION}"
-                        }
-                        echo "=== C iOS Tests Complete"
-                    }
-                    post {
-                        always {
-                            echo "=== Teardown C iOS Tests"
-                            timeout(time: 5, unit: 'MINUTES') {
-                                sh 'jenkins/pipelines/QE/c/teardown.sh'
-                            }
-                            archiveArtifacts artifacts: 'tests/QE/c_ios/**/*', fingerprint: true, allowEmptyArchive: true
-                            echo "=== C iOS Test Teardown Complete"
-                        }
-                    }
-                }
-                stage('Android') {
-                    agent { label 'mac-mini-CBL-Android1' }
-                    options {
-                        lock('R5CT20FYA7R')
-                    }
-                    environment {
-                        ANDROID_HOME = "/Users/couchbase/Library/Android/sdk"
-                        JAVA_HOME = "/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home"
-                        PATH = "\$JAVA_HOME/bin:\$ANDROID_HOME/platform-tools:\$ANDROID_HOME/tools:\$ANDROID_HOME/tools/bin:/opt/homebrew/opt/python@3.10/bin:/opt/homebrew/bin:/usr/local/bin:${env.PATH}"
-                        TS_ARTIFACTS_DIR = 'c_android'
-                    }
-                    steps {
-                        withCredentials([string(credentialsId: 'mobile-qe', variable: 'KEYCHAIN_PASSWORD')]) {
-                            sh 'security unlock-keychain -p ${KEYCHAIN_PASSWORD} ~/Library/Keychains/login.keychain-db'
-                        }
-                        echo "=== Run C Android Tests"
-                        timeout(time: 120, unit: 'MINUTES') {
-                            sh "jenkins/pipelines/QE/c/run_test.sh ${params.CBL_VERSION} android ${params.SGW_VERSION} ${params.TS_DATASET_VERSION}"
-                        }
-                        echo "=== C Android Tests Complete"
-                    }
-                    post {
-                        always {
-                            echo "=== Teardown C Android Tests"
-                            timeout(time: 5, unit: 'MINUTES') {
-                                sh 'jenkins/pipelines/QE/c/teardown.sh'
-                            }
-                            archiveArtifacts artifacts: 'tests/QE/c_android/**/*', fingerprint: true, allowEmptyArchive: true
-                            echo "=== C Android Test Teardown Complete"
-                        }
-                    }
-                }
                 stage('Linux') {
                     agent { label 'linux-c' }
                     environment {
@@ -153,29 +91,6 @@ pipeline {
                             }
                             archiveArtifacts artifacts: 'tests/QE/c_linux/**/*', fingerprint: true, allowEmptyArchive: true
                             echo "=== C Linux Test Teardown Complete"
-                        }
-                    }
-                }
-                stage('Windows') {
-                    agent { label 'net-windows' }
-                    environment {
-                        TS_ARTIFACTS_DIR = 'c_windows'
-                    }
-                    steps {
-                        echo "=== Run C Windows Tests"
-                        timeout(time: 120, unit: 'MINUTES') {
-                            powershell "jenkins\\pipelines\\QE\\c\\run_test.ps1 -Version ${params.CBL_VERSION} -SgwVersion ${params.SGW_VERSION} -DatasetVersion ${params.TS_DATASET_VERSION}"
-                        }
-                        echo "=== C Windows Tests Complete"
-                    }
-                    post {
-                        always {
-                            echo "=== Teardown C Windows Tests"
-                            timeout(time: 5, unit: 'MINUTES') {
-                                powershell 'jenkins\\pipelines\\QE\\c\\teardown.ps1'
-                            }
-                            archiveArtifacts artifacts: 'tests\\QE\\c_windows\\**\\*', fingerprint: true, allowEmptyArchive: true
-                            echo "=== C Windows Test Teardown Complete"
                         }
                     }
                 }

--- a/jenkins/pipelines/QE/c/Jenkinsfile
+++ b/jenkins/pipelines/QE/c/Jenkinsfile
@@ -14,7 +14,6 @@ pipeline {
                 script {
                     if (params.CBL_VERSION == '') { error "CBL_VERSION is required" }
                     if (params.SGW_VERSION == '') { error "SGW_VERSION is required" }
-
                     currentBuild.displayName = "C CBL:${params.CBL_VERSION} (#${currentBuild.number})"
                     currentBuild.description = "SGW: ${params.SGW_VERSION}"
                 }

--- a/jenkins/pipelines/QE/c/Jenkinsfile
+++ b/jenkins/pipelines/QE/c/Jenkinsfile
@@ -77,6 +77,7 @@ pipeline {
                         lock('00008101-000E0519020A001E')
                     }
                     environment {
+                        KEYCHAIN_PASSWORD = credentials('mobile-qe')
                         PATH = "/opt/homebrew/opt/python@3.10/bin:/opt/homebrew/bin:/usr/local/bin:${env.PATH}"
                         TS_ARTIFACTS_DIR = 'c_ios'
                     }

--- a/jenkins/pipelines/QE/c/Jenkinsfile
+++ b/jenkins/pipelines/QE/c/Jenkinsfile
@@ -46,9 +46,6 @@ pipeline {
             parallel {
                 stage('macOS') {
                     agent { label 'mac-mini-new' }
-                    options {
-                        lock('mac-mini-new')
-                    }
                     environment {
                         PATH = "/opt/homebrew/opt/python@3.10/bin:/opt/homebrew/bin:/usr/local/bin:${env.PATH}"
                         TS_ARTIFACTS_DIR = 'c_macos'
@@ -77,7 +74,7 @@ pipeline {
                 stage('iOS') {
                     agent { label 'mac-mini-new' }
                     options {
-                        lock('mac-mini-new,00008101-000E0519020A001E')
+                        lock('00008101-000E0519020A001E')
                     }
                     environment {
                         PATH = "/opt/homebrew/opt/python@3.10/bin:/opt/homebrew/bin:/usr/local/bin:${env.PATH}"
@@ -107,7 +104,7 @@ pipeline {
                 stage('Android') {
                     agent { label 'mac-mini-CBL-Android1' }
                     options {
-                        lock('mac-mini-CBL-Android1,R5CT20FYA7R')
+                        lock('R5CT20FYA7R')
                     }
                     environment {
                         ANDROID_HOME = "/Users/couchbase/Library/Android/sdk"
@@ -138,9 +135,6 @@ pipeline {
                 }
                 stage('Linux') {
                     agent { label 'linux-c' }
-                    options {
-                        lock('linux-c')
-                    }
                     environment {
                         TS_ARTIFACTS_DIR = 'c_linux'
                     }
@@ -164,9 +158,6 @@ pipeline {
                 }
                 stage('Windows') {
                     agent { label 'net-windows' }
-                    options {
-                        lock('net-windows')
-                    }
                     environment {
                         TS_ARTIFACTS_DIR = 'c_windows'
                     }

--- a/jenkins/pipelines/QE/c/Jenkinsfile
+++ b/jenkins/pipelines/QE/c/Jenkinsfile
@@ -51,9 +51,6 @@ pipeline {
                         TS_ARTIFACTS_DIR = 'c_macos'
                     }
                     steps {
-                        withCredentials([string(credentialsId: 'mobile-qe', variable: 'KEYCHAIN_PASSWORD')]) {
-                            sh 'security unlock-keychain -p ${KEYCHAIN_PASSWORD} ~/Library/Keychains/login.keychain-db'
-                        }
                         echo "=== Run C macOS Tests"
                         timeout(time: 120, unit: 'MINUTES') {
                             sh "jenkins/pipelines/QE/c/run_test.sh ${params.CBL_VERSION} macos ${params.SGW_VERSION} ${params.TS_DATASET_VERSION}"
@@ -72,17 +69,17 @@ pipeline {
                     }
                 }
                 stage('iOS') {
-                    agent { label 'mac-mini-new' }
+                    agent { label 'qe-mac-india' }
                     options {
-                        lock('00008101-000E0519020A001E')
+                        lock('00008140-0006458A0C22801C')
                     }
                     environment {
-                        KEYCHAIN_PASSWORD = credentials('mobile-qe')
+                        KEYCHAIN_PASSWORD = credentials('mobile-qe-india')
                         PATH = "/opt/homebrew/opt/python@3.10/bin:/opt/homebrew/bin:/usr/local/bin:${env.PATH}"
                         TS_ARTIFACTS_DIR = 'c_ios'
                     }
                     steps {
-                        withCredentials([string(credentialsId: 'mobile-qe', variable: 'KEYCHAIN_PASSWORD')]) {
+                        withCredentials([string(credentialsId: 'mobile-qe-india', variable: 'KEYCHAIN_PASSWORD')]) {
                             sh 'security unlock-keychain -p ${KEYCHAIN_PASSWORD} ~/Library/Keychains/login.keychain-db'
                         }
                         echo "=== Run C iOS Tests"
@@ -116,9 +113,6 @@ pipeline {
                         TS_ARTIFACTS_DIR = 'c_android'
                     }
                     steps {
-                        withCredentials([string(credentialsId: 'mobile-qe', variable: 'KEYCHAIN_PASSWORD')]) {
-                            sh 'security unlock-keychain -p ${KEYCHAIN_PASSWORD} ~/Library/Keychains/login.keychain-db'
-                        }
                         echo "=== Run C Android Tests"
                         timeout(time: 120, unit: 'MINUTES') {
                             sh "jenkins/pipelines/QE/c/run_test.sh ${params.CBL_VERSION} android ${params.SGW_VERSION} ${params.TS_DATASET_VERSION}"

--- a/jenkins/pipelines/QE/c/Jenkinsfile
+++ b/jenkins/pipelines/QE/c/Jenkinsfile
@@ -102,12 +102,14 @@ pipeline {
                     }
                 }
                 stage('Android') {
-                    agent { label 'mac-mini-CBL-Android1' }
+                    agent { label 'qe-mac-india' }
                     options {
-                        lock('R5CT20FYA7R')
+                        lock('56141JEBF18456')
                     }
                     environment {
-                        ANDROID_HOME = "/Users/couchbase/Library/Android/sdk"
+                        KEYCHAIN_PASSWORD = credentials('mobile-qe-india')
+                        ANDROID_HOME = "${env.HOME}/Library/Android/sdk"
+                        ANDROID_SERIAL = "56141JEBF18456"
                         JAVA_HOME = "/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home"
                         PATH = "\$JAVA_HOME/bin:\$ANDROID_HOME/platform-tools:\$ANDROID_HOME/tools:\$ANDROID_HOME/tools/bin:/opt/homebrew/opt/python@3.10/bin:/opt/homebrew/bin:/usr/local/bin:${env.PATH}"
                         TS_ARTIFACTS_DIR = 'c_android'

--- a/jenkins/pipelines/QE/c/topologies/topology_single_ios.json
+++ b/jenkins/pipelines/QE/c/topologies/topology_single_ios.json
@@ -4,8 +4,8 @@
         {
             "platform": "c_ios",
             "cbl_version": "{{version}}",
-            "location": "00008110-000E544201D1401E",
-            "ip_hint": "172.16.150.155",
+            "location": "00008101-000E0519020A001E",
+            "ip_hint": "10.100.150.115",
             "download": true
         }
     ],

--- a/jenkins/pipelines/QE/c/topologies/topology_single_ios.json
+++ b/jenkins/pipelines/QE/c/topologies/topology_single_ios.json
@@ -4,8 +4,8 @@
         {
             "platform": "c_ios",
             "cbl_version": "{{version}}",
-            "location": "00008101-000E0519020A001E",
-            "ip_hint": "10.100.150.115",
+            "location": "00008140-0006458A0C22801C",
+            "ip_hint": "172.16.150.158",
             "download": true
         }
     ],

--- a/jenkins/pipelines/QE/c/topologies/topology_single_linux_x86_64.json
+++ b/jenkins/pipelines/QE/c/topologies/topology_single_linux_x86_64.json
@@ -4,7 +4,8 @@
         {
             "platform": "c_linux_x86_64",
             "cbl_version": "{{version}}",
-            "location": "localhost"
+            "location": "localhost",
+            "download": true
         }
     ],
     "include": "../../../../../environment/aws/topology_setup/default_topology.json"

--- a/jenkins/pipelines/QE/c/topologies/topology_single_macos.json
+++ b/jenkins/pipelines/QE/c/topologies/topology_single_macos.json
@@ -4,7 +4,8 @@
         {
             "platform": "c_macos",
             "cbl_version": "{{version}}",
-            "location": "localhost"
+            "location": "localhost",
+            "download": true
         }
     ],
     "include": "../../../../../environment/aws/topology_setup/default_topology.json"

--- a/jenkins/pipelines/QE/dotnet/Jenkinsfile
+++ b/jenkins/pipelines/QE/dotnet/Jenkinsfile
@@ -133,12 +133,12 @@ pipeline {
                     }
                 }
                 stage('Android') {
-                    agent { label 'mac-mini-CBL-Android1' }
+                    agent { label 'qe-mac-india' }
                     options {
-                        lock('mac-mini-CBL-Android1,R5CT20FYA7R')
+                        lock('qe-mac-india,51131XEKB7DBF1')
                     }
                     environment {
-                        KEYCHAIN_PASSWORD = credentials('mobile-qe')
+                        KEYCHAIN_PASSWORD = credentials('mobile-qe-india')
                         ANDROID_HOME = "/Users/couchbase/Library/Android/sdk"
                         JAVA_HOME = "/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home"
                         PATH = "\$JAVA_HOME/bin:\$ANDROID_HOME/platform-tools:\$ANDROID_HOME/tools:\$ANDROID_HOME/tools/bin:/opt/homebrew/opt/python@3.10/bin:/opt/homebrew/bin:/usr/local/bin:${env.PATH}"

--- a/jenkins/pipelines/QE/dotnet/Jenkinsfile
+++ b/jenkins/pipelines/QE/dotnet/Jenkinsfile
@@ -77,7 +77,6 @@ pipeline {
                         TS_ARTIFACTS_DIR = 'dotnet_macos'
                     }
                     steps {
-                        sh 'security unlock-keychain -p ${KEYCHAIN_PASSWORD} ~/Library/Keychains/login.keychain-db'
                         echo "=== Run Dotnet macOS Tests"
                         timeout(time: 120, unit: 'MINUTES') {
                             sh "jenkins/pipelines/QE/dotnet/run_test.sh ${params.CBL_VERSION} macos ${params.SGW_VERSION} ${params.TS_DATASET_VERSION}"
@@ -139,7 +138,6 @@ pipeline {
                         TS_ARTIFACTS_DIR = 'dotnet_android'
                     }
                     steps {
-                        sh 'security unlock-keychain -p ${KEYCHAIN_PASSWORD} ~/Library/Keychains/login.keychain-db'
                         echo "=== Run Dotnet Android Tests"
                         timeout(time: 120, unit: 'MINUTES') {
                             sh "jenkins/pipelines/QE/dotnet/run_test.sh ${params.CBL_VERSION} android ${params.SGW_VERSION} ${params.TS_DATASET_VERSION}"

--- a/jenkins/pipelines/QE/dotnet/Jenkinsfile
+++ b/jenkins/pipelines/QE/dotnet/Jenkinsfile
@@ -166,4 +166,12 @@ pipeline {
             }
         }
     }
+    post {
+        success {
+            mail bcc: '', body: "Project: <a href='${env.BUILD_URL}'>${env.JOB_NAME}</a> succeeded.", cc: '', charset: 'UTF-8', from: 'jenkins@couchbase.com', mimeType: 'text/html', replyTo: 'no-reply@couchbase.com', subject: "${env.JOB_NAME} succeeded", to: "sanjivani.patra@couchbase.com";
+        }
+        regression {
+            mail bcc: '', body: "Project: <a href='${env.BUILD_URL}'>${env.JOB_NAME}</a> regressed (first failure after success).", cc: '', charset: 'UTF-8', from: 'jenkins@couchbase.com', mimeType: 'text/html', replyTo: 'no-reply@couchbase.com', subject: "${env.JOB_NAME} regressed", to: "sanjivani.patra@couchbase.com";
+        }
+    }
 }

--- a/jenkins/pipelines/QE/dotnet/Jenkinsfile
+++ b/jenkins/pipelines/QE/dotnet/Jenkinsfile
@@ -98,7 +98,7 @@ pipeline {
                 stage('iOS') {
                     agent { label 'qe-mac-india' }
                     options {
-                        lock('00008140-0006458A0C22801C')
+                        lock('00008110-000E544201D1401E')
                     }
                     environment {
                         KEYCHAIN_PASSWORD = credentials('mobile-qe-india')

--- a/jenkins/pipelines/QE/dotnet/Jenkinsfile
+++ b/jenkins/pipelines/QE/dotnet/Jenkinsfile
@@ -46,9 +46,6 @@ pipeline {
             parallel {
                 stage('Windows') {
                     agent { label 'net-windows' }
-                    options {
-                        lock('net-windows')
-                    }
                     environment {
                         TS_ARTIFACTS_DIR = 'dotnet_windows'
                     }
@@ -72,9 +69,6 @@ pipeline {
                 }
                 stage('macOS') {
                     agent { label 'qe-mac-india' }
-                    options {
-                        lock('qe-mac-india')
-                    }
                     environment {
                         KEYCHAIN_PASSWORD = credentials('mobile-qe-india')
                         DEVELOPER_DIR = "/Applications/Xcode.app"
@@ -104,7 +98,7 @@ pipeline {
                 stage('iOS') {
                     agent { label 'qe-mac-india' }
                     options {
-                        lock('qe-mac-india,00008140-0006458A0C22801C')
+                        lock('00008140-0006458A0C22801C')
                     }
                     environment {
                         KEYCHAIN_PASSWORD = credentials('mobile-qe-india')
@@ -135,7 +129,7 @@ pipeline {
                 stage('Android') {
                     agent { label 'qe-mac-india' }
                     options {
-                        lock('qe-mac-india,51131XEKB7DBF1')
+                        lock('51131XEKB7DBF1')
                     }
                     environment {
                         KEYCHAIN_PASSWORD = credentials('mobile-qe-india')

--- a/jenkins/pipelines/QE/dotnet/Jenkinsfile
+++ b/jenkins/pipelines/QE/dotnet/Jenkinsfile
@@ -79,7 +79,7 @@ pipeline {
                         KEYCHAIN_PASSWORD = credentials('mobile-qe-india')
                         DEVELOPER_DIR = "/Applications/Xcode.app"
                         MD_APPLE_SDK_ROOT = "/Applications/Xcode.app"
-                        PATH = "/opt/homebrew/opt/python@3.10/bin:/opt/homebrew/bin:/usr/local/bin:${env.PATH}"
+                        PATH = "/opt/homebrew/opt/python@3.10/bin:/opt/homebrew/bin:/usr/local/bin:$PATH"
                         TS_ARTIFACTS_DIR = 'dotnet_macos'
                     }
                     steps {
@@ -110,7 +110,7 @@ pipeline {
                         KEYCHAIN_PASSWORD = credentials('mobile-qe-india')
                         DEVELOPER_DIR = "/Applications/Xcode.app"
                         MD_APPLE_SDK_ROOT = "/Applications/Xcode.app"
-                        PATH = "/opt/homebrew/opt/python@3.10/bin:/opt/homebrew/bin:/usr/local/bin:${env.PATH}"
+                        PATH = "/opt/homebrew/opt/python@3.10/bin:/opt/homebrew/bin:/usr/local/bin:$PATH"
                         TS_ARTIFACTS_DIR = 'dotnet_ios'
                     }
                     steps {

--- a/jenkins/pipelines/QE/dotnet/Jenkinsfile
+++ b/jenkins/pipelines/QE/dotnet/Jenkinsfile
@@ -129,7 +129,7 @@ pipeline {
                 stage('Android') {
                     agent { label 'qe-mac-india' }
                     options {
-                        lock('51131XEKB7DBF1')
+                        lock('45291VDJH01660')
                     }
                     environment {
                         KEYCHAIN_PASSWORD = credentials('mobile-qe-india')

--- a/jenkins/pipelines/QE/dotnet/topologies/topology_single_android.json
+++ b/jenkins/pipelines/QE/dotnet/topologies/topology_single_android.json
@@ -4,7 +4,8 @@
         {
             "platform": "dotnet_android",
             "cbl_version": "{{version}}",
-            "location": "R5CT20FYA7R",
+            "location": "51131XEKB7DBF1",
+            "ip_hint": "172.16.150.163",
             "download": true
         }
     ],

--- a/jenkins/pipelines/QE/dotnet/topologies/topology_single_android.json
+++ b/jenkins/pipelines/QE/dotnet/topologies/topology_single_android.json
@@ -4,8 +4,8 @@
         {
             "platform": "dotnet_android",
             "cbl_version": "{{version}}",
-            "location": "51131XEKB7DBF1",
-            "ip_hint": "172.16.150.163",
+            "location": "45291VDJH01660",
+            "ip_hint": "172.16.150.159",
             "download": true
         }
     ],

--- a/jenkins/pipelines/QE/dotnet/topologies/topology_single_ios.json
+++ b/jenkins/pipelines/QE/dotnet/topologies/topology_single_ios.json
@@ -4,8 +4,8 @@
         {
             "platform": "dotnet_ios",
             "cbl_version": "{{version}}",
-            "location": "00008140-0006458A0C22801C",
-            "ip_hint": "172.16.150.158",
+            "location": "00008110-000E544201D1401E",
+            "ip_hint": "172.16.150.155",
             "download": true
         }
     ],

--- a/jenkins/pipelines/QE/ios/Jenkinsfile
+++ b/jenkins/pipelines/QE/ios/Jenkinsfile
@@ -32,7 +32,7 @@ pipeline {
             agent { label 'qe-mac-india' }
             environment {
                 KEYCHAIN_PASSWORD = credentials('mobile-qe-india')
-                PATH = "/opt/homebrew/opt/python@3.10/bin:/opt/homebrew/bin:/usr/local/bin:${env.PATH}"
+                PATH = "/opt/homebrew/opt/python@3.10/bin:/opt/homebrew/bin:/usr/local/bin:$PATH"
                 TS_ARTIFACTS_DIR = 'ios'
             }
             steps {

--- a/jenkins/pipelines/QE/ios/Jenkinsfile
+++ b/jenkins/pipelines/QE/ios/Jenkinsfile
@@ -56,4 +56,12 @@ pipeline {
             }
         }
     }
+    post {
+        success {
+            mail bcc: '', body: "Project: <a href='${env.BUILD_URL}'>${env.JOB_NAME}</a> succeeded.", cc: '', charset: 'UTF-8', from: 'jenkins@couchbase.com', mimeType: 'text/html', replyTo: 'no-reply@couchbase.com', subject: "${env.JOB_NAME} succeeded", to: "sanjivani.patra@couchbase.com";
+        }
+        regression {
+            mail bcc: '', body: "Project: <a href='${env.BUILD_URL}'>${env.JOB_NAME}</a> regressed (first failure after success).", cc: '', charset: 'UTF-8', from: 'jenkins@couchbase.com', mimeType: 'text/html', replyTo: 'no-reply@couchbase.com', subject: "${env.JOB_NAME} regressed", to: "sanjivani.patra@couchbase.com";
+        }
+    }
 }

--- a/jenkins/pipelines/QE/ios/topology_single_device.json
+++ b/jenkins/pipelines/QE/ios/topology_single_device.json
@@ -4,8 +4,8 @@
         {
             "platform": "swift_ios",
             "cbl_version": "{{version}}",
-            "location": "00008140-0006458A0C22801C",
-            "ip_hint": "172.16.150.158",
+            "location": "00008122-001108DC2EB9801C",
+            "ip_hint": "172.16.150.152",
             "download": true
         }
     ],

--- a/jenkins/pipelines/QE/ios/topology_single_device.json
+++ b/jenkins/pipelines/QE/ios/topology_single_device.json
@@ -4,8 +4,8 @@
         {
             "platform": "swift_ios",
             "cbl_version": "{{version}}",
-            "location": "00008122-001108DC2EB9801C",
-            "ip_hint": "172.16.150.152",
+            "location": "00008140-0006458A0C22801C",
+            "ip_hint": "172.16.150.158",
             "download": true
         }
     ],

--- a/jenkins/pipelines/QE/java/Jenkinsfile
+++ b/jenkins/pipelines/QE/java/Jenkinsfile
@@ -46,7 +46,6 @@ pipeline {
                         TS_DATASET_VERSION = "${params.TS_DATASET_VERSION}"
                     }
                     steps {
-                        sh 'security unlock-keychain -p ${KEYCHAIN_PASSWORD} ~/Library/Keychains/login.keychain-db'
                         echo "=== Run macOS Desktop Tests"
                         timeout(time: 120, unit: 'MINUTES') {
                             sh "jenkins/pipelines/QE/java/desktop/run_test.sh ${params.CBL_VERSION} ${params.SGW_VERSION} ${params.TS_DATASET_VERSION}"


### PR DESCRIPTION
This PR adds in the other platforms to the Jenkinsfiles as well as fixes needed which were previously in `qe-jenkins` branch.

**Features added:**
- Added all platforms to the C Jenkinsfile (in `jenkins/pipelines/QE/c/Jenkinsfile`).
- The phone connected to mac-mini-CBL-Android1 node keeps intermittently disconnecting so changed it to use qe-mac-india node.
- Changed path in iOS Jenkinsfile to fix the git-lfs issue.
- Added post stage in iOS and .NET Jenkinsfile to get notified on regressions and successes (in `jenkins/pipelines/QE/dotnet/Jenkinsfile` and `jenkins/pipelines/QE/ios/Jenkinsfile`).