### PR TITLE
Add wait_for_db_offline and use it in db_online_offline tests

### DIFF
--- a/client/src/cbltest/api/syncgateway.py
+++ b/client/src/cbltest/api/syncgateway.py
@@ -2110,7 +2110,7 @@ class SyncGateway(_SyncGatewayBase):
             if status is None or status.state != "Online":
                 return
             await asyncio.sleep(retry_delay)
-        total_seconds = max_retries * request_timeout + (max_retries - 1) * retry_delay
+        total_seconds = max_retries * request_timeout + max(0, max_retries - 1) * retry_delay
         raise TimeoutError(
             f"Database {db_name} did not go offline within {total_seconds} seconds"
         )

--- a/client/src/cbltest/api/syncgateway.py
+++ b/client/src/cbltest/api/syncgateway.py
@@ -2108,7 +2108,7 @@ class SyncGateway(_SyncGatewayBase):
                     self.get_database_status(db_name), request_timeout
                 )
                 consecutive_failures = 0
-            except (asyncio.TimeoutError, ClientConnectorError):
+            except (asyncio.TimeoutError, ClientError):
                 consecutive_failures += 1
                 if consecutive_failures >= 2:
                     return

--- a/client/src/cbltest/api/syncgateway.py
+++ b/client/src/cbltest/api/syncgateway.py
@@ -2066,9 +2066,9 @@ class SyncGateway(_SyncGatewayBase):
         """
         status = await self.get_database_status(db_name)
         assert status is not None, f"Database {db_name} is not up yet"
-
-        # Wait for the node to settle down after coming online
-        await asyncio.sleep(settle_online)
+        assert status.state == "Online", (
+            f"Database {db_name} is not Online yet (state={status.state})"
+        )
 
     @tenacity.retry(
         # Same polling cadence as wait_for_db_up; give up after 60s.

--- a/client/src/cbltest/api/syncgateway.py
+++ b/client/src/cbltest/api/syncgateway.py
@@ -2071,6 +2071,7 @@ class SyncGateway(_SyncGatewayBase):
         )
         if settle_online > 0:
             await asyncio.sleep(settle_online)
+
     @tenacity.retry(
         # Same polling cadence as wait_for_db_up; give up after 60s.
         wait=tenacity.wait_fixed(3),

--- a/client/src/cbltest/api/syncgateway.py
+++ b/client/src/cbltest/api/syncgateway.py
@@ -2079,6 +2079,41 @@ class SyncGateway(_SyncGatewayBase):
         # Wait for the node to settle down after coming online
         await asyncio.sleep(settle_online)
 
+    async def wait_for_db_offline(
+        self,
+        db_name: str,
+        max_retries: int = 20,
+        retry_delay: int = 3,
+        request_timeout: int = 15,
+    ) -> None:
+        """
+        Wait until the SGW database is no longer online.
+
+        A database whose Couchbase Server bucket has been deleted may leave the
+        admin ``/{db}/`` endpoint hanging rather than promptly reporting a
+        non-Online state. Each poll is therefore bounded by ``request_timeout``,
+        and a timeout (or connection error) is treated as the database being
+        offline/unavailable -- which is the condition this waits for.
+
+        :param db_name: Database name to poll.
+        :param max_retries: Number of polls before timing out.
+        :param retry_delay: Seconds between polls.
+        :param request_timeout: Per-poll timeout, in seconds, for the status request.
+        """
+        for _ in range(max_retries):
+            try:
+                status = await asyncio.wait_for(
+                    self.get_database_status(db_name), request_timeout
+                )
+            except (asyncio.TimeoutError, ClientConnectorError):
+                return
+            if status is None or status.state != "Online":
+                return
+            await asyncio.sleep(retry_delay)
+        raise TimeoutError(
+            f"Database {db_name} did not go offline within {max_retries * retry_delay} seconds"
+        )
+
     @tenacity.retry(
         # Import count flips on SGW's polling cadence, not sub-second, so poll at
         # a steady interval; give up after 60s.

--- a/client/src/cbltest/api/syncgateway.py
+++ b/client/src/cbltest/api/syncgateway.py
@@ -2101,13 +2101,19 @@ class SyncGateway(_SyncGatewayBase):
         :param request_timeout: Per-poll timeout, in seconds, for the status request.
         """
         start = asyncio.get_running_loop().time()
+        consecutive_failures = 0
         for _ in range(max_retries):
             try:
                 status = await asyncio.wait_for(
                     self.get_database_status(db_name), request_timeout
                 )
+                consecutive_failures = 0
             except (asyncio.TimeoutError, ClientConnectorError):
-                return
+                consecutive_failures += 1
+                if consecutive_failures >= 2:
+                    return
+                await asyncio.sleep(retry_delay)
+                continue
             if status is None or status.state != "Online":
                 return
             await asyncio.sleep(retry_delay)

--- a/client/src/cbltest/api/syncgateway.py
+++ b/client/src/cbltest/api/syncgateway.py
@@ -2110,8 +2110,9 @@ class SyncGateway(_SyncGatewayBase):
             if status is None or status.state != "Online":
                 return
             await asyncio.sleep(retry_delay)
