### PR TITLE
Added delta-sync history based tests

### DIFF
--- a/client/src/cbltest/api/couchbaseserver.py
+++ b/client/src/cbltest/api/couchbaseserver.py
@@ -357,12 +357,16 @@ class CouchbaseServer:
         dataset_name: str,
         *,
         repo_name: str | None = None,
+        reset_expired_ttl: bool = False,
     ) -> None:
         """
         Restores a bucket from a backup source
 
         :param name: The name of the bucket to restore
         :param backup_source: The path to the backup source
+        :param reset_expired_ttl: When True, restore already-expired documents
+            with no expiry (``--replace-ttl expired --replace-ttl-with 0``) so
+            they are not purged on access.
         """
         with self.__tracer.start_as_current_span(
             "restore_bucket",
@@ -396,24 +400,29 @@ class CouchbaseServer:
                         f"Backup zip '{data_filepath}' is invalid: {e}"
                     ) from e
 
-                subprocess.run(
-                    [
-                        cbbackupmgr_path,
-                        "restore",
-                        "-a",
-                        str(extract_path / dataset_name),
-                        "-c",
-                        self.__hostname,
-                        "-r",
-                        repo_name or dataset_name,
-                        "-u",
-                        self.__username,
-                        "-p",
-                        self.__password,
-                        "--auto-create-buckets",
-                    ],
-                    check=True,
-                )
+                restore_args = [
+                    cbbackupmgr_path,
+                    "restore",
+                    "-a",
+                    str(extract_path / dataset_name),
+                    "-c",
+                    self.__hostname,
+                    "-r",
+                    repo_name or dataset_name,
+                    "-u",
+                    self.__username,
+                    "-p",
+                    self.__password,
+                    "--auto-create-buckets",
+                ]
+                if reset_expired_ttl:
+                    restore_args += [
+                        "--replace-ttl",
+                        "expired",
+                        "--replace-ttl-with",
+                        "0",
+                    ]
+                subprocess.run(restore_args, check=True)
 
     def indexes_count(self, bucket: str) -> int:
         """

--- a/client/src/cbltest/api/syncgateway.py
+++ b/client/src/cbltest/api/syncgateway.py
@@ -763,8 +763,8 @@ class _SyncGatewayBase:
                     current_span.add_event("SGW returned 500, retry")
                     await asyncio.sleep(2)
                     await self._delete_database(db_name, retry_count + 1)
-                elif e.code == 403:
-                    pass
+                elif e.code == 403 or e.code == 404:
+                    pass  # Database doesn't exist anyway.
                 else:
                     raise
 

--- a/client/src/cbltest/api/syncgateway.py
+++ b/client/src/cbltest/api/syncgateway.py
@@ -705,13 +705,8 @@ class _SyncGatewayBase:
 
     async def get_delta_sync_stats(self, dataset_name: str) -> dict:
         """
