### PR TITLE
Share resolveProgetVersion across QE Jenkinsfiles

### DIFF
--- a/jenkins/pipelines/QE/sgw/Jenkinsfile
+++ b/jenkins/pipelines/QE/sgw/Jenkinsfile
@@ -1,27 +1,3 @@
-def resolveProgetVersion(String product, String version, String label) {
-    if (version.tokenize('.').size() >= 3) {
-        echo "${label} already fully qualified: ${version}"
-        return version
-    }
-    def url = "http://proget.build.couchbase.com:8080/api/latest_release?product=${product}&version=${version}&prerelease=true"
-    echo "Resolving ${label}: ${url}"
-    def resolved
-    if (isUnix()) {
-        resolved = powershell(script: """
-            try { (Invoke-RestMethod '${url}').version }
-            catch { Write-Error "ProGet request failed for ${label}: \$_"; exit 1 }
-        """.stripIndent(), returnStdout: true).trim()
-    } else {
-        resolved = powershell(script: """
-            try { (Invoke-RestMethod '${url}').version }
-            catch { Write-Error "ProGet request failed for ${label}: \$_"; exit 1 }
-        """.stripIndent(), returnStdout: true).trim()
-    }
-    if (!resolved || resolved == 'null') { error "Could not resolve ${label} from '${version}' (url: ${url})" }
-    echo "Resolved ${label}: ${resolved}"
-    return resolved
-}
-
 pipeline {
     agent none
 // This job uses UI defined params and their default values.
@@ -37,8 +13,9 @@ pipeline {
                 script {
                     if (params.CBL_VERSION == '') { error "CBL_VERSION is required" }
                     if (params.SGW_VERSION == '') { error "SGW_VERSION is required" }
-                    env.CBL_VERSION = resolveProgetVersion("couchbase-lite-ios", params.CBL_VERSION, 'CBL_VERSION')
-                    env.SGW_VERSION = resolveProgetVersion('sync-gateway', params.SGW_VERSION, 'SGW_VERSION')
+                    def proget = load 'jenkins/pipelines/shared/resolveProgetVersion.groovy'
+                    env.CBL_VERSION = proget.resolveProgetVersion("couchbase-lite-ios", params.CBL_VERSION, 'CBL_VERSION')
+                    env.SGW_VERSION = proget.resolveProgetVersion('sync-gateway', params.SGW_VERSION, 'SGW_VERSION')
                     currentBuild.displayName = "CBL:${env.CBL_VERSION} SGW:${env.SGW_VERSION} (#${currentBuild.number})"
                 }
             }

--- a/jenkins/pipelines/QE/upg-sgw/Jenkinsfile
+++ b/jenkins/pipelines/QE/upg-sgw/Jenkinsfile
@@ -1,27 +1,3 @@
-def resolveProgetVersion(String product, String version, String label) {
-    if (version.tokenize('.').size() >= 3) {
-        echo "${label} already fully qualified: ${version}"
-        return version
-    }
-    def url = "http://proget.build.couchbase.com:8080/api/latest_release?product=${product}&version=${version}&prerelease=true"
-    echo "Resolving ${label}: ${url}"
-    def resolved
-    if (isUnix()) {
-        resolved = sh(
-            script: "curl -sf '${url}' | python3 -c 'import json,sys; print(json.load(sys.stdin).get(\"version\",\"\"))'",
-            returnStdout: true
-        ).trim()
-    } else {
-        resolved = powershell(script: """
-            try { (Invoke-RestMethod '${url}').version }
-            catch { Write-Error "ProGet request failed for ${label}: \$_"; exit 1 }
-        """.stripIndent(), returnStdout: true).trim()
-    }
-    if (!resolved || resolved == 'null') { error "Could not resolve ${label} from '${version}' (url: ${url})" }
-    echo "Resolved ${label}: ${resolved}"
-    return resolved
-}
-
 pipeline {
     agent none
 // This job uses UI defined params and their default values.
@@ -37,7 +13,8 @@ pipeline {
                 script {
                     if (params.CBL_VERSION == '') { error "CBL_VERSION is required" }
                     if (params.SGW_VERSIONS == '') { error "SGW_VERSIONS are required (atleast one)" }
-                    env.CBL_VERSION = resolveProgetVersion("couchbase-lite-ios", params.CBL_VERSION, 'CBL_VERSION')
+                    def proget = load 'jenkins/pipelines/shared/resolveProgetVersion.groovy'
+                    env.CBL_VERSION = proget.resolveProgetVersion("couchbase-lite-ios", params.CBL_VERSION, 'CBL_VERSION')
                     currentBuild.displayName = "CBL:${env.CBL_VERSION} SGW:${params.SGW_VERSIONS} (#${currentBuild.number})"
                 }
             }

--- a/jenkins/pipelines/QE/upg-sgw/Jenkinsfile_rolling
+++ b/jenkins/pipelines/QE/upg-sgw/Jenkinsfile_rolling
@@ -1,27 +1,3 @@
-def resolveProgetVersion(String product, String version, String label) {
-    if (version.tokenize('.').size() >= 3) {
-        echo "${label} already fully qualified: ${version}"
-        return version
-    }
-    def url = "http://proget.build.couchbase.com:8080/api/latest_release?product=${product}&version=${version}&prerelease=true"
-    echo "Resolving ${label}: ${url}"
-    def resolved
-    if (isUnix()) {
-        resolved = sh(
-            script: "curl -sf '${url}' | python3 -c 'import json,sys; print(json.load(sys.stdin).get(\"version\",\"\"))'",
-            returnStdout: true
-        ).trim()
-    } else {
-        resolved = powershell(script: """
-            try { (Invoke-RestMethod '${url}').version }
-            catch { Write-Error "ProGet request failed for ${label}: \$_"; exit 1 }
-        """.stripIndent(), returnStdout: true).trim()
-    }
-    if (!resolved || resolved == 'null') { error "Could not resolve ${label} from '${version}' (url: ${url})" }
-    echo "Resolved ${label}: ${resolved}"
-    return resolved
-}
-
 pipeline {
     agent none
 // This job uses UI defined params and their default values.
@@ -37,7 +13,8 @@ pipeline {
                 script {
                     if (params.CBL_VERSION == '') { error "CBL_VERSION is required" }
                     if (params.SGW_VERSIONS == '') { error "SGW_VERSIONS are required (atleast one)" }
-                    env.CBL_VERSION = resolveProgetVersion("couchbase-lite-ios", params.CBL_VERSION, 'CBL_VERSION')
+                    def proget = load 'jenkins/pipelines/shared/resolveProgetVersion.groovy'
+                    env.CBL_VERSION = proget.resolveProgetVersion("couchbase-lite-ios", params.CBL_VERSION, 'CBL_VERSION')
                     currentBuild.displayName = "CBL:${env.CBL_VERSION} SGW:${params.SGW_VERSIONS} (#${currentBuild.number})"
                 }
             }

--- a/jenkins/pipelines/shared/resolveProgetVersion.groovy
+++ b/jenkins/pipelines/shared/resolveProgetVersion.groovy
@@ -8,6 +8,9 @@
 //     def proget = load 'jenkins/pipelines/shared/resolveProgetVersion.groovy'
 //     env.CBL_VERSION = proget.resolveProgetVersion('couchbase-lite-c', params.CBL_VERSION, 'CBL_VERSION')
 def resolveProgetVersion(String product, String version, String label) {
+    version = version?.trim()
+    if (!version) { error "${label} is required" }
+
     if (version.tokenize('.').size() >= 3) {
         echo "${label} already fully qualified: ${version}"
         return version

--- a/jenkins/pipelines/shared/resolveProgetVersion.groovy
+++ b/jenkins/pipelines/shared/resolveProgetVersion.groovy
@@ -1,0 +1,34 @@
+// Shared helper to resolve a partial product version (e.g. "4") to a concrete
+// published version via ProGet (including prereleases when available). A fully-qualified
+// version (>= 3 dot-separated components, e.g. "4.1.0" or "4.1.0-18") is returned unchanged.
+//
+// Load it from a Jenkinsfile inside a node/agent context (so sh/powershell are
+// available), then call the method on the returned object:
+//
+//     def proget = load 'jenkins/pipelines/shared/resolveProgetVersion.groovy'
+//     env.CBL_VERSION = proget.resolveProgetVersion('couchbase-lite-c', params.CBL_VERSION, 'CBL_VERSION')
+def resolveProgetVersion(String product, String version, String label) {
+    if (version.tokenize('.').size() >= 3) {
+        echo "${label} already fully qualified: ${version}"
+        return version
+    }
+    def url = "http://proget.build.couchbase.com:8080/api/latest_release?product=${java.net.URLEncoder.encode(product, 'UTF-8')}&version=${java.net.URLEncoder.encode(version, 'UTF-8')}&prerelease=true"
+    echo "Resolving ${label}: ${url}"
+    def resolved
+    if (isUnix()) {
+        resolved = sh(
+            script: "curl -sf '${url}' | python3 -c 'import json,sys; print(json.load(sys.stdin).get(\"version\",\"\"))'",
+            returnStdout: true
+        ).trim()
+    } else {
+        resolved = powershell(script: """
+            try { (Invoke-RestMethod '${url}').version }
+            catch { Write-Error "ProGet request failed for ${label}: ${'$'}_"; exit 1 }
+        """.stripIndent(), returnStdout: true).trim()
+    }
+    if (!resolved || resolved == 'null') { error "Could not resolve ${label} from '${version}' (url: ${url})" }
+    echo "Resolved ${label}: ${resolved}"
+    return resolved
+}
+
+return this


### PR DESCRIPTION
[CBG-5526](https://jira.issues.couchbase.com/browse/CBG-5526)

Pulls the copy-pasted resolveProgetVersion helper into one shared resolveProgetVersion.groovy and loads it from the QE/sgw, upg-sgw, and upg-sgw rolling Jenkinsfiles instead of each keeping its own copy. That also fixes the QE/sgw copy, which ran PowerShell on both branches and broke on the Mac agents whenever it got a partial version like 4.

### Notes
Left dev_e2e/sgw out since that pipeline isn't shipping, hence this PR also follows a split-PRs into smaller components and leaving the rest from #425 
That will be closed once all the sub-component PRs are up


[CBG-5526]: https://couchbasecloud.atlassian.net/browse/CBG-5526?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