+        total_seconds = max_retries * request_timeout + (max_retries - 1) * retry_delay
         raise TimeoutError(
-            f"Database {db_name} did not go offline within {max_retries * retry_delay} seconds"
+            f"Database {db_name} did not go offline within {total_seconds} seconds"
         )
 
     @tenacity.retry(

--- a/client/src/cbltest/api/syncgateway.py
+++ b/client/src/cbltest/api/syncgateway.py
@@ -2100,6 +2100,11 @@ class SyncGateway(_SyncGatewayBase):
         except (asyncio.TimeoutError, ClientError):
             # Hung or unreachable admin endpoint -- effectively offline.
             return
+        except CblSyncGatewayBadResponseError as e:
+            if e.code == 503:
+                # DB endpoint can return 503 when its backing bucket is gone.
+                return
+            raise
         assert status is None or status.state != "Online", (
             f"Database {db_name} is still Online"
         )

--- a/client/src/cbltest/api/syncgateway.py
+++ b/client/src/cbltest/api/syncgateway.py
@@ -2100,6 +2100,7 @@ class SyncGateway(_SyncGatewayBase):
         :param retry_delay: Seconds between polls.
         :param request_timeout: Per-poll timeout, in seconds, for the status request.
         """
+        start = asyncio.get_running_loop().time()
         for _ in range(max_retries):
             try:
                 status = await asyncio.wait_for(
@@ -2110,9 +2111,9 @@ class SyncGateway(_SyncGatewayBase):
             if status is None or status.state != "Online":
                 return
             await asyncio.sleep(retry_delay)
-        total_seconds = max_retries * request_timeout + max(0, max_retries - 1) * retry_delay
+        elapsed = asyncio.get_running_loop().time() - start
         raise TimeoutError(
-            f"Database {db_name} did not go offline within {total_seconds} seconds"
+            f"Database {db_name} did not go offline after {elapsed:.1f} seconds"
         )
 
     @tenacity.retry(

--- a/client/src/cbltest/api/syncgateway.py
+++ b/client/src/cbltest/api/syncgateway.py
@@ -2069,7 +2069,8 @@ class SyncGateway(_SyncGatewayBase):
         assert status.state == "Online", (
             f"Database {db_name} is not Online yet (state={status.state})"
         )
-
+        if settle_online > 0:
+            await asyncio.sleep(settle_online)
     @tenacity.retry(
         # Same polling cadence as wait_for_db_up; give up after 60s.
         wait=tenacity.wait_fixed(3),

--- a/client/src/cbltest/api/syncgateway.py
+++ b/client/src/cbltest/api/syncgateway.py
@@ -2048,46 +2048,41 @@ class SyncGateway(_SyncGatewayBase):
             await asyncio.sleep(retry_delay)
         raise TimeoutError(f"Database {db_name} still exists on some SG nodes")
 
-    async def wait_for_db_up(
-        self,
-        db_name: str,
-        max_retries: int = 20,
-        retry_delay: int = 3,
-        settle_online: int = 10,
-    ) -> None:
+    @tenacity.retry(
+        # DB state flips on SGW's config-polling cadence, not sub-second, so
+        # poll at a steady interval; give up after 60s. Connection errors mean
+        # the node is still coming up, so they retry too.
+        wait=tenacity.wait_fixed(3),
+        stop=tenacity.stop_after_delay(60),
+        reraise=True,
+        retry=tenacity.retry_if_exception_type((AssertionError, ClientError)),
+    )
+    async def wait_for_db_up(self, db_name: str, settle_online: int = 10) -> None:
         """
-        Wait until the SGW node is online.
+        Wait until the SGW database is up. Raises if it still isn't after 60s.
 
         :param db_name: Database name to poll.
-        :param max_retries: Number of polls before timing out.
-        :param retry_delay: Seconds between polls.
-        :param settle_online: Extra seconds to wait after seeing Online.
+        :param settle_online: Extra seconds to wait after seeing the DB up.
         """
-        for _ in range(max_retries):
-            try:
-                sg_status = await self.get_database_status(db_name)
-            except ClientConnectorError:
-                sg_status = None
-            if sg_status is not None:
-                break
-            await asyncio.sleep(retry_delay)
-        else:
-            raise TimeoutError(
-                f"Node {db_name} is not online within {max_retries * retry_delay} seconds"
-            )
+        status = await self.get_database_status(db_name)
+        assert status is not None, f"Database {db_name} is not up yet"
 
         # Wait for the node to settle down after coming online
         await asyncio.sleep(settle_online)
 
+    @tenacity.retry(
+        # Same polling cadence as wait_for_db_up; give up after 60s.
+        wait=tenacity.wait_fixed(3),
+        stop=tenacity.stop_after_delay(60),
+        reraise=True,
+        retry=tenacity.retry_if_exception_type(AssertionError),
+    )
     async def wait_for_db_offline(
-        self,
-        db_name: str,
-        max_retries: int = 20,
-        retry_delay: int = 3,
-        request_timeout: int = 15,
+        self, db_name: str, request_timeout: int = 15
     ) -> None:
         """
-        Wait until the SGW database is no longer online.
+        Wait until the SGW database is no longer online. Raises if it is still
+        Online after 60s.
 
         A database whose Couchbase Server bucket has been deleted may leave the
         admin ``/{db}/`` endpoint hanging rather than promptly reporting a
@@ -2096,30 +2091,17 @@ class SyncGateway(_SyncGatewayBase):
         offline/unavailable -- which is the condition this waits for.
 
         :param db_name: Database name to poll.
-        :param max_retries: Number of polls before timing out.
-        :param retry_delay: Seconds between polls.
         :param request_timeout: Per-poll timeout, in seconds, for the status request.
         """
-        start = asyncio.get_running_loop().time()
-        consecutive_failures = 0
-        for _ in range(max_retries):
-            try:
-                status = await asyncio.wait_for(
-                    self.get_database_status(db_name), request_timeout
-                )
-                consecutive_failures = 0
-            except (asyncio.TimeoutError, ClientError):
-                consecutive_failures += 1
-                if consecutive_failures >= 2:
-                    return
-                await asyncio.sleep(retry_delay)
-                continue
-            if status is None or status.state != "Online":
-                return
-            await asyncio.sleep(retry_delay)
-        elapsed = asyncio.get_running_loop().time() - start
-        raise TimeoutError(
-            f"Database {db_name} did not go offline after {elapsed:.1f} seconds"
+        try:
+            status = await asyncio.wait_for(
+                self.get_database_status(db_name), request_timeout
+            )
+        except (asyncio.TimeoutError, ClientError):
+            # Hung or unreachable admin endpoint -- effectively offline.
+            return
+        assert status is None or status.state != "Online", (
+            f"Database {db_name} is still Online"
         )
 
     @tenacity.retry(

--- a/tests/QE/test_db_online_offline.py
+++ b/tests/QE/test_db_online_offline.py
@@ -112,6 +112,7 @@ class TestDbOnlineOffline(CBLTestClass):
 
         self.mark_test_step("Delete bucket to sever connection")
         cbs.drop_bucket(bucket_name)
+        cbs.wait_for_bucket_deleted(bucket_name)
         await sg.wait_for_db_offline(sg_db)
 
         self.mark_test_step("Verify database is offline - REST endpoints return 403")

--- a/tests/QE/test_db_online_offline.py
+++ b/tests/QE/test_db_online_offline.py
@@ -1,4 +1,3 @@
-import asyncio
 from json.decoder import JSONDecodeError
 from pathlib import Path
 from typing import Any
@@ -113,10 +112,7 @@ class TestDbOnlineOffline(CBLTestClass):
 
         self.mark_test_step("Delete bucket to sever connection")
         cbs.drop_bucket(bucket_name)
-        db_status = await sg.get_database_status(sg_db)
-        while db_status is not None and db_status.state == "Online":
-            db_status = await sg.get_database_status(sg_db)
-            await asyncio.sleep(10)
+        await sg.wait_for_db_offline(sg_db)
 
         self.mark_test_step("Verify database is offline - REST endpoints return 403")
         endpoints_tested, errors_403 = await self.scan_rest_endpoints(
@@ -186,10 +182,7 @@ class TestDbOnlineOffline(CBLTestClass):
         await cbs.wait_for_bucket_deleted("data-bucket-1")
         await cbs.wait_for_bucket_deleted("data-bucket-3")
         for db_name in ["db1", "db3"]:
-            db_status = await sg.get_database_status(db_name)
-            while db_status is not None and db_status.state == "Online":
-                db_status = await sg.get_database_status(db_name)
-                await asyncio.sleep(10)
+            await sg.wait_for_db_offline(db_name)
 
         self.mark_test_step("Verify db2 and db4 remain online")
         for db_name in ["db2", "db4"]:

--- a/tests/QE/test_db_online_offline.py
+++ b/tests/QE/test_db_online_offline.py
@@ -112,7 +112,7 @@ class TestDbOnlineOffline(CBLTestClass):
 
         self.mark_test_step("Delete bucket to sever connection")
         cbs.drop_bucket(bucket_name)
-        cbs.wait_for_bucket_deleted(bucket_name)
+        await cbs.wait_for_bucket_deleted(bucket_name)
         await sg.wait_for_db_offline(sg_db)
 
         self.mark_test_step("Verify database is offline - REST endpoints return 403")


### PR DESCRIPTION
[CBG-5530](https://jira.issues.couchbase.com/browse/CBG-5530)

Added this function already in the `syncgateway.py` as a helper rather than a code chunk sitting in the test since it would be used in other tests being added and hence would help the test CODE only focused on what's being tested and keeping the helping logic away in functions.

### NOTE
This is the last part of the deduplication for the PR #425 and hence that 425 can now be closed/drafted as needed.
cc @borrrden 

[CBG-5530]: https://couchbasecloud.atlassian.net/browse/CBG-5530?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