-        Gets the delta_sync counters for a given database as exposed by
-        ``GET /_expvar``. Returns the raw ``delta_sync`` sub-dict so callers
-        can diff counters (e.g. ``deltas_sent``, ``delta_pull_replication_count``)
-        across a replication run to confirm delta-sync actually engaged.
-
-        Returns an empty dict if the delta_sync section is absent (older SGW
-        builds, or feature disabled).
+        Gets the ``delta_sync`` counters for a database from ``GET /_expvar``.
+        Returns an empty dict if the section is absent.
 
         :param dataset_name: The name of the SGW database to inspect.
         """

--- a/client/src/cbltest/api/syncgateway.py
+++ b/client/src/cbltest/api/syncgateway.py
@@ -703,6 +703,29 @@ class _SyncGatewayBase:
         doc_writes_bytes = db_stats["doc_writes_bytes_blip"]
         return doc_reads_bytes, doc_writes_bytes
 
+    async def get_delta_sync_stats(self, dataset_name: str) -> dict:
+        """
+        Gets the delta_sync counters for a given database as exposed by
+        ``GET /_expvar``. Returns the raw ``delta_sync`` sub-dict so callers
+        can diff counters (e.g. ``deltas_sent``, ``delta_pull_replication_count``)
+        across a replication run to confirm delta-sync actually engaged.
+
+        Returns an empty dict if the delta_sync section is absent (older SGW
+        builds, or feature disabled).
+
+        :param dataset_name: The name of the SGW database to inspect.
+        """
+        resp_data = await self._send_request("get", "/_expvar")
+        assert isinstance(resp_data, dict)
+        expvars = cast(dict, resp_data)
+
+        try:
+            db_section = expvars["syncgateway"]["per_db"][dataset_name]
+        except KeyError:
+            return {}
+        delta = db_section.get("delta_sync")
+        return delta if isinstance(delta, dict) else {}
+
     async def _put_database(
         self, db_name: str, payload: PutDatabasePayload, retry_count: int = 0
     ) -> None:

--- a/client/src/cbltest/api/upgrade_test_helpers.py
+++ b/client/src/cbltest/api/upgrade_test_helpers.py
@@ -1,4 +1,4 @@
-import time
+import asyncio
 from collections.abc import Callable
 from pathlib import Path
 from typing import TypeAlias
@@ -7,7 +7,6 @@ from cbltest import CBLPyTest, CouchbaseServer
 from cbltest.api.cbltestclass import CBLTestClass
 from cbltest.api.database import Database, GetDocumentResult
 from cbltest.api.database_types import DocumentEntry
-from cbltest.api.error import CblSyncGatewayBadResponseError
 from cbltest.api.replicator import Replicator
 from cbltest.api.replicator_types import (
     ReplicatorActivityLevel,
@@ -47,12 +46,7 @@ async def setup_upgrade_env(
     )
 
     test_case.mark_test_step("Delete Sync Gateway 'upgrade' database if exists")
-    sg = cblpytest.sync_gateways[0]
-    try:
-        await sg.delete_database("upgrade")
-    except CblSyncGatewayBadResponseError as e:
-        if e.code != 403:
-            raise
+    await cblpytest.sync_gateways[0].delete_database("upgrade")
 
     test_case.mark_test_step("Restore Couchbase Server Bucket using `upgrade` dataset")
     cbs: CouchbaseServer = cblpytest.couchbase_servers[0]
@@ -60,7 +54,7 @@ async def setup_upgrade_env(
     cbs.restore_bucket("upgrade", tools_path(), dataset_path, "upgrade")
 
     test_case.mark_test_step("Wait 2s to ensure SG picks up the restored database.")
-    time.sleep(2)
+    await asyncio.sleep(2)
 
     test_case.mark_test_step("Reset local database, and load `upgrade` dataset.")
     dbs = await cblpytest.test_servers[0].create_and_reset_db(

--- a/client/src/cbltest/api/upgrade_test_helpers.py
+++ b/client/src/cbltest/api/upgrade_test_helpers.py
@@ -1,0 +1,161 @@
+import time
+from collections.abc import Callable
+from pathlib import Path
+from typing import TypeAlias
+
+from cbltest import CBLPyTest, CouchbaseServer
+from cbltest.api.cbltestclass import CBLTestClass
+from cbltest.api.database import Database, GetDocumentResult
+from cbltest.api.database_types import DocumentEntry
+from cbltest.api.error import CblSyncGatewayBadResponseError
+from cbltest.api.replicator import Replicator
+from cbltest.api.replicator_types import (
+    ReplicatorActivityLevel,
+    ReplicatorBasicAuthenticator,
+    ReplicatorCollectionEntry,
+    ReplicatorConflictResolver,
+    ReplicatorType,
+    WaitForDocumentEventEntry,
+)
+from cbltest.api.syncgateway import RemoteDocument
+from cbltest.api.test_functions import compare_local_and_remote
+from cbltest.logging import cbl_info
+
+
+class DocSnapshot:
+    def __init__(self, local: GetDocumentResult, remote: RemoteDocument):
+        self.local = local
+        self.remote = remote
+
+
+DocValidator: TypeAlias = Callable[[DocSnapshot, DocSnapshot], None]
+
+
+def tools_path() -> Path:
+    # client/src/cbltest/api/upgrade_test_helpers.py -> parents[4] is repo root
+    return Path(__file__).resolve().parents[4] / "tests" / ".tools"
+
+
+async def setup_upgrade_env(
+    test_case: CBLTestClass, cblpytest: CBLPyTest, dataset_path: Path
+) -> Database:
+    await test_case.skip_if_cbl_not(cblpytest.test_servers[0], ">= 4.0.0")
+
+    dataset_ver = cblpytest.test_servers[0].dataset_version
+    test_case.skip_if_not(
+        dataset_ver == "4.0", f"Requires dataset v4.0 (current: {dataset_ver})."
+    )
+
+    test_case.mark_test_step("Delete Sync Gateway 'upgrade' database if exists")
+    sg = cblpytest.sync_gateways[0]
+    try:
+        await sg.delete_database("upgrade")
+    except CblSyncGatewayBadResponseError as e:
+        if e.code != 403:
+            raise
+
+    test_case.mark_test_step("Restore Couchbase Server Bucket using `upgrade` dataset")
+    cbs: CouchbaseServer = cblpytest.couchbase_servers[0]
+    cbs.drop_bucket("upgrade")
+    cbs.restore_bucket("upgrade", tools_path(), dataset_path, "upgrade")
+
+    test_case.mark_test_step("Wait 2s to ensure SG picks up the restored database.")
+    time.sleep(2)
+
+    test_case.mark_test_step("Reset local database, and load `upgrade` dataset.")
+    dbs = await cblpytest.test_servers[0].create_and_reset_db(
+        ["db1"], dataset="upgrade"
+    )
+    return dbs[0]
+
+
+async def do_upgrade_replication_test(
+    test_case: CBLTestClass,
+    cblpytest: CBLPyTest,
+    db: Database,
+    doc_id: str,
+    replicator_type: ReplicatorType,
+    conflict_resolver: ReplicatorConflictResolver | None = None,
+    doc_events: set[WaitForDocumentEventEntry] | None = None,
+    compare_docs: bool | None = True,
+    validator: DocValidator | None = None,
+) -> None:
+    sg = cblpytest.sync_gateways[0]
+
+    pre_local_doc = await db.get_document(DocumentEntry("_default._default", doc_id))
+    pre_remote_doc = await sg.get_document("upgrade", doc_id)
+
+    assert pre_local_doc is not None
+    assert pre_remote_doc is not None
+    cbl_info(f"Revision Info before Replication ({replicator_type}):")
+    cbl_info(f"Local : RevID = {pre_local_doc.revid}, HLV = {pre_local_doc.cv}")
+    cbl_info(f"Remote : RevID = {pre_remote_doc.revid}, HLV = {pre_remote_doc.cv}")
+
+    wait_for_doc_events = bool(doc_events)
+
+    conflict_resolver_name = (
+        f"{conflict_resolver.name}" if conflict_resolver else "None"
+    )
+
+    test_case.mark_test_step(f"""
+        Start a replicator:
+        * endpoint: '/upgrade'
+        * collections : '_default._default'
+        * type: {replicator_type}
+        * document_ids: ['{doc_id}']
+        * continuous: {wait_for_doc_events}
+        * conflict_resolver: {conflict_resolver_name}
+    """)
+    replicator = Replicator(
+        db,
+        cblpytest.sync_gateways[0].replication_url("upgrade"),
+        collections=[
+            ReplicatorCollectionEntry(
+                names=["_default._default"],
+                document_ids=[doc_id],
+                conflict_resolver=conflict_resolver,
+            )
+        ],
+        replicator_type=replicator_type,
+        continuous=wait_for_doc_events,
+        authenticator=ReplicatorBasicAuthenticator("user1", "pass"),
+        pinned_server_cert=cblpytest.sync_gateways[0].tls_cert(),
+        enable_document_listener=wait_for_doc_events,
+    )
+
+    await replicator.start()
+
+    if doc_events:
+        test_case.mark_test_step("Wait until receiving all document replication events")
+        await replicator.wait_for_all_doc_events(
+            events=doc_events,
+            max_retries=100,
+        )
+    else:
+        test_case.mark_test_step("Wait until the replicator is stopped.")
+        status = await replicator.wait_for(ReplicatorActivityLevel.STOPPED)
+        assert status.error is None, (
+            f"Error waiting for replicator: ({status.error.domain} / {status.error.code}) {status.error.message}"
+        )
+
+    if compare_docs:
+        test_case.mark_test_step("Check that the doc is replicated correctly.")
+        await compare_local_and_remote(
+            db, sg, replicator_type, "upgrade", ["_default._default"], [doc_id]
+        )
+
+    local_doc = await db.get_document(DocumentEntry("_default._default", doc_id))
+    remote_doc = await sg.get_document("upgrade", doc_id)
+
+    assert local_doc is not None
+    assert remote_doc is not None
+    cbl_info(f"Revision Info after Replication ({replicator_type}):")
+    cbl_info(f"Local : RevID = {local_doc.revid}, HLV = {local_doc.cv}")
+    cbl_info(f"Remote : RevID = {remote_doc.revid}, HLV = {remote_doc.cv}")
+
+    if validator:
+        test_case.mark_test_step("Validate revid and HLV of local and remote doc.")
+        validator(
+            DocSnapshot(pre_local_doc, pre_remote_doc),
+            DocSnapshot(local_doc, remote_doc),
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,10 +33,11 @@ lint = [
 members = [ "client" ]
 
 [tool.ty.environment]
-root = [".", "client/src"]
+root = [".", "client/src", "tests"]
 
 [tool.pytest.ini_options]
 asyncio_default_fixture_loop_scope = "session"
+pythonpath = ["tests"]
 filterwarnings = [
   "ignore:Class property max_ttl is deprecated.*:couchbase.logic.supportability.CouchbaseDeprecationWarning",
 ]

--- a/spec/tests/QE/test_replication_upgrade_delta_sync.md
+++ b/spec/tests/QE/test_replication_upgrade_delta_sync.md
@@ -1,0 +1,129 @@
+# Test Cases
+
+These tests cover delta-sync replication behavior across a simulated 3.x → 4.x
+SGW upgrade. The pre-upgrade state is materialised by restoring the prebuilt
+`upgrade` CBS backup (revtree-only docs, no HLV xattrs) and resetting the CBL
+local DB from the matching `upgrade` cblite2 file; both binaries run 4.x
+throughout. Delta sync is enabled on the SGW `upgrade` database.
+
+## #1 test_delta_sync_history_pull_post_upgrade_sgw_mutation
+
+### Description
+
+PULL replication of a doc whose 2nd revision was created on 4.x SGW (so SGW
+holds both a revtree and an HLV) by a client that still holds the revtree-only
+ancestor. With delta sync enabled, SGW must populate the rev message's
+`history` field with the revtree predecessors so the client can ingest the
+delta. The current build sends an empty `history` here — this test is the
+regression marker for the fix, and is marked `xfail(strict=True)` until the
+SGW fix lands.
+
+Uses doc `nonconflict_3` from the prebuilt `upgrade` dataset. The 2nd
+revision is created in-test by mutating the doc on 4.x SGW, which adds an HLV
+in parallel with the new revtree leaf (4.x SGW always writes both).
+
+```
++------------------+-------------------------------+-------------------------------+
+|                  |             CBL               |              SGW              |
+|                  +---------------+---------------+---------------+---------------+
+|                  |   Rev Tree    |      HLV      |   Rev Tree    |      HLV      |
++------------------+---------------+---------------+---------------+---------------+
+| After restore    |     2-abc     |     none      |     2-abc     |     none      |
+| After SGW mutate |     2-abc     |     none      | 3-xxx, 2-abc  |   [N@SGW]     |
+| Expected post-PULL|     none     |    [N@SGW]    | 3-xxx, 2-abc  |   [N@SGW]     |
++------------------+---------------+---------------+---------------+---------------+
+```
+
+### Steps
+
+1. Delete Sync Gateway 'upgrade' database if exists.
+2. Restore Couchbase Server Bucket using `upgrade` dataset.
+3. Wait 2s to ensure SG picks up the restored database.
+4. Reset local database, and load `upgrade` dataset.
+5. Create SG 'upgrade' database with delta_sync enabled and import from bucket.
+   On 412 (already exists), force-recreate by `delete_database` + `put_database`.
+6. Verify delta_sync is actually enabled on SGW 'upgrade' database by fetching
+   the live config; fail with the active config dumped if not enabled.
+7. Create user `user1` with full access to `_default._default`.
+8. Mutate `nonconflict_3` on 4.x SGW to produce a new revtree leaf + fresh HLV.
+9. Start a replicator:
+   * endpoint: `/upgrade`
+   * collections: `_default._default`
+   * type: pull
+   * document_ids: `['nonconflict_3']`
+   * continuous: False
+   * credentials: user1/pass
+10. Wait until the replicator is stopped.
+11. Validate revid and HLV of local and remote doc:
+    * Pre: local has revid + no HLV; SGW has revid + canonical HLV (not
+      RTE-encoded).
+    * Post: local has no revid (4.x CBL is HLV-only); local HLV equals SGW HLV.
+
+### Expected Outcome
+
+✅ **With SGW fix**: CBL ingests the delta, ends up HLV-only with HLV matching SGW.
+❌ **Without SGW fix** (current build): rev message's `history` field is empty,
+client cannot ingest → test fails the postcondition. The `xfail(strict=True)`
+marker makes this an expected failure today and an `XPASS` (CI failure) the
+day the fix lands, forcing the developer landing the fix to remove the marker.
+
+---
+
+## #2 test_delta_sync_history_pull_pre_upgrade_sgw_two_revs
+
+### Description
+
+PULL replication of a doc whose 2nd revision was created on 3.x SGW (so both
+sides have revtree-only state, no HLV anywhere) by a client that holds the
+revtree-only ancestor. With delta sync enabled, the client must pull the
+newer revtree-only rev and generate an HLV locally using the
+Revision-Tree-Encoding (RTE) format. This case is expected to work on the
+current build (via the pre-fix code path) and serves as a forward regression
+marker once the SGW fix lands.
+
+Uses doc `nonconflict_2` from the prebuilt `upgrade` dataset — its baked-in
+state already matches the required pre-state, so no in-test SGW mutation is
+needed.
+
+```
++------------------+-------------------------------+-------------------------------+
+|                  |             CBL               |              SGW              |
+|                  +---------------+---------------+---------------+---------------+
+|                  |   Rev Tree    |      HLV      |   Rev Tree    |      HLV      |
++------------------+---------------+---------------+---------------+---------------+
+| After restore    |    1-abc      |     none      | 2-def, 1-abc  |     none      |
+| Expected post-PULL|    none      | [2def@RTE]    | 2-def, 1-abc  |     none      |
++------------------+---------------+---------------+---------------+---------------+
+```
+
+### Steps
+
+1. Delete Sync Gateway 'upgrade' database if exists.
+2. Restore Couchbase Server Bucket using `upgrade` dataset.
+3. Wait 2s to ensure SG picks up the restored database.
+4. Reset local database, and load `upgrade` dataset.
+5. Create SG 'upgrade' database with delta_sync enabled and import from bucket.
+   On 412 (already exists), force-recreate by `delete_database` + `put_database`.
+6. Verify delta_sync is actually enabled on SGW 'upgrade' database by fetching
+   the live config; fail with the active config dumped if not enabled.
+7. Create user `user1` with full access to `_default._default`.
+8. Start a replicator:
+   * endpoint: `/upgrade`
+   * collections: `_default._default`
+   * type: pull
+   * document_ids: `['nonconflict_2']`
+   * continuous: False
+   * credentials: user1/pass
+9. Wait until the replicator is stopped.
+10. Validate revid and HLV of local and remote doc:
+    * Pre: both sides have revid and no HLV; CBL revid < SGW revid.
+    * Post: local has no revid (4.x CBL is HLV-only); local HLV ends with
+      `@Revision+Tree+Encoding`; SGW HLV is still None (PULL doesn't touch SGW).
+
+### Expected Outcome
+
+✅ **Today** (pre-fix): the existing code path correctly pulls the
+revtree-only rev and the client generates an RTE-encoded HLV. Test passes.
+✅ **After fix lands**: same path, same outcome. Test continues to pass.
+This is the forward regression marker confirming the fix doesn't break the
+symmetric, revtree-only case.

--- a/spec/tests/QE/test_replication_upgrade_delta_sync.md
+++ b/spec/tests/QE/test_replication_upgrade_delta_sync.md
@@ -1,51 +1,55 @@
 # Test Cases
 
-These tests cover delta-sync replication behavior across a simulated 3.x → 4.x
-SGW upgrade. The pre-upgrade state is materialised by restoring the prebuilt
+These tests cover delta-sync PULL replication across a simulated 3.x → 4.x SGW
+upgrade. The pre-upgrade state is materialised by restoring the prebuilt
 `upgrade` CBS backup (revtree-only docs, no HLV xattrs) and resetting the CBL
 local DB from the matching `upgrade` cblite2 file; both binaries run 4.x
 throughout. Delta sync is enabled on the SGW `upgrade` database.
+
+The bucket is restored with expired old-revision backup bodies (`_sync:rev:*`)
+re-enabled (their captured TTL has long lapsed), so SGW can compute a delta
+against a legacy ancestor revision instead of falling back to a full body.
+
+Both tests assert that SGW actually sends the revision **as a delta** (via the
+per-rev `deltas_sent` expvar counter), and that the document converges on the
+client. The SGW delta-sync `history`-field defect is a wire-level issue that is
+not observable from end-state and is verified separately; asserting on it from
+the test is tracked as future work.
 
 ## #1 test_delta_sync_history_pull_post_upgrade_sgw_mutation
 
 ### Description
 
-PULL replication of a doc whose 2nd revision was created on 4.x SGW (so SGW
-holds both a revtree and an HLV) by a client that still holds the revtree-only
-ancestor. With delta sync enabled, SGW must populate the rev message's
-`history` field with the revtree predecessors so the client can ingest the
-delta. The current build sends an empty `history` here — this test is the
-regression marker for the fix, and is marked `xfail(strict=True)` until the
-SGW fix lands.
-
-Uses doc `nonconflict_3` from the prebuilt `upgrade` dataset. The 2nd
-revision is created in-test by mutating the doc on 4.x SGW, which adds an HLV
-in parallel with the new revtree leaf (4.x SGW always writes both).
+PULL replication of a doc whose new revision is created on 4.x SGW (so SGW
+holds both a revtree leaf and an HLV) by a client that holds the **direct
+revtree parent**. Uses doc `nonconflict_3`; the new revision is created in-test
+by mutating the doc on 4.x SGW, which adds an HLV in parallel with the new
+revtree leaf.
 
 ```
-+------------------+-------------------------------+-------------------------------+
-|                  |             CBL               |              SGW              |
-|                  +---------------+---------------+---------------+---------------+
-|                  |   Rev Tree    |      HLV      |   Rev Tree    |      HLV      |
-+------------------+---------------+---------------+---------------+---------------+
-| After restore    |     2-abc     |     none      |     2-abc     |     none      |
-| After SGW mutate |     2-abc     |     none      | 3-xxx, 2-abc  |   [N@SGW]     |
-| Expected post-PULL|     none     |    [N@SGW]    | 3-xxx, 2-abc  |   [N@SGW]     |
-+------------------+---------------+---------------+---------------+---------------+
++-------------------+-------------------------------+-------------------------------+
+|                   |             CBL               |              SGW              |
+|                   +---------------+---------------+---------------+---------------+
+|                   |   Rev Tree    |      HLV      |   Rev Tree    |      HLV      |
++-------------------+---------------+---------------+---------------+---------------+
+| After restore     |     2-abc     |     none      |     2-abc     |     none      |
+| After SGW mutate  |     2-abc     |     none      | 3-xxx, 2-abc  |   [N@SGW]     |
+| Expected post-PULL|     none      |   [N@SGW]     | 3-xxx, 2-abc  |   [N@SGW]     |
++-------------------+---------------+---------------+---------------+---------------+
 ```
 
 ### Steps
 
 1. Delete Sync Gateway 'upgrade' database if exists.
-2. Restore Couchbase Server Bucket using `upgrade` dataset.
+2. Restore Couchbase Server Bucket using `upgrade` dataset, re-enabling expired
+   old-revision backup bodies.
 3. Wait 2s to ensure SG picks up the restored database.
 4. Reset local database, and load `upgrade` dataset.
 5. Create SG 'upgrade' database with delta_sync enabled and import from bucket.
    On 412 (already exists), force-recreate by `delete_database` + `put_database`.
-6. Verify delta_sync is actually enabled on SGW 'upgrade' database by fetching
-   the live config; fail with the active config dumped if not enabled.
+6. Verify delta_sync is actually enabled on SGW 'upgrade' database.
 7. Create user `user1` with full access to `_default._default`.
-8. Mutate `nonconflict_3` on 4.x SGW to produce a new revtree leaf + fresh HLV.
+8. Mutate `nonconflict_3` on 4.x SGW to create a new revtree leaf + HLV.
 9. Start a replicator:
    * endpoint: `/upgrade`
    * collections: `_default._default`
@@ -54,18 +58,16 @@ in parallel with the new revtree leaf (4.x SGW always writes both).
    * continuous: False
    * credentials: user1/pass
 10. Wait until the replicator is stopped.
-11. Validate revid and HLV of local and remote doc:
-    * Pre: local has revid + no HLV; SGW has revid + canonical HLV (not
-      RTE-encoded).
+11. Check that the doc is replicated correctly.
+12. Validate revid and HLV of local and remote doc:
+    * Pre: local has revid + no HLV; SGW has revid + canonical (non-RTE) HLV.
     * Post: local has no revid (4.x CBL is HLV-only); local HLV equals SGW HLV.
+13. Confirm SGW sent the revision as a delta (`deltas_sent` incremented).
 
 ### Expected Outcome
 
-✅ **With SGW fix**: CBL ingests the delta, ends up HLV-only with HLV matching SGW.
-❌ **Without SGW fix** (current build): rev message's `history` field is empty,
-client cannot ingest → test fails the postcondition. The `xfail(strict=True)`
-marker makes this an expected failure today and an `XPASS` (CI failure) the
-day the fix lands, forcing the developer landing the fix to remove the marker.
+CBL ingests the delta and ends up HLV-only with an HLV matching SGW; the
+`deltas_sent` counter confirms a delta (not a full body) was sent.
 
 ---
 
@@ -73,57 +75,53 @@ day the fix lands, forcing the developer landing the fix to remove the marker.
 
 ### Description
 
-PULL replication of a doc whose 2nd revision was created on 3.x SGW (so both
-sides have revtree-only state, no HLV anywhere) by a client that holds the
-revtree-only ancestor. With delta sync enabled, the client must pull the
-newer revtree-only rev and generate an HLV locally using the
-Revision-Tree-Encoding (RTE) format. This case is expected to work on the
-current build (via the pre-fix code path) and serves as a forward regression
-marker once the SGW fix lands.
-
-Uses doc `nonconflict_2` from the prebuilt `upgrade` dataset — its baked-in
-state already matches the required pre-state, so no in-test SGW mutation is
-needed.
+PULL replication where the client holds an **older legacy ancestor** while SGW
+has advanced past a pre-upgrade revision. Uses doc `nonconflict_2`: after
+restore the client is at rev 1 and SGW is at rev 2 (both revtree-only, no HLV);
+a new revision is then created on 4.x SGW. SGW must compute the delta against
+the client's rev 1, which requires the restored rev-1 backup body — exercising
+the delta path across a pre-upgrade revision.
 
 ```
-+------------------+-------------------------------+-------------------------------+
-|                  |             CBL               |              SGW              |
-|                  +---------------+---------------+---------------+---------------+
-|                  |   Rev Tree    |      HLV      |   Rev Tree    |      HLV      |
-+------------------+---------------+---------------+---------------+---------------+
-| After restore    |    1-abc      |     none      | 2-def, 1-abc  |     none      |
-| Expected post-PULL|    none      | [2def@RTE]    | 2-def, 1-abc  |     none      |
-+------------------+---------------+---------------+---------------+---------------+
++-------------------+-----------------------------------+-----------------------------------+
+|                   |               CBL                 |                SGW                |
+|                   +---------------+-------------------+-------------------+---------------+
+|                   |   Rev Tree    |        HLV        |     Rev Tree      |      HLV      |
++-------------------+---------------+-------------------+-------------------+---------------+
+| After restore     |     1-abc     |       none        |   2-def, 1-abc    |     none      |
+| After SGW mutate  |     1-abc     |       none        | 3-xxx,2-def,1-abc |   [N@SGW]     |
+| Expected post-PULL|     none      |     [N@SGW]       | 3-xxx,2-def,1-abc |   [N@SGW]     |
++-------------------+---------------+-------------------+-------------------+---------------+
 ```
 
 ### Steps
 
 1. Delete Sync Gateway 'upgrade' database if exists.
-2. Restore Couchbase Server Bucket using `upgrade` dataset.
+2. Restore Couchbase Server Bucket using `upgrade` dataset, re-enabling expired
+   old-revision backup bodies.
 3. Wait 2s to ensure SG picks up the restored database.
 4. Reset local database, and load `upgrade` dataset.
 5. Create SG 'upgrade' database with delta_sync enabled and import from bucket.
    On 412 (already exists), force-recreate by `delete_database` + `put_database`.
-6. Verify delta_sync is actually enabled on SGW 'upgrade' database by fetching
-   the live config; fail with the active config dumped if not enabled.
+6. Verify delta_sync is actually enabled on SGW 'upgrade' database.
 7. Create user `user1` with full access to `_default._default`.
-8. Start a replicator:
+8. Mutate `nonconflict_2` on 4.x SGW to create a new revtree leaf + HLV.
+9. Start a replicator:
    * endpoint: `/upgrade`
    * collections: `_default._default`
    * type: pull
    * document_ids: `['nonconflict_2']`
    * continuous: False
    * credentials: user1/pass
-9. Wait until the replicator is stopped.
-10. Validate revid and HLV of local and remote doc:
-    * Pre: both sides have revid and no HLV; CBL revid < SGW revid.
-    * Post: local has no revid (4.x CBL is HLV-only); local HLV ends with
-      `@Revision+Tree+Encoding`; SGW HLV is still None (PULL doesn't touch SGW).
+10. Wait until the replicator is stopped.
+11. Check that the doc is replicated correctly.
+12. Validate revid and HLV of local and remote doc:
+    * Pre: local has revid + no HLV; SGW has revid + HLV; local revid < SGW revid.
+    * Post: local has no revid (4.x CBL is HLV-only); local HLV equals SGW HLV.
+13. Confirm SGW sent the revision as a delta (`deltas_sent` incremented).
 
 ### Expected Outcome
 
-✅ **Today** (pre-fix): the existing code path correctly pulls the
-revtree-only rev and the client generates an RTE-encoded HLV. Test passes.
-✅ **After fix lands**: same path, same outcome. Test continues to pass.
-This is the forward regression marker confirming the fix doesn't break the
-symmetric, revtree-only case.
+CBL ingests the delta computed against its legacy rev-1 ancestor and ends up
+HLV-only with an HLV matching SGW; the `deltas_sent` counter confirms a delta
+(not a full body) was sent.

--- a/spec/tests/QE/test_replication_upgrade_delta_sync.md
+++ b/spec/tests/QE/test_replication_upgrade_delta_sync.md
@@ -75,23 +75,24 @@ CBL ingests the delta and ends up HLV-only with an HLV matching SGW; the
 
 ### Description
 
-PULL replication where the client holds an **older legacy ancestor** while SGW
-has advanced past a pre-upgrade revision. Uses doc `nonconflict_2`: after
-restore the client is at rev 1 and SGW is at rev 2 (both revtree-only, no HLV);
-a new revision is then created on 4.x SGW. SGW must compute the delta against
-the client's rev 1, which requires the restored rev-1 backup body — exercising
-the delta path across a pre-upgrade revision.
+PULL replication of a **legacy, pre-upgrade** second revision. Uses doc
+`nonconflict_2`: after restore the client is at rev 1 and SGW is at rev 2, both
+revtree-only with **no HLV** (rev 2 was created pre-upgrade on 3.x, so it never
+got an HLV). There is **no in-test mutation**. SGW sends the existing rev 2 as a
+**revID-identified (legacy) delta** computed against the client's rev 1 — which
+requires rev 1's old-revision backup body, made available by the TTL rescue at
+restore. This is the distinguishing case from #1: the delta is of a revtree-only
+rev with no HLV, not a 4.x HLV-bearing rev.
 
 ```
-+-------------------+-----------------------------------+-----------------------------------+
-|                   |               CBL                 |                SGW                |
-|                   +---------------+-------------------+-------------------+---------------+
-|                   |   Rev Tree    |        HLV        |     Rev Tree      |      HLV      |
-+-------------------+---------------+-------------------+-------------------+---------------+
-| After restore     |     1-abc     |       none        |   2-def, 1-abc    |     none      |
-| After SGW mutate  |     1-abc     |       none        | 3-xxx,2-def,1-abc |   [N@SGW]     |
-| Expected post-PULL|     none      |     [N@SGW]       | 3-xxx,2-def,1-abc |   [N@SGW]     |
-+-------------------+---------------+-------------------+-------------------+---------------+
++-------------------+-------------------------------+-------------------------------+
+|                   |             CBL               |              SGW              |
+|                   +---------------+---------------+---------------+---------------+
+|                   |   Rev Tree    |      HLV      |   Rev Tree    |      HLV      |
++-------------------+---------------+---------------+---------------+---------------+
+| After restore     |     1-abc     |     none      | 2-def, 1-abc  |     none      |
+| Expected post-PULL| 2-def, 1-abc  |     none      | 2-def, 1-abc  |     none      |
++-------------------+---------------+---------------+---------------+---------------+
 ```
 
 ### Steps
@@ -105,23 +106,23 @@ the delta path across a pre-upgrade revision.
    On 412 (already exists), force-recreate by `delete_database` + `put_database`.
 6. Verify delta_sync is actually enabled on SGW 'upgrade' database.
 7. Create user `user1` with full access to `_default._default`.
-8. Mutate `nonconflict_2` on 4.x SGW to create a new revtree leaf + HLV.
-9. Start a replicator:
+8. Start a replicator:
    * endpoint: `/upgrade`
    * collections: `_default._default`
    * type: pull
    * document_ids: `['nonconflict_2']`
    * continuous: False
    * credentials: user1/pass
-10. Wait until the replicator is stopped.
-11. Check that the doc is replicated correctly.
-12. Validate revid and HLV of local and remote doc:
-    * Pre: local has revid + no HLV; SGW has revid + HLV; local revid < SGW revid.
-    * Post: local has no revid (4.x CBL is HLV-only); local HLV equals SGW HLV.
-13. Confirm SGW sent the revision as a delta (`deltas_sent` incremented).
+9. Wait until the replicator is stopped.
+10. Check that the doc is replicated correctly.
+11. Validate revid and HLV of local and remote doc:
+    * Pre: both sides have revid and no HLV; local revid < SGW revid.
+    * Post: local and SGW share the same revid; neither has an HLV (the legacy
+      rev carries no HLV and PULL doesn't touch SGW).
+12. Confirm SGW sent the revision as a delta (`deltas_sent` incremented).
 
 ### Expected Outcome
 
-CBL ingests the delta computed against its legacy rev-1 ancestor and ends up
-HLV-only with an HLV matching SGW; the `deltas_sent` counter confirms a delta
-(not a full body) was sent.
+SGW sends rev 2 as a revID-identified legacy delta (no HLV) computed against the
+client's rev 1; CBL applies it and ends up revtree-only at rev 2; the
+`deltas_sent` counter confirms a delta (not a full body) was sent.

--- a/tests/QE/test_replication_upgrade_delta_sync.py
+++ b/tests/QE/test_replication_upgrade_delta_sync.py
@@ -98,7 +98,7 @@ class TestUpgradeDeltaSync(CBLTestClass):
     async def test_delta_sync_history_pull_post_upgrade_sgw_mutation(
         self, cblpytest: CBLPyTest, dataset_path: Path
     ) -> None:
-        doc_id = "nonconflict_2"
+        doc_id = "nonconflict_3"
         db = await setup_upgrade_env(self, cblpytest, dataset_path)
         await self._prepare_sg_with_delta_sync(cblpytest)
         sg = cblpytest.sync_gateways[0]

--- a/tests/QE/test_replication_upgrade_delta_sync.py
+++ b/tests/QE/test_replication_upgrade_delta_sync.py
@@ -84,17 +84,21 @@ class TestUpgradeDeltaSync(CBLTestClass):
 
     @pytest.mark.asyncio(loop_scope="session")
     @pytest.mark.xfail(
-        strict=True,
+        strict=False,
         reason=(
             "SGW delta-sync history bug: when SGW sends a delta of a "
             "revtree+HLV rev to a client holding the revtree-only ancestor, "
-            "the rev message's `history` field is empty. Fix pending."
+            "the rev message's `history` field is empty. Fix pending. "
+            "NOTE: non-strict — the bug currently does not surface through "
+            "end-state revid/HLV/body comparison (likely a BLIP wire-level "
+            "issue only). When the SGW fix lands, flip strict=True so an "
+            "XPASS becomes a loud signal to remove this decorator."
         ),
     )
     async def test_delta_sync_history_pull_post_upgrade_sgw_mutation(
         self, cblpytest: CBLPyTest, dataset_path: Path
     ) -> None:
-        doc_id = "nonconflict_3"
+        doc_id = "nonconflict_2"
         db = await setup_upgrade_env(self, cblpytest, dataset_path)
         await self._prepare_sg_with_delta_sync(cblpytest)
         sg = cblpytest.sync_gateways[0]
@@ -142,7 +146,7 @@ class TestUpgradeDeltaSync(CBLTestClass):
             db,
             doc_id=doc_id,
             replicator_type=ReplicatorType.PULL,
-            compare_docs=False,
+            compare_docs=True,
             validator=validator,
         )
 
@@ -168,15 +172,13 @@ class TestUpgradeDeltaSync(CBLTestClass):
                 f"got local={pre.local.revid}, remote={pre.remote.revid}"
             )
 
-            assert post.local.revid is None, (
-                f"Expected post-pull local doc to be HLV-only, "
-                f"got revid={post.local.revid}"
+            assert post.local.revid and post.local.revid == post.remote.revid, (
+                f"Expected post-pull revtree-only doc with matching revids. "
+                f"Local={post.local.revid}, Remote={post.remote.revid}"
             )
-            assert post.local.cv and post.local.cv.endswith(
-                "@Revision+Tree+Encoding"
-            ), (
-                f"Expected post-pull local HLV to be RTE-encoded from the "
-                f"pulled revtree-only rev, got {post.local.cv}"
+            assert post.local.cv is None, (
+                f"Expected post-pull local doc to remain revtree-only "
+                f"(neither side wrote under 4.x), got HLV={post.local.cv}"
             )
             assert post.remote.cv is None, (
                 f"Expected SGW HLV unchanged (none) after PULL, got {post.remote.cv}"
@@ -188,6 +190,6 @@ class TestUpgradeDeltaSync(CBLTestClass):
             db,
             doc_id=doc_id,
             replicator_type=ReplicatorType.PULL,
-            compare_docs=False,
+            compare_docs=True,
             validator=validator,
         )

--- a/tests/QE/test_replication_upgrade_delta_sync.py
+++ b/tests/QE/test_replication_upgrade_delta_sync.py
@@ -52,10 +52,18 @@ class TestUpgradeDeltaSync(CBLTestClass):
         except CblSyncGatewayBadResponseError as e:
             if e.code != 412:
                 raise
-            # in case DB already exits, force-recreate, so our delta_sync
-            # config is rather than running against the previous config
+            # DB already exists. Try to force-recreate so our delta_sync
+            # config is applied. delete_database silently swallows 403
+            # internally (config-managed DBs), so the delete may be a no-op
+            # and the retry put may also 412. Tolerate that — the
+            # verify-config assertion below is the real backstop and will
+            # dump the active config if delta_sync is not enabled.
             await sg.delete_database("upgrade")
-            await sg.put_database("upgrade", payload)
+            try:
+                await sg.put_database("upgrade", payload)
+            except CblSyncGatewayBadResponseError as e2:
+                if e2.code != 412:
+                    raise
         await sg.wait_for_db_up("upgrade")
 
         self.mark_test_step(

--- a/tests/QE/test_replication_upgrade_delta_sync.py
+++ b/tests/QE/test_replication_upgrade_delta_sync.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 
 import pytest
@@ -5,12 +6,83 @@ from cbltest import CBLPyTest
 from cbltest.api.cbltestclass import CBLTestClass
 from cbltest.api.error import CblSyncGatewayBadResponseError
 from cbltest.api.replicator_types import ReplicatorType
-from cbltest.api.syncgateway import DocumentUpdateEntry, PutDatabasePayload
+from cbltest.api.syncgateway import (
+    DocumentUpdateEntry,
+    PutDatabasePayload,
+    SyncGateway,
+)
+from cbltest.logging import cbl_info
 from shared.upgrade_test_helpers import (
     DocSnapshot,
     do_upgrade_replication_test,
     setup_upgrade_env,
 )
+
+# ~10KB padding added during the SGW mutation step so the doc body is
+# big enough that SGW's delta-sync code path is exercised on pull, and the
+# pre/post bytes_transferred delta gives a measurable signal.
+_LARGE_PADDING: str = "x" * 10_240
+
+
+def _delta_counter_total(stats: dict) -> int:
+    """Sum the counters in an SGW per-db ``delta_sync`` expvar dict.
+
+    SGW exposes a handful of delta-related counters under
+    ``syncgateway.per_db.<db>.delta_sync`` (e.g. ``deltas_sent``,
+    ``delta_pull_replication_count``). We sum whichever integer counters
+    are present so we don't have to hard-code a specific key name that
+    might shift between SGW versions — any positive delta over a pull means
+    delta-sync participated.
+    """
+    return sum(v for v in stats.values() if isinstance(v, int))
+
+
+async def _assert_delta_sync_participated(
+    sg: SyncGateway,
+    db_name: str,
+    bytes_before: int,
+    delta_stats_before: dict,
+    new_body_size: int,
+) -> None:
+    """Verify SGW's delta-sync path actually served the pull.
+
+    Two independent signals are checked; the test passes if either one
+    fires (both should fire when delta-sync engages, but we accept either
+    so we're resilient to SGW expvar schema drift):
+
+    1. ``delta_sync`` counters in ``/_expvar`` incremented across the pull.
+    2. Bytes written by SGW over BLIP for this pull are meaningfully less
+       than the full new body — i.e. SGW actually compressed.
+    """
+    bytes_after, _ = await sg.bytes_transferred(db_name)
+    bytes_for_pull = bytes_after - bytes_before
+
+    delta_stats_after = await sg.get_delta_sync_stats(db_name)
+    counter_before = _delta_counter_total(delta_stats_before)
+    counter_after = _delta_counter_total(delta_stats_after)
+    counter_increment = counter_after - counter_before
+
+    cbl_info(
+        f"Delta-sync participation check: "
+        f"bytes_for_pull={bytes_for_pull}, new_body_size={new_body_size}, "
+        f"delta_counter_increment={counter_increment}, "
+        f"delta_stats_before={delta_stats_before}, "
+        f"delta_stats_after={delta_stats_after}"
+    )
+
+    counter_signal = counter_increment > 0
+    bytes_signal = 0 < bytes_for_pull < new_body_size
+
+    assert counter_signal or bytes_signal, (
+        "Delta-sync did not appear to participate in this pull. "
+        f"bytes_for_pull={bytes_for_pull} (expected 0 < x < new_body_size="
+        f"{new_body_size}); delta counters delta={counter_increment} "
+        f"(before={delta_stats_before}, after={delta_stats_after}). "
+        "Either SGW fell back to sending the full body (delta path not "
+        "exercised, so the history-field bug cannot manifest), or the "
+        "expvar schema we're polling has changed."
+    )
+
 
 _DELTA_SYNC_UPGRADE_CONFIG: dict = {
     "bucket": "upgrade",
@@ -104,14 +176,33 @@ class TestUpgradeDeltaSync(CBLTestClass):
         sg = cblpytest.sync_gateways[0]
 
         self.mark_test_step(
-            f"Mutate '{doc_id}' on 4.x SGW to produce a new revtree leaf + fresh HLV"
+            f"Mutate '{doc_id}' on 4.x SGW with a large body so delta-sync "
+            "engages on the subsequent pull. The new rev gets revtree + HLV."
         )
         current = await sg.get_document("upgrade", doc_id)
         assert current is not None, f"Expected '{doc_id}' imported from bucket"
         assert current.revid is not None, (
             f"Expected '{doc_id}' to have a revid pre-mutation, got None"
         )
-        new_body = {**current.body, "updated_by": "delta_sync_history_test"}
+        # New body: keep the original fields (so client's ancestor body overlaps
+        # with the new rev — gives delta-sync something meaningful to compress),
+        # plus a substantial padding field to make the new body large enough
+        # that "bytes transferred < new body size" is a clean signal.
+        new_body = {
+            **current.body,
+            "updated_by": "delta_sync_history_test",
+            "large_payload": _LARGE_PADDING,
+        }
+        new_body_size = len(json.dumps(new_body).encode("utf-8"))
+
+        self.mark_test_step(
+            "Snapshot SGW bytes-transferred and delta_sync expvar counters "
+            "before the pull, so we can verify delta-sync participated."
+        )
+        bytes_before, _ = await sg.bytes_transferred("upgrade")
+        delta_stats_before = await sg.get_delta_sync_stats("upgrade")
+
+        self.mark_test_step(f"Apply the large-body mutation to '{doc_id}' on SGW")
         await sg.update_documents(
             "upgrade",
             [DocumentUpdateEntry(doc_id, current.revid, body=new_body)],
@@ -150,38 +241,90 @@ class TestUpgradeDeltaSync(CBLTestClass):
             validator=validator,
         )
 
+        self.mark_test_step(
+            "Confirm delta-sync actually participated in this pull "
+            "(otherwise the history-field bug we're targeting can't manifest)."
+        )
+        await _assert_delta_sync_participated(
+            sg,
+            "upgrade",
+            bytes_before,
+            delta_stats_before,
+            new_body_size,
+        )
+
     @pytest.mark.asyncio(loop_scope="session")
     async def test_delta_sync_history_pull_pre_upgrade_sgw_two_revs(
         self, cblpytest: CBLPyTest, dataset_path: Path
     ) -> None:
+        # Same template as Test 1, but using nonconflict_2 — client starts at
+        # rev 1 (revtree-only) while SGW's dataset state is already at rev 2
+        # (revtree-only legacy). After the 4.x SGW mutation below, SGW is at
+        # rev 3 (revtree + HLV). The client is therefore TWO revs behind, with
+        # rev 1 as the only common ancestor — and per the senior's wire-level
+        # investigation, the legacy-rev backup body for rev 1 isn't seeded in
+        # the bucket, so SGW is expected to fall back to a full body send and
+        # the delta-sync participation check should fail. That failure is the
+        # signal that the TDK upgrade dataset needs backup-rev seeding.
         doc_id = "nonconflict_2"
         db = await setup_upgrade_env(self, cblpytest, dataset_path)
         await self._prepare_sg_with_delta_sync(cblpytest)
+        sg = cblpytest.sync_gateways[0]
+
+        self.mark_test_step(
+            f"Mutate '{doc_id}' on 4.x SGW with a large body so delta-sync "
+            "engages on the subsequent pull. The new rev gets revtree + HLV."
+        )
+        current = await sg.get_document("upgrade", doc_id)
+        assert current is not None, f"Expected '{doc_id}' imported from bucket"
+        assert current.revid is not None, (
+            f"Expected '{doc_id}' to have a revid pre-mutation, got None"
+        )
+        new_body = {
+            **current.body,
+            "updated_by": "delta_sync_history_test",
+            "large_payload": _LARGE_PADDING,
+        }
+        new_body_size = len(json.dumps(new_body).encode("utf-8"))
+
+        self.mark_test_step(
+            "Snapshot SGW bytes-transferred and delta_sync expvar counters "
+            "before the pull, so we can verify delta-sync participated."
+        )
+        bytes_before, _ = await sg.bytes_transferred("upgrade")
+        delta_stats_before = await sg.get_delta_sync_stats("upgrade")
+
+        self.mark_test_step(f"Apply the large-body mutation to '{doc_id}' on SGW")
+        await sg.update_documents(
+            "upgrade",
+            [DocumentUpdateEntry(doc_id, current.revid, body=new_body)],
+        )
 
         def validator(pre: DocSnapshot, post: DocSnapshot) -> None:
             assert pre.local.revid is not None and pre.local.cv is None, (
                 f"Local precondition invalid: RevID={pre.local.revid}, "
                 f"HLV={pre.local.cv} (expected revtree-only)"
             )
-            assert pre.remote.revid is not None and pre.remote.cv is None, (
+            assert pre.remote.revid is not None and pre.remote.cv is not None, (
                 f"Remote precondition invalid: RevID={pre.remote.revid}, "
-                f"HLV={pre.remote.cv} (expected revtree-only, no HLV)"
+                f"HLV={pre.remote.cv} (expected revtree + HLV after 4.x mutation)"
+            )
+            assert not pre.remote.cv.endswith("@Revision+Tree+Encoding"), (
+                f"Expected canonical HLV on SGW after 4.x write, got RTE-encoded: "
+                f"{pre.remote.cv}"
             )
             assert pre.local.revid < pre.remote.revid, (
                 f"Pre-condition: expected local revid < remote revid, "
                 f"got local={pre.local.revid}, remote={pre.remote.revid}"
             )
 
-            assert post.local.revid and post.local.revid == post.remote.revid, (
-                f"Expected post-pull revtree-only doc with matching revids. "
-                f"Local={post.local.revid}, Remote={post.remote.revid}"
+            assert post.local.revid is None, (
+                f"Expected post-pull local doc to be HLV-only, "
+                f"got revid={post.local.revid}"
             )
-            assert post.local.cv is None, (
-                f"Expected post-pull local doc to remain revtree-only "
-                f"(neither side wrote under 4.x), got HLV={post.local.cv}"
-            )
-            assert post.remote.cv is None, (
-                f"Expected SGW HLV unchanged (none) after PULL, got {post.remote.cv}"
+            assert post.local.cv and post.local.cv == post.remote.cv, (
+                f"Expected post-pull local HLV to match SGW HLV. "
+                f"Local={post.local.cv}, Remote={post.remote.cv}"
             )
 
         await do_upgrade_replication_test(
@@ -192,4 +335,18 @@ class TestUpgradeDeltaSync(CBLTestClass):
             replicator_type=ReplicatorType.PULL,
             compare_docs=True,
             validator=validator,
+        )
+
+        self.mark_test_step(
+            "Confirm delta-sync actually participated in this pull. "
+            "Expected to FAIL today: legacy backup rev for rev 1 isn't seeded "
+            "in the bucket, so SGW falls back to full body. Becomes a PASS "
+            "once the TDK dataset is regenerated with backup revs included."
+        )
+        await _assert_delta_sync_participated(
+            sg,
+            "upgrade",
+            bytes_before,
+            delta_stats_before,
+            new_body_size,
         )

--- a/tests/QE/test_replication_upgrade_delta_sync.py
+++ b/tests/QE/test_replication_upgrade_delta_sync.py
@@ -177,40 +177,27 @@ class TestUpgradeDeltaSync(CBLTestClass):
         await self._prepare_sg_with_delta_sync(cblpytest)
         sg = cblpytest.sync_gateways[0]
 
-        self.mark_test_step(
-            f"Mutate '{doc_id}' on 4.x SGW to create a new revtree leaf + HLV."
-        )
-        current = await sg.get_document("upgrade", doc_id)
-        assert current is not None, f"Expected '{doc_id}' imported from bucket"
-        assert current.revid is not None, f"Expected '{doc_id}' to have a revid"
         deltas_sent_before = _deltas_sent(await sg.get_delta_sync_stats("upgrade"))
-        await sg.update_documents(
-            "upgrade",
-            [
-                DocumentUpdateEntry(
-                    doc_id,
-                    current.revid,
-                    body={**current.body, "updated_by": "delta_sync_history_test"},
-                )
-            ],
-        )
 
         def validator(pre: DocSnapshot, post: DocSnapshot) -> None:
             assert pre.local.revid is not None and pre.local.cv is None, (
                 f"Pre local expected revtree-only: revid={pre.local.revid}, hlv={pre.local.cv}"
             )
-            assert pre.remote.revid is not None and pre.remote.cv is not None, (
-                f"Pre remote expected revtree+HLV: revid={pre.remote.revid}, hlv={pre.remote.cv}"
+            assert pre.remote.revid is not None and pre.remote.cv is None, (
+                f"Pre remote expected revtree-only (no HLV): revid={pre.remote.revid}, hlv={pre.remote.cv}"
             )
             assert pre.local.revid < pre.remote.revid, (
                 f"Pre expected local revid < remote revid: "
                 f"local={pre.local.revid}, remote={pre.remote.revid}"
             )
-            assert post.local.revid is None, (
-                f"Post local expected HLV-only, got revid={post.local.revid}"
+            assert post.local.revid and post.local.revid == post.remote.revid, (
+                f"Post expected matching revtree revid: local={post.local.revid}, remote={post.remote.revid}"
             )
-            assert post.local.cv and post.local.cv == post.remote.cv, (
-                f"Post HLV mismatch: local={post.local.cv}, remote={post.remote.cv}"
+            assert post.local.cv is None, (
+                f"Post local expected revtree-only (no HLV), got {post.local.cv}"
+            )
+            assert post.remote.cv is None, (
+                f"Post remote expected no HLV (PULL doesn't touch SGW), got {post.remote.cv}"
             )
 
         await do_upgrade_replication_test(

--- a/tests/QE/test_replication_upgrade_delta_sync.py
+++ b/tests/QE/test_replication_upgrade_delta_sync.py
@@ -1,0 +1,172 @@
+from pathlib import Path
+
+import pytest
+from cbltest import CBLPyTest
+from cbltest.api.cbltestclass import CBLTestClass
+from cbltest.api.error import CblSyncGatewayBadResponseError
+from cbltest.api.replicator_types import ReplicatorType
+from cbltest.api.syncgateway import DocumentUpdateEntry, PutDatabasePayload
+from cbltest.api.upgrade_test_helpers import (
+    DocSnapshot,
+    do_upgrade_replication_test,
+    setup_upgrade_env,
+)
+
+_DELTA_SYNC_UPGRADE_CONFIG: dict = {
+    "bucket": "upgrade",
+    "num_index_replicas": 0,
+    "scopes": {
+        "_default": {
+            "collections": {
+                "_default": {
+                    "sync": (
+                        "function(doc, oldDoc, meta) {"
+                        "  if (doc._deleted) { channel(oldDoc.channels); }"
+                        "  else { channel(doc.channels || 'upgrade'); }"
+                        "}"
+                    )
+                }
+            }
+        }
+    },
+    "import_docs": True,
+    "enable_shared_bucket_access": True,
+    "delta_sync": {"enabled": True},
+}
+
+
+@pytest.mark.sgw
+@pytest.mark.min_test_servers(1)
+@pytest.mark.min_sync_gateways(1)
+@pytest.mark.min_couchbase_servers(1)
+class TestUpgradeDeltaSync(CBLTestClass):
+    async def _prepare_sg_with_delta_sync(self, cblpytest: CBLPyTest) -> None:
+        sg = cblpytest.sync_gateways[0]
+
+        self.mark_test_step(
+            "Create SG 'upgrade' database with delta_sync enabled and import from bucket"
+        )
+        try:
+            await sg.put_database(
+                "upgrade", PutDatabasePayload(_DELTA_SYNC_UPGRADE_CONFIG)
+            )
+        except CblSyncGatewayBadResponseError as e:
+            if e.code != 412:
+                raise
+        await sg.wait_for_db_up("upgrade")
+
+        self.mark_test_step("Create user1 for replication")
+        collection_access = sg.create_collection_access_dict(
+            {"_default._default": ["*"]}
+        )
+        await sg.add_user("upgrade", "user1", "pass", collection_access)
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.xfail(
+        strict=True,
+        reason=(
+            "SGW delta-sync history bug: when SGW sends a delta of a "
+            "revtree+HLV rev to a client holding the revtree-only ancestor, "
+            "the rev message's `history` field is empty. Fix pending."
+        ),
+    )
+    async def test_delta_sync_history_pull_post_upgrade_sgw_mutation(
+        self, cblpytest: CBLPyTest, dataset_path: Path
+    ) -> None:
+        doc_id = "nonconflict_3"
+        db = await setup_upgrade_env(self, cblpytest, dataset_path)
+        await self._prepare_sg_with_delta_sync(cblpytest)
+        sg = cblpytest.sync_gateways[0]
+
+        self.mark_test_step(
+            f"Mutate '{doc_id}' on 4.x SGW to produce a new revtree leaf + fresh HLV"
+        )
+        current = await sg.get_document("upgrade", doc_id)
+        assert current is not None, f"Expected '{doc_id}' imported from bucket"
+        assert current.revid is not None, (
+            f"Expected '{doc_id}' to have a revid pre-mutation, got None"
+        )
+        new_body = {**current.body, "updated_by": "delta_sync_history_test"}
+        await sg.update_documents(
+            "upgrade",
+            [DocumentUpdateEntry(doc_id, current.revid, body=new_body)],
+        )
+
+        def validator(pre: DocSnapshot, post: DocSnapshot) -> None:
+            assert pre.local.revid is not None and pre.local.cv is None, (
+                f"Local precondition invalid: RevID={pre.local.revid}, "
+                f"HLV={pre.local.cv} (expected revtree-only)"
+            )
+            assert pre.remote.revid is not None and pre.remote.cv is not None, (
+                f"Remote precondition invalid: RevID={pre.remote.revid}, "
+                f"HLV={pre.remote.cv} (expected revtree + HLV after 4.x mutation)"
+            )
+            assert not pre.remote.cv.endswith("@Revision+Tree+Encoding"), (
+                f"Expected canonical HLV on SGW after 4.x write, got RTE-encoded: "
+                f"{pre.remote.cv}"
+            )
+
+            assert post.local.revid is None, (
+                f"Expected post-pull local doc to be HLV-only, "
+                f"got revid={post.local.revid}"
+            )
+            assert post.local.cv and post.local.cv == post.remote.cv, (
+                f"Expected post-pull local HLV to match SGW HLV. "
+                f"Local={post.local.cv}, Remote={post.remote.cv}"
+            )
+
+        await do_upgrade_replication_test(
+            self,
+            cblpytest,
+            db,
+            doc_id=doc_id,
+            replicator_type=ReplicatorType.PULL,
+            compare_docs=False,
+            validator=validator,
+        )
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_delta_sync_history_pull_pre_upgrade_sgw_two_revs(
+        self, cblpytest: CBLPyTest, dataset_path: Path
+    ) -> None:
+        doc_id = "nonconflict_2"
+        db = await setup_upgrade_env(self, cblpytest, dataset_path)
+        await self._prepare_sg_with_delta_sync(cblpytest)
+
+        def validator(pre: DocSnapshot, post: DocSnapshot) -> None:
+            assert pre.local.revid is not None and pre.local.cv is None, (
+                f"Local precondition invalid: RevID={pre.local.revid}, "
+                f"HLV={pre.local.cv} (expected revtree-only)"
+            )
+            assert pre.remote.revid is not None and pre.remote.cv is None, (
+                f"Remote precondition invalid: RevID={pre.remote.revid}, "
+                f"HLV={pre.remote.cv} (expected revtree-only, no HLV)"
+            )
+            assert pre.local.revid < pre.remote.revid, (
+                f"Pre-condition: expected local revid < remote revid, "
+                f"got local={pre.local.revid}, remote={pre.remote.revid}"
+            )
+
+            assert post.local.revid is None, (
+                f"Expected post-pull local doc to be HLV-only, "
+                f"got revid={post.local.revid}"
+            )
+            assert post.local.cv and post.local.cv.endswith(
+                "@Revision+Tree+Encoding"
+            ), (
+                f"Expected post-pull local HLV to be RTE-encoded from the "
+                f"pulled revtree-only rev, got {post.local.cv}"
+            )
+            assert post.remote.cv is None, (
+                f"Expected SGW HLV unchanged (none) after PULL, got {post.remote.cv}"
+            )
+
+        await do_upgrade_replication_test(
+            self,
+            cblpytest,
+            db,
+            doc_id=doc_id,
+            replicator_type=ReplicatorType.PULL,
+            compare_docs=False,
+            validator=validator,
+        )

--- a/tests/QE/test_replication_upgrade_delta_sync.py
+++ b/tests/QE/test_replication_upgrade_delta_sync.py
@@ -6,7 +6,7 @@ from cbltest.api.cbltestclass import CBLTestClass
 from cbltest.api.error import CblSyncGatewayBadResponseError
 from cbltest.api.replicator_types import ReplicatorType
 from cbltest.api.syncgateway import DocumentUpdateEntry, PutDatabasePayload
-from cbltest.api.upgrade_test_helpers import (
+from shared.upgrade_test_helpers import (
     DocSnapshot,
     do_upgrade_replication_test,
     setup_upgrade_env,

--- a/tests/QE/test_replication_upgrade_delta_sync.py
+++ b/tests/QE/test_replication_upgrade_delta_sync.py
@@ -42,18 +42,31 @@ _DELTA_SYNC_UPGRADE_CONFIG: dict = {
 class TestUpgradeDeltaSync(CBLTestClass):
     async def _prepare_sg_with_delta_sync(self, cblpytest: CBLPyTest) -> None:
         sg = cblpytest.sync_gateways[0]
+        payload = PutDatabasePayload(_DELTA_SYNC_UPGRADE_CONFIG)
 
         self.mark_test_step(
             "Create SG 'upgrade' database with delta_sync enabled and import from bucket"
         )
         try:
-            await sg.put_database(
-                "upgrade", PutDatabasePayload(_DELTA_SYNC_UPGRADE_CONFIG)
-            )
+            await sg.put_database("upgrade", payload)
         except CblSyncGatewayBadResponseError as e:
             if e.code != 412:
                 raise
+            # in case DB already exits, force-recreate, so our delta_sync
+            # config is rather than running against the previous config
+            await sg.delete_database("upgrade")
+            await sg.put_database("upgrade", payload)
         await sg.wait_for_db_up("upgrade")
+
+        self.mark_test_step(
+            "Verify delta_sync is actually enabled on SGW 'upgrade' database"
+        )
+        config = await sg.get_database_config("upgrade")
+        delta_sync = config.get("delta_sync") or {}
+        assert delta_sync.get("enabled") is True, (
+            "Prerequisite failed: SGW 'upgrade' database does not have "
+            f"delta_sync.enabled=True. Active config: {config!r}"
+        )
 
         self.mark_test_step("Create user1 for replication")
         collection_access = sg.create_collection_access_dict(

--- a/tests/QE/test_replication_upgrade_delta_sync.py
+++ b/tests/QE/test_replication_upgrade_delta_sync.py
@@ -1,4 +1,3 @@
-import json
 from pathlib import Path
 
 import pytest
@@ -11,76 +10,36 @@ from cbltest.api.syncgateway import (
     PutDatabasePayload,
     SyncGateway,
 )
-from cbltest.logging import cbl_info
 from shared.upgrade_test_helpers import (
     DocSnapshot,
     do_upgrade_replication_test,
     setup_upgrade_env,
 )
 
-# ~10KB padding added during the SGW mutation step so the doc body is
-# big enough that SGW's delta-sync code path is exercised on pull, and the
-# pre/post bytes_transferred delta gives a measurable signal.
-_LARGE_PADDING: str = "x" * 10_240
+# A real delta send is only distinguishable from a full-body fallback by a
+# per-rev "deltas sent" counter under syncgateway.per_db.<db>.delta_sync;
+# session-level counters increment even when SGW falls back to a full body.
+_DELTAS_SENT_KEYS: tuple[str, ...] = ("deltas_sent", "delta_sent", "deltas_sent_count")
 
 
-def _delta_counter_total(stats: dict) -> int:
-    """Sum the counters in an SGW per-db ``delta_sync`` expvar dict.
-
-    SGW exposes a handful of delta-related counters under
-    ``syncgateway.per_db.<db>.delta_sync`` (e.g. ``deltas_sent``,
-    ``delta_pull_replication_count``). We sum whichever integer counters
-    are present so we don't have to hard-code a specific key name that
-    might shift between SGW versions — any positive delta over a pull means
-    delta-sync participated.
-    """
-    return sum(v for v in stats.values() if isinstance(v, int))
+def _deltas_sent(stats: dict) -> int | None:
+    for key in _DELTAS_SENT_KEYS:
+        value = stats.get(key)
+        if isinstance(value, int):
+            return value
+    return None
 
 
 async def _assert_delta_sync_participated(
-    sg: SyncGateway,
-    db_name: str,
-    bytes_before: int,
-    delta_stats_before: dict,
-    new_body_size: int,
+    sg: SyncGateway, db_name: str, deltas_sent_before: int | None
 ) -> None:
-    """Verify SGW's delta-sync path actually served the pull.
-
-    Two independent signals are checked; the test passes if either one
-    fires (both should fire when delta-sync engages, but we accept either
-    so we're resilient to SGW expvar schema drift):
-
-    1. ``delta_sync`` counters in ``/_expvar`` incremented across the pull.
-    2. Bytes written by SGW over BLIP for this pull are meaningfully less
-       than the full new body — i.e. SGW actually compressed.
-    """
-    bytes_after, _ = await sg.bytes_transferred(db_name)
-    bytes_for_pull = bytes_after - bytes_before
-
-    delta_stats_after = await sg.get_delta_sync_stats(db_name)
-    counter_before = _delta_counter_total(delta_stats_before)
-    counter_after = _delta_counter_total(delta_stats_after)
-    counter_increment = counter_after - counter_before
-
-    cbl_info(
-        f"Delta-sync participation check: "
-        f"bytes_for_pull={bytes_for_pull}, new_body_size={new_body_size}, "
-        f"delta_counter_increment={counter_increment}, "
-        f"delta_stats_before={delta_stats_before}, "
-        f"delta_stats_after={delta_stats_after}"
+    """Assert SGW sent the revision as a delta, not a full-body fallback."""
+    deltas_sent_after = _deltas_sent(await sg.get_delta_sync_stats(db_name))
+    assert deltas_sent_after is not None, (
+        f"No per-rev delta counter in SGW expvar (tried {_DELTAS_SENT_KEYS})."
     )
-
-    counter_signal = counter_increment > 0
-    bytes_signal = 0 < bytes_for_pull < new_body_size
-
-    assert counter_signal or bytes_signal, (
-        "Delta-sync did not appear to participate in this pull. "
-        f"bytes_for_pull={bytes_for_pull} (expected 0 < x < new_body_size="
-        f"{new_body_size}); delta counters delta={counter_increment} "
-        f"(before={delta_stats_before}, after={delta_stats_after}). "
-        "Either SGW fell back to sending the full body (delta path not "
-        "exercised, so the history-field bug cannot manifest), or the "
-        "expvar schema we're polling has changed."
+    assert deltas_sent_after - (deltas_sent_before or 0) > 0, (
+        "SGW fell back to a full-body send instead of a delta."
     )
 
 
@@ -124,12 +83,6 @@ class TestUpgradeDeltaSync(CBLTestClass):
         except CblSyncGatewayBadResponseError as e:
             if e.code != 412:
                 raise
-            # DB already exists. Try to force-recreate so our delta_sync
-            # config is applied. delete_database silently swallows 403
-            # internally (config-managed DBs), so the delete may be a no-op
-            # and the retry put may also 412. Tolerate that — the
-            # verify-config assertion below is the real backstop and will
-            # dump the active config if delta_sync is not enabled.
             await sg.delete_database("upgrade")
             try:
                 await sg.put_database("upgrade", payload)
@@ -155,80 +108,49 @@ class TestUpgradeDeltaSync(CBLTestClass):
         await sg.add_user("upgrade", "user1", "pass", collection_access)
 
     @pytest.mark.asyncio(loop_scope="session")
-    @pytest.mark.xfail(
-        strict=False,
-        reason=(
-            "SGW delta-sync history bug: when SGW sends a delta of a "
-            "revtree+HLV rev to a client holding the revtree-only ancestor, "
-            "the rev message's `history` field is empty. Fix pending. "
-            "NOTE: non-strict — the bug currently does not surface through "
-            "end-state revid/HLV/body comparison (likely a BLIP wire-level "
-            "issue only). When the SGW fix lands, flip strict=True so an "
-            "XPASS becomes a loud signal to remove this decorator."
-        ),
-    )
     async def test_delta_sync_history_pull_post_upgrade_sgw_mutation(
         self, cblpytest: CBLPyTest, dataset_path: Path
     ) -> None:
         doc_id = "nonconflict_3"
-        db = await setup_upgrade_env(self, cblpytest, dataset_path)
+        db = await setup_upgrade_env(
+            self, cblpytest, dataset_path, reset_expired_ttl=True
+        )
         await self._prepare_sg_with_delta_sync(cblpytest)
         sg = cblpytest.sync_gateways[0]
 
         self.mark_test_step(
-            f"Mutate '{doc_id}' on 4.x SGW with a large body so delta-sync "
-            "engages on the subsequent pull. The new rev gets revtree + HLV."
+            f"Mutate '{doc_id}' on 4.x SGW to create a new revtree leaf + HLV."
         )
         current = await sg.get_document("upgrade", doc_id)
         assert current is not None, f"Expected '{doc_id}' imported from bucket"
-        assert current.revid is not None, (
-            f"Expected '{doc_id}' to have a revid pre-mutation, got None"
-        )
-        # New body: keep the original fields (so client's ancestor body overlaps
-        # with the new rev — gives delta-sync something meaningful to compress),
-        # plus a substantial padding field to make the new body large enough
-        # that "bytes transferred < new body size" is a clean signal.
-        new_body = {
-            **current.body,
-            "updated_by": "delta_sync_history_test",
-            "large_payload": _LARGE_PADDING,
-        }
-        new_body_size = len(json.dumps(new_body).encode("utf-8"))
-
-        self.mark_test_step(
-            "Snapshot SGW bytes-transferred and delta_sync expvar counters "
-            "before the pull, so we can verify delta-sync participated."
-        )
-        bytes_before, _ = await sg.bytes_transferred("upgrade")
-        delta_stats_before = await sg.get_delta_sync_stats("upgrade")
-
-        self.mark_test_step(f"Apply the large-body mutation to '{doc_id}' on SGW")
+        assert current.revid is not None, f"Expected '{doc_id}' to have a revid"
+        deltas_sent_before = _deltas_sent(await sg.get_delta_sync_stats("upgrade"))
         await sg.update_documents(
             "upgrade",
-            [DocumentUpdateEntry(doc_id, current.revid, body=new_body)],
+            [
+                DocumentUpdateEntry(
+                    doc_id,
+                    current.revid,
+                    body={**current.body, "updated_by": "delta_sync_history_test"},
+                )
+            ],
         )
 
         def validator(pre: DocSnapshot, post: DocSnapshot) -> None:
             assert pre.local.revid is not None and pre.local.cv is None, (
-                f"Local precondition invalid: RevID={pre.local.revid}, "
-                f"HLV={pre.local.cv} (expected revtree-only)"
+                f"Pre local expected revtree-only: revid={pre.local.revid}, hlv={pre.local.cv}"
             )
             assert pre.remote.revid is not None and pre.remote.cv is not None, (
-                f"Remote precondition invalid: RevID={pre.remote.revid}, "
-                f"HLV={pre.remote.cv} (expected revtree + HLV after 4.x mutation)"
+                f"Pre remote expected revtree+HLV: revid={pre.remote.revid}, hlv={pre.remote.cv}"
             )
             assert not pre.remote.cv.endswith("@Revision+Tree+Encoding"), (
-                f"Expected canonical HLV on SGW after 4.x write, got RTE-encoded: "
-                f"{pre.remote.cv}"
+                f"Pre remote expected canonical HLV, got RTE-encoded: {pre.remote.cv}"
             )
-
             assert post.local.revid is None, (
-                f"Expected post-pull local doc to be HLV-only, "
-                f"got revid={post.local.revid}"
+                f"Post local expected HLV-only, got revid={post.local.revid}"
             )
             assert post.local.cv and post.local.cv == post.remote.cv, (
-                f"Expected post-pull local HLV to match SGW HLV. "
-                f"Local={post.local.cv}, Remote={post.remote.cv}"
+                f"Post HLV mismatch: local={post.local.cv}, remote={post.remote.cv}"
             )
 
         await do_upgrade_replication_test(
@@ -241,90 +163,54 @@ class TestUpgradeDeltaSync(CBLTestClass):
             validator=validator,
         )
 
-        self.mark_test_step(
-            "Confirm delta-sync actually participated in this pull "
-            "(otherwise the history-field bug we're targeting can't manifest)."
-        )
-        await _assert_delta_sync_participated(
-            sg,
-            "upgrade",
-            bytes_before,
-            delta_stats_before,
-            new_body_size,
-        )
+        self.mark_test_step("Confirm SGW sent the revision as a delta.")
+        await _assert_delta_sync_participated(sg, "upgrade", deltas_sent_before)
 
     @pytest.mark.asyncio(loop_scope="session")
     async def test_delta_sync_history_pull_pre_upgrade_sgw_two_revs(
         self, cblpytest: CBLPyTest, dataset_path: Path
     ) -> None:
-        # Same template as Test 1, but using nonconflict_2 — client starts at
-        # rev 1 (revtree-only) while SGW's dataset state is already at rev 2
-        # (revtree-only legacy). After the 4.x SGW mutation below, SGW is at
-        # rev 3 (revtree + HLV). The client is therefore TWO revs behind, with
-        # rev 1 as the only common ancestor — and per the senior's wire-level
-        # investigation, the legacy-rev backup body for rev 1 isn't seeded in
-        # the bucket, so SGW is expected to fall back to a full body send and
-        # the delta-sync participation check should fail. That failure is the
-        # signal that the TDK upgrade dataset needs backup-rev seeding.
         doc_id = "nonconflict_2"
-        db = await setup_upgrade_env(self, cblpytest, dataset_path)
+        db = await setup_upgrade_env(
+            self, cblpytest, dataset_path, reset_expired_ttl=True
+        )
         await self._prepare_sg_with_delta_sync(cblpytest)
         sg = cblpytest.sync_gateways[0]
 
         self.mark_test_step(
-            f"Mutate '{doc_id}' on 4.x SGW with a large body so delta-sync "
-            "engages on the subsequent pull. The new rev gets revtree + HLV."
+            f"Mutate '{doc_id}' on 4.x SGW to create a new revtree leaf + HLV."
         )
         current = await sg.get_document("upgrade", doc_id)
         assert current is not None, f"Expected '{doc_id}' imported from bucket"
-        assert current.revid is not None, (
-            f"Expected '{doc_id}' to have a revid pre-mutation, got None"
-        )
-        new_body = {
-            **current.body,
-            "updated_by": "delta_sync_history_test",
-            "large_payload": _LARGE_PADDING,
-        }
-        new_body_size = len(json.dumps(new_body).encode("utf-8"))
-
-        self.mark_test_step(
-            "Snapshot SGW bytes-transferred and delta_sync expvar counters "
-            "before the pull, so we can verify delta-sync participated."
-        )
-        bytes_before, _ = await sg.bytes_transferred("upgrade")
-        delta_stats_before = await sg.get_delta_sync_stats("upgrade")
-
-        self.mark_test_step(f"Apply the large-body mutation to '{doc_id}' on SGW")
+        assert current.revid is not None, f"Expected '{doc_id}' to have a revid"
+        deltas_sent_before = _deltas_sent(await sg.get_delta_sync_stats("upgrade"))
         await sg.update_documents(
             "upgrade",
-            [DocumentUpdateEntry(doc_id, current.revid, body=new_body)],
+            [
+                DocumentUpdateEntry(
+                    doc_id,
+                    current.revid,
+                    body={**current.body, "updated_by": "delta_sync_history_test"},
+                )
+            ],
         )
 
         def validator(pre: DocSnapshot, post: DocSnapshot) -> None:
             assert pre.local.revid is not None and pre.local.cv is None, (
-                f"Local precondition invalid: RevID={pre.local.revid}, "
-                f"HLV={pre.local.cv} (expected revtree-only)"
+                f"Pre local expected revtree-only: revid={pre.local.revid}, hlv={pre.local.cv}"
             )
             assert pre.remote.revid is not None and pre.remote.cv is not None, (
-                f"Remote precondition invalid: RevID={pre.remote.revid}, "
-                f"HLV={pre.remote.cv} (expected revtree + HLV after 4.x mutation)"
-            )
-            assert not pre.remote.cv.endswith("@Revision+Tree+Encoding"), (
-                f"Expected canonical HLV on SGW after 4.x write, got RTE-encoded: "
-                f"{pre.remote.cv}"
+                f"Pre remote expected revtree+HLV: revid={pre.remote.revid}, hlv={pre.remote.cv}"
             )
             assert pre.local.revid < pre.remote.revid, (
-                f"Pre-condition: expected local revid < remote revid, "
-                f"got local={pre.local.revid}, remote={pre.remote.revid}"
+                f"Pre expected local revid < remote revid: "
+                f"local={pre.local.revid}, remote={pre.remote.revid}"
             )
-
             assert post.local.revid is None, (
-                f"Expected post-pull local doc to be HLV-only, "
-                f"got revid={post.local.revid}"
+                f"Post local expected HLV-only, got revid={post.local.revid}"
             )
             assert post.local.cv and post.local.cv == post.remote.cv, (
-                f"Expected post-pull local HLV to match SGW HLV. "
-                f"Local={post.local.cv}, Remote={post.remote.cv}"
+                f"Post HLV mismatch: local={post.local.cv}, remote={post.remote.cv}"
             )
 
         await do_upgrade_replication_test(
@@ -337,16 +223,5 @@ class TestUpgradeDeltaSync(CBLTestClass):
             validator=validator,
         )
 
-        self.mark_test_step(
-            "Confirm delta-sync actually participated in this pull. "
-            "Expected to FAIL today: legacy backup rev for rev 1 isn't seeded "
-            "in the bucket, so SGW falls back to full body. Becomes a PASS "
-            "once the TDK dataset is regenerated with backup revs included."
-        )
-        await _assert_delta_sync_participated(
-            sg,
-            "upgrade",
-            bytes_before,
-            delta_stats_before,
-            new_body_size,
-        )
+        self.mark_test_step("Confirm SGW sent the revision as a delta.")
+        await _assert_delta_sync_participated(sg, "upgrade", deltas_sent_before)

--- a/tests/dev_e2e/test_replication_upgrade.py
+++ b/tests/dev_e2e/test_replication_upgrade.py
@@ -8,7 +8,7 @@ from cbltest.api.replicator_types import (
     ReplicatorType,
     WaitForDocumentEventEntry,
 )
-from cbltest.api.upgrade_test_helpers import (
+from shared.upgrade_test_helpers import (
     DocSnapshot,
     do_upgrade_replication_test,
     setup_upgrade_env,

--- a/tests/dev_e2e/test_replication_upgrade.py
+++ b/tests/dev_e2e/test_replication_upgrade.py
@@ -123,7 +123,7 @@ class TestReplicationUpgrade(CBLTestClass):
             )
 
             assert post.remote.cv is None, (
-                f"Expected remove doc to have no HLV, but got: {post.remote.cv}"
+                f"Expected remote doc to have no HLV, but got: {post.remote.cv}"
             )
 
         await do_upgrade_replication_test(
@@ -181,7 +181,7 @@ class TestReplicationUpgrade(CBLTestClass):
             )
 
             assert post.remote.cv is None, (
-                f"Expected remove doc to have no HLV, but got: {post.remote.cv}"
+                f"Expected remote doc to have no HLV, but got: {post.remote.cv}"
             )
 
         await do_upgrade_replication_test(
@@ -634,7 +634,7 @@ class TestReplicationUpgrade(CBLTestClass):
             )
 
             assert pre.local.cv is None and post.local.cv, (
-                f"Expected local doc to have HLV, bot got: {post.local.cv}"
+                f"Expected local doc to have HLV, but got: {post.local.cv}"
             )
 
         await do_upgrade_replication_test(

--- a/tests/dev_e2e/test_replication_upgrade.py
+++ b/tests/dev_e2e/test_replication_upgrade.py
@@ -1,168 +1,24 @@
-import time
-from collections.abc import Callable
 from pathlib import Path
 
 import pytest
-from cbltest import CBLPyTest, CouchbaseServer
+from cbltest import CBLPyTest
 from cbltest.api.cbltestclass import CBLTestClass
-from cbltest.api.database import Database, GetDocumentResult
-from cbltest.api.database_types import DocumentEntry
-from cbltest.api.error import CblSyncGatewayBadResponseError
-from cbltest.api.replicator import Replicator
 from cbltest.api.replicator_types import (
-    ReplicatorActivityLevel,
-    ReplicatorBasicAuthenticator,
-    ReplicatorCollectionEntry,
     ReplicatorConflictResolver,
     ReplicatorType,
     WaitForDocumentEventEntry,
 )
-from cbltest.api.syncgateway import RemoteDocument
-from cbltest.api.test_functions import compare_local_and_remote
-from cbltest.logging import cbl_info
+from cbltest.api.upgrade_test_helpers import (
+    DocSnapshot,
+    do_upgrade_replication_test,
+    setup_upgrade_env,
+)
 
 
 @pytest.mark.min_test_servers(1)
 @pytest.mark.min_sync_gateways(1)
 @pytest.mark.min_couchbase_servers(1)
 class TestReplicationUpgrade(CBLTestClass):
-    @staticmethod
-    def tools_path() -> Path:
-        return Path(__file__).resolve().parent.parent / ".tools"
-
-    async def setup_env(self, cblpytest: CBLPyTest, dataset_path: Path) -> Database:
-        await self.skip_if_cbl_not(cblpytest.test_servers[0], ">= 4.0.0")
-
-        dataset_ver = cblpytest.test_servers[0].dataset_version
-        self.skip_if_not(
-            dataset_ver == "4.0", f"Requires dataset v4.0 (current: {dataset_ver})."
-        )
-
-        # Delete SG database first to avoid reset error after backup is restored
-        self.mark_test_step("Delete Sync Gateway 'upgrade' database if exists")
-        sg = cblpytest.sync_gateways[0]
-        try:
-            await sg.delete_database("upgrade")
-        except CblSyncGatewayBadResponseError as e:
-            if e.code != 403:
-                raise
-
-        self.mark_test_step("Restore Couchbase Server Bucket using `upgrade` dataset")
-        cbs: CouchbaseServer = cblpytest.couchbase_servers[0]
-        cbs.drop_bucket("upgrade")
-        cbs.restore_bucket("upgrade", self.tools_path(), dataset_path, "upgrade")
-
-        self.mark_test_step("Wait 2s to ensure SG picks up the restored database.")
-        time.sleep(2)
-
-        self.mark_test_step("Reset local database, and load `upgrade` dataset.")
-        dbs = await cblpytest.test_servers[0].create_and_reset_db(
-            ["db1"], dataset="upgrade"
-        )
-        return dbs[0]
-
-    # A simple snapshot class to hold local and remote documents
-    class DocSnapshot:
-        def __init__(self, local: GetDocumentResult, remote: RemoteDocument):
-            self.local = local
-            self.remote = remote
-
-    # (pre_doc, post_doc) -> None
-    DocValidator = Callable[[DocSnapshot, DocSnapshot], None]
-
-    async def do_replication_test(
-        self,
-        cblpytest: CBLPyTest,
-        db: Database,
-        doc_id: str,
-        replicator_type: ReplicatorType,
-        conflict_resolver: ReplicatorConflictResolver | None = None,
-        doc_events: set[WaitForDocumentEventEntry] | None = None,
-        compare_docs: bool | None = True,
-        validator: DocValidator | None = None,
-    ):
-        sg = cblpytest.sync_gateways[0]
-
-        pre_local_doc = await db.get_document(
-            DocumentEntry("_default._default", doc_id)
-        )
-        pre_remote_doc = await sg.get_document("upgrade", doc_id)
-
-        assert pre_local_doc is not None
-        assert pre_remote_doc is not None
-        cbl_info(f"Revision Info before Replication ({replicator_type}):")
-        cbl_info(f"Local : RevID = {pre_local_doc.revid}, HLV = {pre_local_doc.cv}")
-        cbl_info(f"Remote : RevID = {pre_remote_doc.revid}, HLV = {pre_remote_doc.cv}")
-
-        wait_for_doc_events = bool(doc_events)
-
-        conflict_resolver_name = (
-            f"{conflict_resolver.name}" if conflict_resolver else "None"
-        )
-
-        self.mark_test_step(f"""
-            Start a replicator:
-            * endpoint: '/upgrade'
-            * collections : '_default._default'
-            * type: {replicator_type}
-            * document_ids: ['{doc_id}']
-            * continuous: {wait_for_doc_events}
-            * conflict_resolver: {conflict_resolver_name}
-        """)
-        replicator = Replicator(
-            db,
-            cblpytest.sync_gateways[0].replication_url("upgrade"),
-            collections=[
-                ReplicatorCollectionEntry(
-                    names=["_default._default"],
-                    document_ids=[doc_id],
-                    conflict_resolver=conflict_resolver,
-                )
-            ],
-            replicator_type=replicator_type,
-            continuous=wait_for_doc_events,
-            authenticator=ReplicatorBasicAuthenticator("user1", "pass"),
-            pinned_server_cert=cblpytest.sync_gateways[0].tls_cert(),
-            enable_document_listener=wait_for_doc_events,
-        )
-
-        await replicator.start()
-
-        if doc_events:
-            self.mark_test_step("Wait until receiving all document replication events")
-            await replicator.wait_for_all_doc_events(
-                events=doc_events,
-                max_retries=100,
-            )
-        else:
-            self.mark_test_step("Wait until the replicator is stopped.")
-            status = await replicator.wait_for(ReplicatorActivityLevel.STOPPED)
-            assert status.error is None, (
-                f"Error waiting for replicator: ({status.error.domain} / {status.error.code}) {status.error.message}"
-            )
-
-        if compare_docs:
-            self.mark_test_step("Check that the doc is replicated correctly.")
-            await compare_local_and_remote(
-                db, sg, replicator_type, "upgrade", ["_default._default"], [doc_id]
-            )
-
-        local_doc = await db.get_document(DocumentEntry("_default._default", doc_id))
-        remote_doc = await sg.get_document("upgrade", doc_id)
-
-        assert local_doc is not None
-        assert remote_doc is not None
-        cbl_info(f"Revision Info after Replication ({replicator_type}):")
-        cbl_info(f"Local : RevID = {local_doc.revid}, HLV = {local_doc.cv}")
-        cbl_info(f"Remote : RevID = {remote_doc.revid}, HLV = {remote_doc.cv}")
-
-        if validator:
-            self.mark_test_step("Validate revid and HLV of local and remote doc.")
-            validator(
-                self.DocSnapshot(pre_local_doc, pre_remote_doc),
-                self.DocSnapshot(local_doc, remote_doc),
-            )
-
     @pytest.mark.asyncio(loop_scope="session")
     async def test_nonconflict_case_1(
         self, cblpytest: CBLPyTest, dataset_path: Path
@@ -179,11 +35,11 @@ class TestReplicationUpgrade(CBLTestClass):
         | Expected Result  |  2-def, 1-abc |      none     |  2-def, 1-abc | Encoded 2-def |
         +------------------+---------------+---------------+---------------+---------------+
         """
-        db = await self.setup_env(cblpytest, dataset_path)
+        db = await setup_upgrade_env(self, cblpytest, dataset_path)
 
         def validator(
-            pre: TestReplicationUpgrade.DocSnapshot,
-            post: TestReplicationUpgrade.DocSnapshot,
+            pre: DocSnapshot,
+            post: DocSnapshot,
         ):
             # Validate pre-condition:
             assert pre.local.revid is not None and pre.local.cv is None, (
@@ -213,7 +69,8 @@ class TestReplicationUpgrade(CBLTestClass):
                 f"Expected remote doc's HLV to end with '@Revision+Tree+Encoding', but got: {post.remote.cv}"
             )
 
-        await self.do_replication_test(
+        await do_upgrade_replication_test(
+            self,
             cblpytest,
             db,
             doc_id="nonconflict_1",
@@ -237,11 +94,11 @@ class TestReplicationUpgrade(CBLTestClass):
         | Expected Result  |  2-def,1-abc  | Encoded 2-def |     2-def     |      none     |
         +------------------+---------------+---------------+---------------+---------------+
         """
-        db = await self.setup_env(cblpytest, dataset_path)
+        db = await setup_upgrade_env(self, cblpytest, dataset_path)
 
         def validator(
-            pre: TestReplicationUpgrade.DocSnapshot,
-            post: TestReplicationUpgrade.DocSnapshot,
+            pre: DocSnapshot,
+            post: DocSnapshot,
         ):
             # Validate pre-condition:
             assert pre.local.revid is not None and pre.local.cv is None, (
@@ -269,7 +126,8 @@ class TestReplicationUpgrade(CBLTestClass):
                 f"Expected remove doc to have no HLV, but got: {post.remote.cv}"
             )
 
-        await self.do_replication_test(
+        await do_upgrade_replication_test(
+            self,
             cblpytest,
             db,
             doc_id="nonconflict_2",
@@ -294,11 +152,11 @@ class TestReplicationUpgrade(CBLTestClass):
         | Expected Result  |     2-abc     |      none     |     2-abc     |      none     |
         +------------------+---------------+---------------+---------------+---------------+
         """
-        db = await self.setup_env(cblpytest, dataset_path)
+        db = await setup_upgrade_env(self, cblpytest, dataset_path)
 
         def validator(
-            pre: TestReplicationUpgrade.DocSnapshot,
-            post: TestReplicationUpgrade.DocSnapshot,
+            pre: DocSnapshot,
+            post: DocSnapshot,
         ):
             # Validate pre-condition:
             assert pre.local.revid is not None and pre.local.cv is None, (
@@ -326,7 +184,8 @@ class TestReplicationUpgrade(CBLTestClass):
                 f"Expected remove doc to have no HLV, but got: {post.remote.cv}"
             )
 
-        await self.do_replication_test(
+        await do_upgrade_replication_test(
+            self,
             cblpytest,
             db,
             doc_id="nonconflict_3",
@@ -352,11 +211,11 @@ class TestReplicationUpgrade(CBLTestClass):
         | Expected Result  |      none     |  [100@SGW1]   |  3-ghi 2-def  |   [100@SGW1]  |
         +------------------+---------------+---------------+---------------+---------------+
         """
-        db = await self.setup_env(cblpytest, dataset_path)
+        db = await setup_upgrade_env(self, cblpytest, dataset_path)
 
         def validator(
-            pre: TestReplicationUpgrade.DocSnapshot,
-            post: TestReplicationUpgrade.DocSnapshot,
+            pre: DocSnapshot,
+            post: DocSnapshot,
         ):
             # Validate pre-condition:
             assert pre.local.revid is not None and pre.local.cv is None, (
@@ -382,7 +241,8 @@ class TestReplicationUpgrade(CBLTestClass):
                 f"HLV mismatch: Local:  {post.local.cv}, Remote: {post.remote.cv}"
             )
 
-        await self.do_replication_test(
+        await do_upgrade_replication_test(
+            self,
             cblpytest,
             db,
             doc_id="nonconflict_4",
@@ -407,11 +267,11 @@ class TestReplicationUpgrade(CBLTestClass):
         | Expected Result  |      none     |   [100@SGW1]  |  3-ghi 2-def  |   [100@SGW1]  |
         +------------------+---------------+---------------+---------------+---------------+
         """
-        db = await self.setup_env(cblpytest, dataset_path)
+        db = await setup_upgrade_env(self, cblpytest, dataset_path)
 
         def validator(
-            pre: TestReplicationUpgrade.DocSnapshot,
-            post: TestReplicationUpgrade.DocSnapshot,
+            pre: DocSnapshot,
+            post: DocSnapshot,
         ):
             # Validate pre-condition:
             assert pre.local.revid is not None and pre.local.cv is None, (
@@ -437,7 +297,8 @@ class TestReplicationUpgrade(CBLTestClass):
                 f"HLV mismatch: Local:  {post.local.cv}, Remote: {post.remote.cv}"
             )
 
-        await self.do_replication_test(
+        await do_upgrade_replication_test(
+            self,
             cblpytest,
             db,
             doc_id="nonconflict_5",
@@ -463,11 +324,11 @@ class TestReplicationUpgrade(CBLTestClass):
         | Expected Result  |         none           | [100@CBL1]             |     3-def     |   [100@CBL1]  |
         +------------------+------------------------+------------------------+---------------+---------------+
         """
-        db = await self.setup_env(cblpytest, dataset_path)
+        db = await setup_upgrade_env(self, cblpytest, dataset_path)
 
         def validator(
-            pre: TestReplicationUpgrade.DocSnapshot,
-            post: TestReplicationUpgrade.DocSnapshot,
+            pre: DocSnapshot,
+            post: DocSnapshot,
         ):
             # Validate pre-condition:
             assert pre.local.revid is None and pre.local.cv is not None, (
@@ -491,7 +352,8 @@ class TestReplicationUpgrade(CBLTestClass):
                 f"HLV mismatch: Local:  {post.local.cv}, Remote: {post.remote.cv}"
             )
 
-        await self.do_replication_test(
+        await do_upgrade_replication_test(
+            self,
             cblpytest,
             db,
             doc_id="nonconflict_6",
@@ -515,7 +377,7 @@ class TestReplicationUpgrade(CBLTestClass):
         | Expected Result  |     3-abc     |      none     |     3-def     |      none     |
         +------------------+---------------+---------------+---------------+---------------+
         """
-        db = await self.setup_env(cblpytest, dataset_path)
+        db = await setup_upgrade_env(self, cblpytest, dataset_path)
 
         doc_events = {
             WaitForDocumentEventEntry(
@@ -529,8 +391,8 @@ class TestReplicationUpgrade(CBLTestClass):
         }
 
         def validator(
-            pre: TestReplicationUpgrade.DocSnapshot,
-            post: TestReplicationUpgrade.DocSnapshot,
+            pre: DocSnapshot,
+            post: DocSnapshot,
         ):
             # Validate pre-condition:
             assert pre.local.revid is not None and pre.local.cv is None, (
@@ -556,7 +418,8 @@ class TestReplicationUpgrade(CBLTestClass):
                 f"but got {post.remote.cv}"
             )
 
-        await self.do_replication_test(
+        await do_upgrade_replication_test(
+            self,
             cblpytest,
             db,
             doc_id="conflict_1",
@@ -584,11 +447,11 @@ class TestReplicationUpgrade(CBLTestClass):
         | Expected Result  |     3-def     |      none     |     3-def     |      none     |
         +------------------+---------------+---------------+---------------+---------------+
         """
-        db = await self.setup_env(cblpytest, dataset_path)
+        db = await setup_upgrade_env(self, cblpytest, dataset_path)
 
         def pull_validator(
-            pre: TestReplicationUpgrade.DocSnapshot,
-            post: TestReplicationUpgrade.DocSnapshot,
+            pre: DocSnapshot,
+            post: DocSnapshot,
         ):
             # Validate pre-condition:
             assert pre.local.revid is not None and pre.local.cv is None, (
@@ -616,7 +479,8 @@ class TestReplicationUpgrade(CBLTestClass):
                 f"Expected local doc to have no HLV, but got: {post.local.cv}"
             )
 
-        await self.do_replication_test(
+        await do_upgrade_replication_test(
+            self,
             cblpytest,
             db,
             doc_id="conflict_2",
@@ -626,8 +490,8 @@ class TestReplicationUpgrade(CBLTestClass):
         )
 
         def push_validator(
-            pre: TestReplicationUpgrade.DocSnapshot,
-            post: TestReplicationUpgrade.DocSnapshot,
+            pre: DocSnapshot,
+            post: DocSnapshot,
         ):
             assert pre.remote.revid == post.remote.revid, (
                 f"Expected remote doc revID to be unchanged after resolved doc was pushed. "
@@ -638,7 +502,8 @@ class TestReplicationUpgrade(CBLTestClass):
                 f"Expected remote doc to have no HLV after resolved doc was pushed, but got: {post.local.cv}"
             )
 
-        await self.do_replication_test(
+        await do_upgrade_replication_test(
+            self,
             cblpytest,
             db,
             doc_id="conflict_2",
@@ -664,11 +529,11 @@ class TestReplicationUpgrade(CBLTestClass):
         | Expected Result  |      none     |  [100@SGW1]   |     3-def     |  [100@SGW1]   |
         +------------------+---------------+---------------+---------------+---------------+
         """
-        db = await self.setup_env(cblpytest, dataset_path)
+        db = await setup_upgrade_env(self, cblpytest, dataset_path)
 
         def pull_validator(
-            pre: TestReplicationUpgrade.DocSnapshot,
-            post: TestReplicationUpgrade.DocSnapshot,
+            pre: DocSnapshot,
+            post: DocSnapshot,
         ):
             # Validate pre-condition:
             assert pre.local.revid is not None and pre.local.cv is None, (
@@ -692,7 +557,8 @@ class TestReplicationUpgrade(CBLTestClass):
                 f"HLV mismatch: Local:  {post.local.cv}, Remote: {post.remote.cv}"
             )
 
-        await self.do_replication_test(
+        await do_upgrade_replication_test(
+            self,
             cblpytest,
             db,
             doc_id="conflict_3",
@@ -702,8 +568,8 @@ class TestReplicationUpgrade(CBLTestClass):
         )
 
         def push_validator(
-            pre: TestReplicationUpgrade.DocSnapshot,
-            post: TestReplicationUpgrade.DocSnapshot,
+            pre: DocSnapshot,
+            post: DocSnapshot,
         ):
             assert pre.remote.revid == post.remote.revid, (
                 f"Expected remote doc revID to be unchanged after resolved doc was pushed. "
@@ -715,7 +581,8 @@ class TestReplicationUpgrade(CBLTestClass):
                 f"Before: {pre.remote.revid}, After: {post.remote.revid}"
             )
 
-        await self.do_replication_test(
+        await do_upgrade_replication_test(
+            self,
             cblpytest,
             db,
             doc_id="conflict_3",
@@ -742,11 +609,11 @@ class TestReplicationUpgrade(CBLTestClass):
         | Expected Result  |      none     | [100@CBL1, 3abc@RTE] |     4-def     | [100@CBL1, 3abc@RTE] |
         +------------------+---------------+----------------------+---------------+----------------------+
         """
-        db = await self.setup_env(cblpytest, dataset_path)
+        db = await setup_upgrade_env(self, cblpytest, dataset_path)
 
         def pull_validator(
-            pre: TestReplicationUpgrade.DocSnapshot,
-            post: TestReplicationUpgrade.DocSnapshot,
+            pre: DocSnapshot,
+            post: DocSnapshot,
         ):
             # Validate pre-condition:
             assert pre.local.revid is not None and pre.local.cv is None, (
@@ -770,7 +637,8 @@ class TestReplicationUpgrade(CBLTestClass):
                 f"Expected local doc to have HLV, bot got: {post.local.cv}"
             )
 
-        await self.do_replication_test(
+        await do_upgrade_replication_test(
+            self,
             cblpytest,
             db,
             doc_id="conflict_4",
@@ -781,8 +649,8 @@ class TestReplicationUpgrade(CBLTestClass):
         )
 
         def push_validator(
-            pre: TestReplicationUpgrade.DocSnapshot,
-            post: TestReplicationUpgrade.DocSnapshot,
+            pre: DocSnapshot,
+            post: DocSnapshot,
         ):
             assert post.remote.revid != pre.remote.revid, (
                 f"Expected remote doc revID to be updated after resolved doc was pushed. "
@@ -794,7 +662,8 @@ class TestReplicationUpgrade(CBLTestClass):
                 f"Remote: {post.remote.cv}, After: {post.local.cv}"
             )
 
-        await self.do_replication_test(
+        await do_upgrade_replication_test(
+            self,
             cblpytest,
             db,
             doc_id="conflict_4",
@@ -821,11 +690,11 @@ class TestReplicationUpgrade(CBLTestClass):
         | Expected Result  |             | [3def@RTE, 100@SGW1] |    4-def    | [3def@RTE, 100@SGW1] |
         +------------------+-------------+----------------------+-------------+----------------------+
         """
-        db = await self.setup_env(cblpytest, dataset_path)
+        db = await setup_upgrade_env(self, cblpytest, dataset_path)
 
         def pull_validator(
-            pre: TestReplicationUpgrade.DocSnapshot,
-            post: TestReplicationUpgrade.DocSnapshot,
+            pre: DocSnapshot,
+            post: DocSnapshot,
         ):
             # Validate pre-condition:
             assert pre.local.revid is not None and pre.local.cv is None, (
@@ -850,7 +719,8 @@ class TestReplicationUpgrade(CBLTestClass):
                 f"but got local={post.local.cv}, remote={post.remote.cv}"
             )
 
-        await self.do_replication_test(
+        await do_upgrade_replication_test(
+            self,
             cblpytest,
             db,
             doc_id="conflict_5",
@@ -861,8 +731,8 @@ class TestReplicationUpgrade(CBLTestClass):
         )
 
         def push_validator(
-            pre: TestReplicationUpgrade.DocSnapshot,
-            post: TestReplicationUpgrade.DocSnapshot,
+            pre: DocSnapshot,
+            post: DocSnapshot,
         ):
             assert post.remote.revid and pre.remote.revid != post.remote.revid, (
                 f"Expected remote doc revID to be updated after resolved doc was pushed. "
@@ -879,7 +749,8 @@ class TestReplicationUpgrade(CBLTestClass):
                 f"Remote: {post.remote.cv}, After: {post.local.cv}"
             )
 
-        await self.do_replication_test(
+        await do_upgrade_replication_test(
+            self,
             cblpytest,
             db,
             doc_id="conflict_5",
@@ -907,11 +778,11 @@ class TestReplicationUpgrade(CBLTestClass):
         | Expected Result  |              | [100@CBL1, 3abc@RTE] |   4-abc      | [100@CBL1, 3abc@RTE] |
         +------------------+--------------+----------------------+--------------+----------------------+
         """
-        db = await self.setup_env(cblpytest, dataset_path)
+        db = await setup_upgrade_env(self, cblpytest, dataset_path)
 
         def pull_validator(
-            pre: TestReplicationUpgrade.DocSnapshot,
-            post: TestReplicationUpgrade.DocSnapshot,
+            pre: DocSnapshot,
+            post: DocSnapshot,
         ):
             # Validate pre-condition:
             assert pre.local.revid is None and pre.local.cv is not None, (
@@ -932,7 +803,8 @@ class TestReplicationUpgrade(CBLTestClass):
                 f"but got before={pre.local.cv}, after={post.local.cv}"
             )
 
-        await self.do_replication_test(
+        await do_upgrade_replication_test(
+            self,
             cblpytest,
             db,
             doc_id="conflict_6",
@@ -943,8 +815,8 @@ class TestReplicationUpgrade(CBLTestClass):
         )
 
         def push_validator(
-            pre: TestReplicationUpgrade.DocSnapshot,
-            post: TestReplicationUpgrade.DocSnapshot,
+            pre: DocSnapshot,
+            post: DocSnapshot,
         ):
             assert post.remote.revid and post.remote.revid != pre.remote.revid, (
                 f"Expected remote doc revID to be updated after resolved doc was pushed. "
@@ -956,7 +828,8 @@ class TestReplicationUpgrade(CBLTestClass):
                 f"Remote: {post.remote.cv}, After: {post.local.cv}"
             )
 
-        await self.do_replication_test(
+        await do_upgrade_replication_test(
+            self,
             cblpytest,
             db,
             doc_id="conflict_6",
@@ -985,11 +858,11 @@ class TestReplicationUpgrade(CBLTestClass):
         | Expected Result  |             |   3abc@RTE  |    3-abc    |     none    |
         +------------------+-------------+-------------+-------------+-------------+
         """
-        db = await self.setup_env(cblpytest, dataset_path)
+        db = await setup_upgrade_env(self, cblpytest, dataset_path)
 
         def pull_validator(
-            pre: TestReplicationUpgrade.DocSnapshot,
-            post: TestReplicationUpgrade.DocSnapshot,
+            pre: DocSnapshot,
+            post: DocSnapshot,
         ):
             # Validate pre-condition:
             assert pre.local.revid is None and pre.local.cv is not None, (
@@ -1015,7 +888,8 @@ class TestReplicationUpgrade(CBLTestClass):
                 f"but got before={post.local.cv}"
             )
 
-        await self.do_replication_test(
+        await do_upgrade_replication_test(
+            self,
             cblpytest,
             db,
             doc_id="conflict_7",
@@ -1026,8 +900,8 @@ class TestReplicationUpgrade(CBLTestClass):
         )
 
         def push_validator(
-            pre: TestReplicationUpgrade.DocSnapshot,
-            post: TestReplicationUpgrade.DocSnapshot,
+            pre: DocSnapshot,
+            post: DocSnapshot,
         ):
             assert post.remote.revid == pre.remote.revid, (
                 f"Expected remote doc revID to be unchanged after resolved doc was pushed. "
@@ -1039,7 +913,8 @@ class TestReplicationUpgrade(CBLTestClass):
                 f"but got {post.remote.cv}"
             )
 
-        await self.do_replication_test(
+        await do_upgrade_replication_test(
+            self,
             cblpytest,
             db,
             doc_id="conflict_7",

--- a/tests/shared/upgrade_test_helpers.py
+++ b/tests/shared/upgrade_test_helpers.py
@@ -36,7 +36,11 @@ def tools_path() -> Path:
 
 
 async def setup_upgrade_env(
-    test_case: CBLTestClass, cblpytest: CBLPyTest, dataset_path: Path
+    test_case: CBLTestClass,
+    cblpytest: CBLPyTest,
+    dataset_path: Path,
+    *,
+    reset_expired_ttl: bool = False,
 ) -> Database:
     await test_case.skip_if_cbl_not(cblpytest.test_servers[0], ">= 4.0.0")
 
@@ -53,7 +57,15 @@ async def setup_upgrade_env(
     test_case.mark_test_step("Restore Couchbase Server Bucket using `upgrade` dataset")
     cbs: CouchbaseServer = cblpytest.couchbase_servers[0]
     cbs.drop_bucket("upgrade")
-    cbs.restore_bucket("upgrade", tools_path(), dataset_path, "upgrade")
+    # reset_expired_ttl restores the delta-sync old-revision backup bodies
+    # (`_sync:rev:*`) so SGW can delta against a legacy ancestor rev.
+    cbs.restore_bucket(
+        "upgrade",
+        tools_path(),
+        dataset_path,
+        "upgrade",
+        reset_expired_ttl=reset_expired_ttl,
+    )
 
     test_case.mark_test_step("Wait 2s to ensure SG picks up the restored database.")
     await asyncio.sleep(2)

--- a/tests/shared/upgrade_test_helpers.py
+++ b/tests/shared/upgrade_test_helpers.py
@@ -31,8 +31,8 @@ DocValidator: TypeAlias = Callable[[DocSnapshot, DocSnapshot], None]
 
 
 def tools_path() -> Path:
-    # client/src/cbltest/api/upgrade_test_helpers.py -> parents[4] is repo root
-    return Path(__file__).resolve().parents[4] / "tests" / ".tools"
+    # tests/shared/upgrade_test_helpers.py -> parents[1] is tests/
+    return Path(__file__).resolve().parents[1] / ".tools"
 
 
 async def setup_upgrade_env(
@@ -46,6 +46,8 @@ async def setup_upgrade_env(
     )
 
     test_case.mark_test_step("Delete Sync Gateway 'upgrade' database if exists")
+    # delete_database silently swallows 403 internally (config-managed DBs)
+    # and retries 500s; no need to wrap further.
     await cblpytest.sync_gateways[0].delete_database("upgrade")
 
     test_case.mark_test_step("Restore Couchbase Server Bucket using `upgrade` dataset")


### PR DESCRIPTION
[CBG-5388](https://jira.issues.couchbase.com/browse/CBG-5388)

## Summary
- Add a new QE test file [tests/QE/test_replication_upgrade_delta_sync.py](tests/QE/test_replication_upgrade_delta_sync.py) covering delta-sync history behavior on upgrade flows, including:
  - `test_delta_sync_history_pull_post_upgrade_sgw_mutation` — pull of a 4.x SGW mutation (revtree + fresh HLV) into a client holding a revtree-only ancestor. Marked `xfail(strict=True)` to track the open SGW delta-sync history bug where the rev message's `history` field comes back empty.
  - `test_delta_sync_history_pull_pre_upgrade_sgw_two_revs` — pull of a revtree-only rev that exists on both sides, verifying the local side resolves to an RTE-encoded HLV while SGW's HLV remains absent.
- Extract the shared upgrade-test scaffolding out of [tests/dev_e2e/test_replication_upgrade.py](tests/dev_e2e/test_replication_upgrade.py) into a new reusable helper module [client/src/cbltest/api/upgrade_test_helpers.py](client/src/cbltest/api/upgrade_test_helpers.py):
  - `setup_upgrade_env(...)` — version/dataset skip checks, SG `upgrade` DB teardown, CBS bucket restore, local DB reset.
  - `do_upgrade_replication_test(...)` — replicator setup, optional doc-event waiting, pre/post snapshot logging, optional `compare_local_and_remote`, and an injectable `DocValidator`.
  - `DocSnapshot` / `DocValidator` exposed as module-level types.
- Refactor `tests/dev_e2e/test_replication_upgrade.py` to consume the shared helpers — pure de-duplication, no behavior change for the existing `nonconflict_*` cases.

## Motivation
The existing `TestReplicationUpgrade` class duplicated all of its environment-setup and replicator-driver logic inside the test class itself. The new delta-sync history tests need exactly the same scaffolding (4.0 dataset, `upgrade` SG DB, revid/HLV snapshots, custom validators), but with a different SG database config (delta_sync enabled) and an explicit SGW write step before replication. Promoting the helpers to `cbltest.api.upgrade_test_helpers` lets both suites share the harness without copy-paste, and unblocks adding more upgrade-history scenarios.

[CBG-5388]: https://couchbasecloud.atlassian.net/browse/CBG-5388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