### PR TITLE
Grant Bluetooth runtime permissions for MultipeerReplicator on Android

### DIFF
--- a/environment/aws/topology_setup/test_server_platforms/android_bridge.py
+++ b/environment/aws/topology_setup/test_server_platforms/android_bridge.py
@@ -49,6 +49,16 @@ class AndroidBridge(PlatformBridge):
         "C:\\Program Files (x86)\\Android\\android-sdk\\platform-tools",
     ]
 
+    # Dangerous (runtime) permissions the MultipeerReplicator may need. These are
+    # granted right after install so the test server doesn't need to block waiting
+    # for a system permission dialog during a test run.
+    __runtime_permissions: list[str] = [
+        "android.permission.ACCESS_FINE_LOCATION",  # BLE scanning on API <= 30
+        "android.permission.BLUETOOTH_SCAN",  # API 31+
+        "android.permission.BLUETOOTH_CONNECT",  # API 31+
+        "android.permission.BLUETOOTH_ADVERTISE",  # API 31+
+    ]
+
     def __init__(self, app_path: str, app_id: str, activity: str = "MainActivity"):
         """
         Initialize the AndroidBridge with the application path, application ID, and activity name.
@@ -117,6 +127,39 @@ class AndroidBridge(PlatformBridge):
             check=True,
             capture_output=False,
         )
+        self.__grant_runtime_permissions(location)
+
+    def __grant_runtime_permissions(self, location: str) -> None:
+        """
+        Grant of the runtime permissions for MultipeerReplicator when using
+        Bluetooth, so the test server never blocks on a system permission
+        dialog.
+
+        Args:
+            location (str): The device location (e.g., device serial number).
+        """
+        header(f"Granting runtime permissions to {self.__app_id} on {location}")
+        for permission in self.__runtime_permissions:
+            result = subprocess.run(
+                [
+                    str(self.__adb_location),
+                    "-s",
+                    location,
+                    "shell",
+                    "pm",
+                    "grant",
+                    self.__app_id,
+                    permission,
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            if result.returncode == 0:
+                click.echo(f"  granted {permission}")
+            else:
+                message = (result.stderr or result.stdout).strip()
+                click.echo(f"  skipped {permission} ({message})")
 
     def run(self, location: str) -> None:
         """

--- a/environment/aws/topology_setup/test_server_platforms/android_bridge.py
+++ b/environment/aws/topology_setup/test_server_platforms/android_bridge.py
@@ -57,6 +57,7 @@ class AndroidBridge(PlatformBridge):
         "android.permission.BLUETOOTH_SCAN",  # API 31+
         "android.permission.BLUETOOTH_CONNECT",  # API 31+
         "android.permission.BLUETOOTH_ADVERTISE",  # API 31+
+        "android.permission.NEARBY_WIFI_DEVICES",  # API 31+
     ]
 
     def __init__(self, app_path: str, app_id: str, activity: str = "MainActivity"):

--- a/servers/jak/android/app/src/main/AndroidManifest.xml
+++ b/servers/jak/android/app/src/main/AndroidManifest.xml
@@ -5,6 +5,25 @@
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
 
+    <!-- MultipeerReplicator Bluetooth transport -->
+    <!-- Android 11 (API 30) and lower -->
+    <uses-permission
+        android:name="android.permission.BLUETOOTH"
+        android:maxSdkVersion="30" />
+    <uses-permission
+        android:name="android.permission.BLUETOOTH_ADMIN"
+        android:maxSdkVersion="30" />
+    <uses-permission
+        android:name="android.permission.ACCESS_FINE_LOCATION"
+        android:maxSdkVersion="30" />
+
+    <!-- Android 12+ (API 31+): runtime permissions, requested on demand -->
+    <uses-permission
+        android:name="android.permission.BLUETOOTH_SCAN"
+        android:usesPermissionFlags="neverForLocation" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+
 
     <application
         android:name="com.couchbase.lite.android.mobiletest.TestServerApp"

--- a/servers/jak/android/app/src/main/AndroidManifest.xml
+++ b/servers/jak/android/app/src/main/AndroidManifest.xml
@@ -23,6 +23,7 @@
         android:usesPermissionFlags="neverForLocation" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" />
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+    <uses-permission android:name="android.permission.NEARBY_WIFI_DEVICES" />
 
 
     <application

--- a/servers/jak/android/app/src/main/AndroidManifest.xml
+++ b/servers/jak/android/app/src/main/AndroidManifest.xml
@@ -17,7 +17,7 @@
         android:name="android.permission.ACCESS_FINE_LOCATION"
         android:maxSdkVersion="30" />
 
-    <!-- Android 12+ (API 31+): runtime permissions, requested on demand -->
+    <!-- Android 12+ (API 31+): runtime permissions (pre-grant via adb pm grant for automation) -->
     <uses-permission
         android:name="android.permission.BLUETOOTH_SCAN"
         android:usesPermissionFlags="neverForLocation" />

