### PR TITLE
Added options to run only specific platforms and skip prebuild for QE pipelines

### DIFF
--- a/jenkins/pipelines/QE/android/Jenkinsfile
+++ b/jenkins/pipelines/QE/android/Jenkinsfile
@@ -4,6 +4,7 @@ pipeline {
         string(name: 'CBL_VERSION', defaultValue: '3.3.0', description: 'Couchbase Lite Version (build number will be fetched if not provided)')
         string(name: 'SGW_VERSION', defaultValue: '3.3.0', description: "The version of Sync Gateway to download")
         string(name: 'TS_DATASET_VERSION', defaultValue: '4.0', description: 'The version of the dataset to use on the test servers')
+        booleanParam(name: 'RUN_PREBUILD', defaultValue: true, description: 'Prebuild the test server. Uncheck to skip prebuild entirely and reuse existing artifacts.')
     }
     stages {
         stage('Init') {
@@ -17,6 +18,7 @@ pipeline {
             }
         }
         stage('Prebuild Servers') {
+            when { expression { params.RUN_PREBUILD } }
             steps {
                 build job: 'prebuild-test-server',
                 parameters: [

--- a/jenkins/pipelines/QE/android/Jenkinsfile
+++ b/jenkins/pipelines/QE/android/Jenkinsfile
@@ -18,7 +18,7 @@ pipeline {
             }
         }
         stage('Prebuild Servers') {
-            when { expression { params.RUN_PREBUILD } }
+            when { beforeAgent true; expression { params.RUN_PREBUILD } }
             steps {
                 build job: 'prebuild-test-server',
                 parameters: [

--- a/jenkins/pipelines/QE/c/Jenkinsfile
+++ b/jenkins/pipelines/QE/c/Jenkinsfile
@@ -26,7 +26,7 @@ pipeline {
             }
         }
         stage('Prebuild Servers') {
-            when { expression { params.RUN_PREBUILD } }
+            when { beforeAgent true; expression { params.RUN_PREBUILD } }
             steps {
                 script {
                     def platforms = []
@@ -59,7 +59,7 @@ pipeline {
         stage('Run Tests') {
             parallel {
                 stage('macOS') {
-                    when { expression { params.RUN_MACOS } }
+                    when { beforeAgent true; expression { params.RUN_MACOS } }
                     agent { label 'mac-mini-new' }
                     environment {
                         PATH = "/opt/homebrew/opt/python@3.10/bin:/opt/homebrew/bin:/usr/local/bin:${env.PATH}"
@@ -84,7 +84,7 @@ pipeline {
                     }
                 }
                 stage('iOS') {
-                    when { expression { params.RUN_IOS } }
+                    when { beforeAgent true; expression { params.RUN_IOS } }
                     agent { label 'qe-mac-india' }
                     options {
                         lock('00008140-0006458A0C22801C')
@@ -116,7 +116,7 @@ pipeline {
                     }
                 }
                 stage('Android') {
-                    when { expression { params.RUN_ANDROID } }
+                    when { beforeAgent true; expression { params.RUN_ANDROID } }
                     agent { label 'qe-mac-india' }
                     options {
                         lock('56141JEBF18456')
@@ -148,7 +148,7 @@ pipeline {
                     }
                 }
                 stage('Linux') {
-                    when { expression { params.RUN_LINUX } }
+                    when { beforeAgent true; expression { params.RUN_LINUX } }
                     agent { label 'linux-c' }
                     environment {
                         TS_ARTIFACTS_DIR = 'c_linux'
@@ -172,7 +172,7 @@ pipeline {
                     }
                 }
                 stage('Windows') {
-                    when { expression { params.RUN_WINDOWS } }
+                    when { beforeAgent true; expression { params.RUN_WINDOWS } }
                     agent { label 'net-windows' }
                     environment {
                         TS_ARTIFACTS_DIR = 'c_windows'

--- a/jenkins/pipelines/QE/c/Jenkinsfile
+++ b/jenkins/pipelines/QE/c/Jenkinsfile
@@ -4,6 +4,12 @@ pipeline {
         string(name: 'CBL_VERSION', defaultValue: '3.3.0', description: 'Couchbase Lite Version (build number will be fetched if not provided)')
         string(name: 'SGW_VERSION', defaultValue: '3.3.0', description: 'The version of Sync Gateway to download')
         string(name: 'TS_DATASET_VERSION', defaultValue: '4.0', description: 'The version of the dataset to use on the test servers')
+        booleanParam(name: 'RUN_PREBUILD', defaultValue: true, description: 'Prebuild test servers (only for the checked platforms). Uncheck to skip prebuild entirely and reuse existing artifacts.')
+        booleanParam(name: 'RUN_MACOS',   defaultValue: true, description: 'Run macOS tests')
+        booleanParam(name: 'RUN_IOS',     defaultValue: true, description: 'Run iOS tests')
+        booleanParam(name: 'RUN_ANDROID', defaultValue: true, description: 'Run Android tests')
+        booleanParam(name: 'RUN_LINUX',   defaultValue: true, description: 'Run Linux tests')
+        booleanParam(name: 'RUN_WINDOWS', defaultValue: true, description: 'Run Windows tests')
     }
     options {
         timeout(time: 150, unit: 'MINUTES')
@@ -20,31 +26,40 @@ pipeline {
             }
         }
         stage('Prebuild Servers') {
+            when { expression { params.RUN_PREBUILD } }
             steps {
                 script {
-                    def platforms = [
-                        'c_macos', 'c_ios', 'c_android', 'c_windows', 'c_linux_x86_64'
-                    ]
-                    def parallelBuilds = [:]
-                    for(p in platforms) {
-                        def platform = p
-                        parallelBuilds[platform] = {
-                            build job: 'prebuild-test-server',
-                            parameters: [
-                                string(name: 'TS_PLATFORM', value: platform),
-                                string(name: 'CBL_VERSION', value: params.CBL_VERSION),
-                            ],
-                            wait: true,
-                            propagate: true
+                    def platforms = []
+                    if (params.RUN_MACOS)   { platforms << 'c_macos' }
+                    if (params.RUN_IOS)     { platforms << 'c_ios' }
+                    if (params.RUN_ANDROID) { platforms << 'c_android' }
+                    if (params.RUN_WINDOWS) { platforms << 'c_windows' }
+                    if (params.RUN_LINUX)   { platforms << 'c_linux_x86_64' }
+                    if (platforms.isEmpty()) {
+                        echo "No platforms selected — nothing to prebuild"
+                    } else {
+                        def parallelBuilds = [:]
+                        for(p in platforms) {
+                            def platform = p
+                            parallelBuilds[platform] = {
+                                build job: 'prebuild-test-server',
+                                parameters: [
+                                    string(name: 'TS_PLATFORM', value: platform),
+                                    string(name: 'CBL_VERSION', value: params.CBL_VERSION),
+                                ],
+                                wait: true,
+                                propagate: true
+                            }
                         }
+                        parallel parallelBuilds
                     }
-                    parallel parallelBuilds
                 }
             }
         }
         stage('Run Tests') {
             parallel {
                 stage('macOS') {
+                    when { expression { params.RUN_MACOS } }
                     agent { label 'mac-mini-new' }
                     environment {
                         PATH = "/opt/homebrew/opt/python@3.10/bin:/opt/homebrew/bin:/usr/local/bin:${env.PATH}"
@@ -69,6 +84,7 @@ pipeline {
                     }
                 }
                 stage('iOS') {
+                    when { expression { params.RUN_IOS } }
                     agent { label 'qe-mac-india' }
                     options {
                         lock('00008140-0006458A0C22801C')
@@ -100,6 +116,7 @@ pipeline {
                     }
                 }
                 stage('Android') {
+                    when { expression { params.RUN_ANDROID } }
                     agent { label 'qe-mac-india' }
                     options {
                         lock('56141JEBF18456')
@@ -131,6 +148,7 @@ pipeline {
                     }
                 }
                 stage('Linux') {
+                    when { expression { params.RUN_LINUX } }
                     agent { label 'linux-c' }
                     environment {
                         TS_ARTIFACTS_DIR = 'c_linux'
@@ -154,6 +172,7 @@ pipeline {
                     }
                 }
                 stage('Windows') {
+                    when { expression { params.RUN_WINDOWS } }
                     agent { label 'net-windows' }
                     environment {
                         TS_ARTIFACTS_DIR = 'c_windows'

--- a/jenkins/pipelines/QE/dotnet/Jenkinsfile
+++ b/jenkins/pipelines/QE/dotnet/Jenkinsfile
@@ -4,6 +4,11 @@ pipeline {
         string(name: 'CBL_VERSION', defaultValue: '3.3.0', description: 'Couchbase Lite Version (build number will be fetched if not provided)')
         string(name: 'SGW_VERSION', defaultValue: '3.2.3', description: "The version of Sync Gateway to download")
         string(name: 'TS_DATASET_VERSION', defaultValue: '4.0', description: 'The version of the dataset to use on the test servers')
+        booleanParam(name: 'RUN_PREBUILD', defaultValue: true, description: 'Prebuild test servers (only for the checked platforms). Uncheck to skip prebuild entirely and reuse existing artifacts.')
+        booleanParam(name: 'RUN_WINDOWS', defaultValue: true, description: 'Run Windows tests')
+        booleanParam(name: 'RUN_MACOS',   defaultValue: true, description: 'Run macOS tests')
+        booleanParam(name: 'RUN_IOS',     defaultValue: true, description: 'Run iOS tests')
+        booleanParam(name: 'RUN_ANDROID', defaultValue: true, description: 'Run Android tests')
     }
     options {
         timeout(time: 150, unit: 'MINUTES')
@@ -20,31 +25,39 @@ pipeline {
             }
         }
         stage('Prebuild Servers') {
+            when { expression { params.RUN_PREBUILD } }
             steps {
                 script {
-                    def platforms = [
-                        'dotnet_windows', 'dotnet_ios', 'dotnet_android', 'dotnet_macos'
-                    ]
-                    def parallelBuilds = [:]
-                    for(p in platforms) {
-                        def platform = p
-                        parallelBuilds[platform] = {
-                            build job: 'prebuild-test-server',
-                            parameters: [
-                                string(name: 'TS_PLATFORM', value: platform),
-                                string(name: 'CBL_VERSION', value: params.CBL_VERSION),
-                            ],
-                            wait: true,
-                            propagate: true
+                    def platforms = []
+                    if (params.RUN_WINDOWS) { platforms << 'dotnet_windows' }
+                    if (params.RUN_IOS)     { platforms << 'dotnet_ios' }
+                    if (params.RUN_ANDROID) { platforms << 'dotnet_android' }
+                    if (params.RUN_MACOS)   { platforms << 'dotnet_macos' }
+                    if (platforms.isEmpty()) {
+                        echo "No platforms selected — nothing to prebuild"
+                    } else {
+                        def parallelBuilds = [:]
+                        for(p in platforms) {
+                            def platform = p
+                            parallelBuilds[platform] = {
+                                build job: 'prebuild-test-server',
+                                parameters: [
+                                    string(name: 'TS_PLATFORM', value: platform),
+                                    string(name: 'CBL_VERSION', value: params.CBL_VERSION),
+                                ],
+                                wait: true,
+                                propagate: true
+                            }
                         }
+                        parallel parallelBuilds
                     }
-                    parallel parallelBuilds
                 }
             }
         }
         stage('Run Tests') {
             parallel {
                 stage('Windows') {
+                    when { expression { params.RUN_WINDOWS } }
                     agent { label 'net-windows' }
                     environment {
                         TS_ARTIFACTS_DIR = 'dotnet_windows'
@@ -68,6 +81,7 @@ pipeline {
                     }
                 }
                 stage('macOS') {
+                    when { expression { params.RUN_MACOS } }
                     agent { label 'qe-mac-india' }
                     environment {
                         KEYCHAIN_PASSWORD = credentials('mobile-qe-india')
@@ -95,6 +109,7 @@ pipeline {
                     }
                 }
                 stage('iOS') {
+                    when { expression { params.RUN_IOS } }
                     agent { label 'qe-mac-india' }
                     options {
                         lock('00008110-000E544201D1401E')
@@ -126,6 +141,7 @@ pipeline {
                     }
                 }
                 stage('Android') {
+                    when { expression { params.RUN_ANDROID } }
                     agent { label 'qe-mac-india' }
                     options {
                         lock('45291VDJH01660')

--- a/jenkins/pipelines/QE/dotnet/Jenkinsfile
+++ b/jenkins/pipelines/QE/dotnet/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
             }
         }
         stage('Prebuild Servers') {
-            when { expression { params.RUN_PREBUILD } }
+            when { beforeAgent true; expression { params.RUN_PREBUILD } }
             steps {
                 script {
                     def platforms = []
@@ -57,7 +57,7 @@ pipeline {
         stage('Run Tests') {
             parallel {
                 stage('Windows') {
-                    when { expression { params.RUN_WINDOWS } }
+                    when { beforeAgent true; expression { params.RUN_WINDOWS } }
                     agent { label 'net-windows' }
                     environment {
                         TS_ARTIFACTS_DIR = 'dotnet_windows'
@@ -81,7 +81,7 @@ pipeline {
                     }
                 }
                 stage('macOS') {
-                    when { expression { params.RUN_MACOS } }
+                    when { beforeAgent true; expression { params.RUN_MACOS } }
                     agent { label 'qe-mac-india' }
                     environment {
                         KEYCHAIN_PASSWORD = credentials('mobile-qe-india')
@@ -109,7 +109,7 @@ pipeline {
                     }
                 }
                 stage('iOS') {
-                    when { expression { params.RUN_IOS } }
+                    when { beforeAgent true; expression { params.RUN_IOS } }
                     agent { label 'qe-mac-india' }
                     options {
                         lock('00008110-000E544201D1401E')
@@ -141,7 +141,7 @@ pipeline {
                     }
                 }
                 stage('Android') {
-                    when { expression { params.RUN_ANDROID } }
+                    when { beforeAgent true; expression { params.RUN_ANDROID } }
                     agent { label 'qe-mac-india' }
                     options {
                         lock('45291VDJH01660')

--- a/jenkins/pipelines/QE/ios/Jenkinsfile
+++ b/jenkins/pipelines/QE/ios/Jenkinsfile
@@ -4,6 +4,7 @@ pipeline {
         string(name: 'CBL_VERSION', defaultValue: '3.3.0', description: 'Couchbase Lite Version (build number will be fetched if not provided)')
         string(name: 'SGW_VERSION', defaultValue: '3.3.0', description: "The version of Sync Gateway to download")
         string(name: 'TS_DATASET_VERSION', defaultValue: '4.0', description: 'The version of the dataset to use on the test servers')
+        booleanParam(name: 'RUN_PREBUILD', defaultValue: true, description: 'Prebuild the test server. Uncheck to skip prebuild entirely and reuse existing artifacts.')
     }
     stages {
         stage('Init') {
@@ -17,6 +18,7 @@ pipeline {
             }
         }
         stage('Prebuild Servers') {
+            when { expression { params.RUN_PREBUILD } }
             agent { label 'mob-e2e-mac-01' }
             steps {
                 build job: 'prebuild-test-server',

--- a/jenkins/pipelines/QE/ios/Jenkinsfile
+++ b/jenkins/pipelines/QE/ios/Jenkinsfile
@@ -18,7 +18,7 @@ pipeline {
             }
         }
         stage('Prebuild Servers') {
-            when { expression { params.RUN_PREBUILD } }
+            when { beforeAgent true; expression { params.RUN_PREBUILD } }
             agent { label 'mob-e2e-mac-01' }
             steps {
                 build job: 'prebuild-test-server',

--- a/jenkins/pipelines/QE/java/Jenkinsfile
+++ b/jenkins/pipelines/QE/java/Jenkinsfile
@@ -26,7 +26,7 @@ pipeline {
         }
 
         stage('Prebuild Servers') {
-            when { expression { params.RUN_PREBUILD } }
+            when { beforeAgent true; expression { params.RUN_PREBUILD } }
             steps {
                 build job: 'prebuild-test-server',
                 parameters: [
@@ -40,7 +40,7 @@ pipeline {
         stage('Run Tests') {
             parallel {
                 stage('macOS Desktop') {
-                    when { expression { params.RUN_MACOS } }
+                    when { beforeAgent true; expression { params.RUN_MACOS } }
                     agent { label 'mac-mini-new' }
                     options {
                         lock('mac-mini-new')
@@ -70,7 +70,7 @@ pipeline {
                     }
                 }
                 stage('Windows Desktop') {
-                    when { expression { params.RUN_WINDOWS } }
+                    when { beforeAgent true; expression { params.RUN_WINDOWS } }
                     agent { label 'net-windows' }
                     options {
                         lock('net-windows')
@@ -110,7 +110,7 @@ pipeline {
                     }
                 }
                 stage('Linux Desktop') {
-                    when { expression { params.RUN_LINUX } }
+                    when { beforeAgent true; expression { params.RUN_LINUX } }
                     agent { label 'linux-java' }
                     options {
                         lock('linux-java')

--- a/jenkins/pipelines/QE/java/Jenkinsfile
+++ b/jenkins/pipelines/QE/java/Jenkinsfile
@@ -4,6 +4,10 @@ pipeline {
         string(name: 'CBL_VERSION', defaultValue: '3.3.0', description: 'Couchbase Lite Version (build number will be fetched if not provided)')
         string(name: 'SGW_VERSION', defaultValue: '3.3.0', description: "The version of Sync Gateway to download")
         string(name: 'TS_DATASET_VERSION', defaultValue: '4.0', description: 'The version of the dataset to use on the test servers')
+        booleanParam(name: 'RUN_PREBUILD', defaultValue: true, description: 'Prebuild the jak_desktop test server. Uncheck to skip prebuild entirely and reuse existing artifacts.')
+        booleanParam(name: 'RUN_MACOS',   defaultValue: true, description: 'Run macOS Desktop tests')
+        booleanParam(name: 'RUN_WINDOWS', defaultValue: true, description: 'Run Windows Desktop tests')
+        booleanParam(name: 'RUN_LINUX',   defaultValue: true, description: 'Run Linux Desktop tests')
     }
     options {
         timeout(time: 150, unit: 'MINUTES')
@@ -22,6 +26,7 @@ pipeline {
         }
 
         stage('Prebuild Servers') {
+            when { expression { params.RUN_PREBUILD } }
             steps {
                 build job: 'prebuild-test-server',
                 parameters: [
@@ -35,6 +40,7 @@ pipeline {
         stage('Run Tests') {
             parallel {
                 stage('macOS Desktop') {
+                    when { expression { params.RUN_MACOS } }
                     agent { label 'mac-mini-new' }
                     options {
                         lock('mac-mini-new')
@@ -64,6 +70,7 @@ pipeline {
                     }
                 }
                 stage('Windows Desktop') {
+                    when { expression { params.RUN_WINDOWS } }
                     agent { label 'net-windows' }
                     options {
                         lock('net-windows')
@@ -103,6 +110,7 @@ pipeline {
                     }
                 }
                 stage('Linux Desktop') {
+                    when { expression { params.RUN_LINUX } }
                     agent { label 'linux-java' }
                     options {
                         lock('linux-java')


### PR DESCRIPTION
This PR includes changes for running the tests for specific CBL builds and option to skip prebuild job.

**Features added:**
- Per-platform checkboxes on the multi-platform QE Jenkinsfiles (dotnet, c, java) so only the selected platforms run tests.
- A `RUN_PREBUILD` checkbox on all five QE pipelines (dotnet, c, java, ios, android) - unchecked skips prebuild and reuses existing artifacts.
- Guarded each stage with `when { beforeAgent true; ... }` so skipped platforms don't wait for executors.

Verified against a duplicated job pointed at this branch.