--- a/servers/jak/android/app/src/main/java/com/couchbase/lite/android/mobiletest/AndroidTestApp.kt
+++ b/servers/jak/android/app/src/main/java/com/couchbase/lite/android/mobiletest/AndroidTestApp.kt
@@ -125,6 +125,8 @@ class AndroidTestApp(private val context: Context) : TestApp("Android") {
     }
 
 
+    fun getContext(): Context = context
+
     fun getMultipeerReplSvc(): MultipeerReplicatorService {
         val mgr = multipeerReplSvc.get()
         if (mgr == null) {

--- a/servers/jak/android/app/src/main/java/com/couchbase/lite/android/mobiletest/endpoints/v1/MultipeerReplicatorManager.java
+++ b/servers/jak/android/app/src/main/java/com/couchbase/lite/android/mobiletest/endpoints/v1/MultipeerReplicatorManager.java
@@ -35,7 +35,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Supplier;
-import java.util.EnumSet
+import java.util.EnumSet;
 
 import com.couchbase.lite.Conflict;
 import com.couchbase.lite.CouchbaseLiteException;

--- a/servers/jak/android/app/src/main/java/com/couchbase/lite/android/mobiletest/services/MultipeerReplicatorService.java
+++ b/servers/jak/android/app/src/main/java/com/couchbase/lite/android/mobiletest/services/MultipeerReplicatorService.java
@@ -33,14 +33,19 @@ import com.couchbase.lite.MultipeerReplicatorConfiguration;
 import com.couchbase.lite.PeerInfo;
 import com.couchbase.lite.PeerReplicatorStatus;
 import com.couchbase.lite.ReplicatorActivityLevel;
+import com.couchbase.lite.android.mobiletest.AndroidTestApp;
+import com.couchbase.lite.mobiletest.TestApp;
 import com.couchbase.lite.mobiletest.TestContext;
 import com.couchbase.lite.mobiletest.errors.CblApiFailure;
 import com.couchbase.lite.mobiletest.errors.ClientError;
 import com.couchbase.lite.mobiletest.errors.ServerError;
 import com.couchbase.lite.mobiletest.services.DatabaseService;
+import com.couchbase.lite.mobiletest.services.Log;
 
 
 public class MultipeerReplicatorService {
+    private static final String TAG = "MP_REPL_SVC";
+
     private final Map<String, Map<PeerInfo.PeerId, PeerReplicatorStatus>> statusMap = new HashMap<>();
     private final Map<String, ListenerToken> listenerTokens = new HashMap<>();
 
@@ -75,6 +80,25 @@ public class MultipeerReplicatorService {
         final MultipeerReplicator repl;
         try { repl = new MultipeerReplicator(config); }
         catch (CouchbaseLiteException e) { throw new CblApiFailure("Failed creating multipeer replicator", e); }
+
+        // Sanity check: the multipeer replicator needs dangerous runtime permissions (e.g. Bluetooth
+        // on API 31+). These are expected to be pre-granted on the device (see AndroidBridge.install,
+        // which runs "adb pm grant" after installing). If any are still missing, fail fast with the
+        // exact commands needed rather than letting the replicator fail later with an opaque error.
+        final AndroidTestApp app = (AndroidTestApp) TestApp.getApp();
+        final Set<String> missingPerms = repl.getMissingPermissions(app.getContext());
+        if (!missingPerms.isEmpty()) {
+            repl.close();
+            final String pkg = app.getContext().getPackageName();
+            final StringBuilder msg = new StringBuilder(
+                "Cannot start the multipeer replicator: the following runtime permissions are not"
+                    + " granted: " + missingPerms + ". Grant them on the device before running, e.g.:");
+            for (String perm : missingPerms) {
+                msg.append("\n  adb shell pm grant ").append(pkg).append(' ').append(perm);
+            }
+            Log.err(TAG, msg.toString());
+            throw new ServerError(msg.toString());
+        }
 
         final String replId = UUID.randomUUID().toString();
         statusMap.put(replId, new HashMap<>());


### PR DESCRIPTION
* Declare permissions required for Bluetooth in AndroidManifest.xml

* AndroidBridge.install: run "adb pm grant" for the dangerous runtime permissions after install so the test server never blocks on a system permission dialog. Noted that this step is only required for MultipeerReplicator testing with bluetooth. When running the test manually on your local device (not via Jenkins pipeline, this step is also required. Here are the sample commands :

  ```
  adb shell pm grant com.couchbase.lite.android.mobiletest android.permission.BLUETOOTH_SCAN
  adb shell pm grant com.couchbase.lite.android.mobiletest android.permission.BLUETOOTH_CONNECT
  adb shell pm grant com.couchbase.lite.android.mobiletest android.permission.BLUETOOTH_ADVERTISE
  adb shell pm grant com.couchbase.lite.android.mobiletest android.permission.ACCESS_FINE_LOCATION
  ```
* Fix missing semicolon on the EnumSet import in MultipeerReplicatorManager