### PR TITLE
Added parallel sg_collect for all nodes from config

### DIFF
--- a/environment/aws/sg_collect.py
+++ b/environment/aws/sg_collect.py
@@ -320,7 +320,7 @@ def main(
         )
         return True
 
-    output_path = Path(output_dir).resolve()
+    output_path = Path(output_dir).expanduser().resolve()
     output_path.mkdir(parents=True, exist_ok=True)
 
     header(f"Running sgcollect_info on {len(hostnames)} SGW node(s): {hostnames}")

--- a/environment/aws/sg_collect.py
+++ b/environment/aws/sg_collect.py
@@ -337,8 +337,12 @@ def main(
     # subsequent build. Only this run's downloads may remain.
     for stale in output_path.glob("sgcollectinfo-*.zip"):
         click.secho(f"Removing stale {stale.name} from a previous run", fg="yellow")
-        stale.unlink()
-
+        try:
+            stale.unlink()
+        except OSError as e:
+            click.secho(
+                f"Unable to remove stale {stale.name} (continuing): {e}", fg="yellow"
+            )
     header(f"Running sgcollect_info on {len(hostnames)} SGW node(s): {hostnames}")
     # Exiting the `with` block joins every worker (Go's WaitGroup.Wait()),
     # guaranteeing no collection is still running when teardown proceeds.

--- a/environment/aws/sg_collect.py
+++ b/environment/aws/sg_collect.py
@@ -139,18 +139,14 @@ def list_sgcollect_zips(hostname: str) -> set[str]:
     """
     resp = requests.get(
         _caddy_url(hostname),
-        headers={"Accept": "application/json"},
         timeout=30,
     )
     resp.raise_for_status()
-    return {
-        entry["name"]
-        for entry in cast(list, resp.json())
-        if isinstance(entry, dict)
-        and not entry.get("is_dir", False)
-        and entry.get("name", "").startswith("sgcollectinfo-")
-        and entry.get("name", "").endswith(".zip")
-    }
+
+    # Caddy `file_server browse` returns HTML; extract zip names from the listing.
+    import re
+
+    return set(re.findall(r"sgcollectinfo-[^\"\s<>]+\.zip", resp.text))
 
 
 def download_zip(hostname: str, filename: str, output_dir: Path) -> Path:

--- a/environment/aws/sg_collect.py
+++ b/environment/aws/sg_collect.py
@@ -84,7 +84,11 @@ def start_collection(
             )
             resp.raise_for_status()
             return scheme
-        except (requests.exceptions.SSLError, requests.ConnectionError) as e:
+        except (
+            requests.exceptions.SSLError,
+            requests.exceptions.ConnectionError,
+            requests.exceptions.Timeout,
+        ) as e:
             last_error = e
 
     raise Exception(f"Could not reach SGW admin API on {hostname}: {last_error}")

--- a/environment/aws/sg_collect.py
+++ b/environment/aws/sg_collect.py
@@ -67,8 +67,7 @@ def start_collection(hostname: str) -> str:
     Raises:
         Exception: If the admin API is unreachable or rejects the request.
     """
-    body = {"output_dir": SGW_LOG_DIR}
-    last_error: Exception | None = None
+    body = {"output_dir": SGW_LOG_DIR, "upload": False}
     for scheme in ("https", "http"):
         try:
             resp = requests.post(

--- a/environment/aws/sg_collect.py
+++ b/environment/aws/sg_collect.py
@@ -165,7 +165,11 @@ def download_zip(hostname: str, filename: str, output_dir: Path) -> Path:
     Returns:
         Path: The local path of the downloaded zip.
     """
-    local_path = output_dir / filename
+    safe_host = hostname.replace(".", "_")
+    local_filename = (
+        f"sgcollectinfo-{safe_host}-{filename.removeprefix('sgcollectinfo-')}"
+    )
+    local_path = output_dir / local_filename
     with requests.get(_caddy_url(hostname, filename), stream=True, timeout=300) as r:
         r.raise_for_status()
         with open(local_path, "wb") as f:

--- a/environment/aws/sg_collect.py
+++ b/environment/aws/sg_collect.py
@@ -139,14 +139,31 @@ def list_sgcollect_zips(hostname: str) -> set[str]:
     """
     resp = requests.get(
         _caddy_url(hostname),
+        headers={"Accept": "application/json"},
         timeout=30,
     )
     resp.raise_for_status()
 
-    # Caddy `file_server browse` returns HTML; extract zip names from the listing.
-    import re
+    try:
+        listing = resp.json()
+    except ValueError:
+        # Fallback: Caddy may return HTML in some configurations.
+        import re
 
-    return set(re.findall(r"sgcollectinfo-[^\"\s<>]+\.zip", resp.text))
+        return set(re.findall(r"sgcollectinfo-[^\"\s<>]+\\.zip", resp.text))
+
+    files = {
+        entry.get("name")
+        for entry in listing
+        if isinstance(entry, dict) and not entry.get("is_dir", False)
+    }
+    return {
+        name
+        for name in files
+        if isinstance(name, str)
+        and name.startswith("sgcollectinfo-")
+        and name.endswith(".zip")
+    }
 
 
 def download_zip(hostname: str, filename: str, output_dir: Path) -> Path:

--- a/environment/aws/sg_collect.py
+++ b/environment/aws/sg_collect.py
@@ -7,7 +7,8 @@ It is intended to run from teardown scripts right before the environment is dest
 so that SGW diagnostics survive the teardown.
 
 Functions:
-    main(topology_file: str | None, upload_host: str, customer: str, timeout: int) -> bool:
+    main(topology_file: str | None, upload_host: str, customer: str, timeout: int,
+         sgw_hosts: list[str] | None = None, ticket: str | None = None) -> bool:
         Main function to collect and upload logs from all Sync Gateway nodes.
 """
 

--- a/environment/aws/sg_collect.py
+++ b/environment/aws/sg_collect.py
@@ -325,6 +325,13 @@ def main(
     output_path = Path(output_dir).expanduser().resolve()
     output_path.mkdir(parents=True, exist_ok=True)
 
+    # The Jenkins workspace persists between builds; zips have unique names,
+    # so leftovers from an earlier run would be re-archived by every
+    # subsequent build. Only this run's downloads may remain.
+    for stale in output_path.glob("sgcollectinfo-*.zip"):
+        click.secho(f"Removing stale {stale.name} from a previous run", fg="yellow")
+        stale.unlink()
+
     header(f"Running sgcollect_info on {len(hostnames)} SGW node(s): {hostnames}")
     # Exiting the `with` block joins every worker (Go's WaitGroup.Wait()),
     # guaranteeing no collection is still running when teardown proceeds.

--- a/environment/aws/sg_collect.py
+++ b/environment/aws/sg_collect.py
@@ -2,17 +2,17 @@
 
 """
 This module runs sgcollect_info on every Sync Gateway node in a previously created
-E2E AWS EC2 testing backend and uploads the results to the Couchbase support portal.
-It is intended to run from teardown scripts right before the environment is destroyed
-so that SGW diagnostics survive the teardown.
+E2E AWS EC2 testing backend and downloads the resulting zips to a local directory.
+It is intended to run from teardown scripts right before the environment is destroyed:
+the zips land in the suite's tests directory, where move_artifacts places them in
+the Jenkins artifacts directory to be archived under the job's normal retention.
 
 Functions:
-    main(topology_file: str | None, upload_host: str, customer: str, timeout: int,
-         sgw_hosts: list[str] | None = None, ticket: str | None = None) -> bool:
-        Main function to collect and upload logs from all Sync Gateway nodes.
+    main(topology_file: str | None, output_dir: str, timeout: int,
+         sgw_hosts: list[str] | None = None) -> bool:
+        Main function to collect and download logs from all Sync Gateway nodes.
 """
 
-import re
 import sys
 import time
 from concurrent.futures import ThreadPoolExecutor
@@ -35,6 +35,10 @@ from environment.aws.topology_setup.setup_topology import TopologyConfig
 
 SGW_ADMIN_PORT = 4985
 SGW_ADMIN_AUTH = ("admin", "password")
+# Caddy on each SGW node serves this directory (see sgw_setup/Caddyfile),
+# so zips written here are downloadable without SSH.
+CADDY_PORT = 20000
+SGW_LOG_DIR = "/home/ec2-user/log"
 POLL_INTERVAL_SECS = 15
 
 # The SGW instances use a self-signed certificate
@@ -45,18 +49,17 @@ def _sgcollect_url(scheme: str, hostname: str) -> str:
     return f"{scheme}://{hostname}:{SGW_ADMIN_PORT}/_sgcollect_info"
 
 
-def start_collection(
-    hostname: str, upload_host: str, customer: str, ticket: str | None
-) -> str:
+def _caddy_url(hostname: str, filename: str = "") -> str:
+    return f"http://{hostname}:{CADDY_PORT}/{filename}"
+
+
+def start_collection(hostname: str) -> str:
     """
-    Start sgcollect_info on a Sync Gateway node.
+    Start sgcollect_info on a Sync Gateway node, writing the zip into the
+    Caddy-served log directory.
 
     Args:
         hostname (str): The public hostname of the Sync Gateway instance.
-        upload_host (str): The host to upload the collected logs to.
-        customer (str): The customer name to file the upload under.
-        ticket (str | None): Optional ticket number (1-7 digits) grouping the
-            uploads of one run under <customer>/<ticket>/ on the upload host.
 
     Returns:
         str: The URL scheme ("https" or "http") that the admin API answered on.
@@ -64,14 +67,7 @@ def start_collection(
     Raises:
         Exception: If the admin API is unreachable or rejects the request.
     """
-    body: dict[str, str | bool] = {
-        "output_dir": "/tmp",
-        "upload": True,
-        "upload_host": upload_host,
-        "customer": customer,
-    }
-    if ticket:
-        body["ticket"] = ticket
+    body = {"output_dir": SGW_LOG_DIR}
     last_error: Exception | None = None
     for scheme in ("https", "http"):
         try:
@@ -104,7 +100,7 @@ def wait_for_collection(scheme: str, hostname: str, timeout: int) -> None:
         timeout (int): Maximum number of seconds to wait.
 
     Raises:
-        Exception: If the collection does not finish within the timeout.
+        Exception: If the collection fails or does not finish within the timeout.
     """
     deadline = time.monotonic() + timeout
     with requests.Session() as session:
@@ -132,6 +128,87 @@ def wait_for_collection(scheme: str, hostname: str, timeout: int) -> None:
     )
 
 
+def list_sgcollect_zips(hostname: str) -> set[str]:
+    """
+    List sgcollect zips currently in the node's Caddy-served log directory.
+
+    Args:
+        hostname (str): The public hostname of the Sync Gateway instance.
+
+    Returns:
+        set[str]: Filenames matching sgcollectinfo-*.zip.
+    """
+    resp = requests.get(
+        _caddy_url(hostname),
+        headers={"Accept": "application/json"},
+        timeout=30,
+    )
+    resp.raise_for_status()
+    return {
+        entry["name"]
+        for entry in cast(list, resp.json())
+        if isinstance(entry, dict)
+        and not entry.get("is_dir", False)
+        and entry.get("name", "").startswith("sgcollectinfo-")
+        and entry.get("name", "").endswith(".zip")
+    }
+
+
+def download_zip(hostname: str, filename: str, output_dir: Path) -> Path:
+    """
+    Stream one sgcollect zip from the node's Caddy fileserver to output_dir.
+
+    Args:
+        hostname (str): The public hostname of the Sync Gateway instance.
+        filename (str): The zip filename to download.
+        output_dir (Path): Local directory to write the zip into.
+
+    Returns:
+        Path: The local path of the downloaded zip.
+    """
+    local_path = output_dir / filename
+    with requests.get(_caddy_url(hostname, filename), stream=True, timeout=300) as r:
+        r.raise_for_status()
+        with open(local_path, "wb") as f:
+            for chunk in r.iter_content(chunk_size=1024 * 1024):
+                f.write(chunk)
+    return local_path
+
+
+def collect_node(hostname: str, output_dir: Path, timeout: int) -> bool:
+    """
+    Run sgcollect_info on a single node and download the resulting zip.
+
+    Args:
+        hostname (str): The public hostname of the Sync Gateway instance.
+        output_dir (Path): Local directory to write the zip into.
+        timeout (int): Seconds to wait for the collection to finish.
+
+    Returns:
+        bool: True if the collection and download succeeded, False otherwise.
+    """
+    try:
+        # Snapshot first so a zip left over from an earlier collection on this
+        # node is never mistaken for this run's output.
+        before = list_sgcollect_zips(hostname)
+        scheme = start_collection(hostname)
+        wait_for_collection(scheme, hostname, timeout)
+        new_zips = list_sgcollect_zips(hostname) - before
+        if not new_zips:
+            raise Exception(f"no new sgcollect zip appeared in {SGW_LOG_DIR}")
+
+        for filename in sorted(new_zips):
+            local_path = download_zip(hostname, filename, output_dir)
+            size_mb = local_path.stat().st_size / (1024 * 1024)
+            click.secho(
+                f"[{hostname}] Downloaded {local_path} ({size_mb:.1f} MB)", fg="green"
+            )
+        return True
+    except Exception as e:
+        click.secho(f"[{hostname}] sgcollect_info failed: {e}", fg="red")
+        return False
+
+
 @click.command()
 @click.option(
     "--topology",
@@ -139,14 +216,10 @@ def wait_for_collection(scheme: str, hostname: str, timeout: int) -> None:
     type=click.Path(exists=True),
 )
 @click.option(
-    "--upload-host",
-    default="uploads.couchbase.com",
-    help="The host to upload the collected logs to",
-)
-@click.option(
-    "--customer",
-    default="sgw-qe",
-    help="The customer name to file the upload under",
+    "--output-dir",
+    default=".",
+    help="Local directory to download the sgcollect zips into "
+    "(teardown passes the suite's tests dir so move_artifacts picks them up)",
 )
 @click.option(
     "--timeout",
@@ -159,21 +232,13 @@ def wait_for_collection(scheme: str, hostname: str, timeout: int) -> None:
     help="Explicit SGW hostname(s) to collect from, bypassing terraform state "
     "(for ad-hoc runs against an environment provisioned elsewhere)",
 )
-@click.option(
-    "--ticket",
-    default=None,
-    help="Ticket number (1-7 digits, e.g. the Jenkins BUILD_NUMBER) grouping "
-    "this run's uploads under <customer>/<ticket>/ on the upload host",
-)
 def cli_entry(
     topology: str | None,
-    upload_host: str,
-    customer: str,
+    output_dir: str,
     timeout: int,
     sgw_host: tuple[str, ...],
-    ticket: str | None,
 ) -> None:
-    if not main(topology, upload_host, customer, timeout, list(sgw_host), ticket):
+    if not main(topology, output_dir, timeout, list(sgw_host)):
         sys.exit(1)
 
 
@@ -200,63 +265,26 @@ def resolve_sgw_hostnames(topology_file: str | None) -> list[str] | None:
     return [sgw.hostname for sgw in topology.sync_gateways]
 
 
-def collect_node(
-    hostname: str, upload_host: str, customer: str, timeout: int, ticket: str | None
-) -> bool:
-    """
-    Run sgcollect_info on a single node from start to upload completion.
-
-    Args:
-        hostname (str): The public hostname of the Sync Gateway instance.
-        upload_host (str): The host to upload the collected logs to.
-        customer (str): The customer name to file the upload under.
-        timeout (int): Seconds to wait for the collection to finish.
-        ticket (str | None): Optional ticket number grouping this run's uploads.
-
-    Returns:
-        bool: True if the collection succeeded, False otherwise.
-    """
-    try:
-        scheme = start_collection(hostname, upload_host, customer, ticket)
-        wait_for_collection(scheme, hostname, timeout)
-        destination = f"{upload_host}/{customer}" + (f"/{ticket}" if ticket else "")
-        click.secho(f"[{hostname}] Logs uploaded to {destination}", fg="green")
-        return True
-    except Exception as e:
-        click.secho(f"[{hostname}] sgcollect_info failed: {e}", fg="red")
-        return False
-
-
 def main(
     topology_file: str | None,
-    upload_host: str,
-    customer: str,
+    output_dir: str,
     timeout: int,
     sgw_hosts: list[str] | None = None,
-    ticket: str | None = None,
 ) -> bool:
     """
-    Collect and upload logs from every Sync Gateway node in the environment,
+    Collect and download logs from every Sync Gateway node in the environment,
     in parallel. Does not return until all collections have finished, so a
     teardown that runs afterwards cannot destroy a node mid-collection.
 
     Args:
         topology_file (str | None): The topology file that was used to start the environment.
-        upload_host (str): The host to upload the collected logs to.
-        customer (str): The customer name to file the upload under.
+        output_dir (str): Local directory to download the sgcollect zips into.
         timeout (int): Seconds to wait for each node's collection to finish.
         sgw_hosts (list[str] | None): Explicit SGW hostnames, bypassing terraform state.
-        ticket (str | None): Optional ticket number grouping this run's uploads.
 
     Returns:
         bool: True if every node was collected successfully, False otherwise.
     """
-    if ticket and not re.fullmatch(r"\d{1,7}", ticket):
-        # SGW rejects malformed tickets with a 400; dropping it keeps the
-        # upload itself (the part that matters) alive.
-        click.secho(f"Ignoring ticket '{ticket}': must be 1 to 7 digits.", fg="yellow")
-        ticket = None
-
     hostnames = sgw_hosts or resolve_sgw_hostnames(topology_file)
     if hostnames is None:
         return False
@@ -267,15 +295,16 @@ def main(
         )
         return True
 
+    output_path = Path(output_dir).resolve()
+    output_path.mkdir(parents=True, exist_ok=True)
+
     header(f"Running sgcollect_info on {len(hostnames)} SGW node(s): {hostnames}")
     # Exiting the `with` block joins every worker (Go's WaitGroup.Wait()),
     # guaranteeing no collection is still running when teardown proceeds.
     with ThreadPoolExecutor(max_workers=len(hostnames)) as pool:
         results = list(
             pool.map(
-                lambda hostname: collect_node(
-                    hostname, upload_host, customer, timeout, ticket
-                ),
+                lambda hostname: collect_node(hostname, output_path, timeout),
                 hostnames,
             )
         )

--- a/environment/aws/sg_collect.py
+++ b/environment/aws/sg_collect.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+
+"""
+This module runs sgcollect_info on every Sync Gateway node in a previously created
+E2E AWS EC2 testing backend and uploads the results to the Couchbase support portal.
+It is intended to run from teardown scripts right before the environment is destroyed
+so that SGW diagnostics survive the teardown.
+
+Functions:
+    main(topology_file: str | None, upload_host: str, customer: str, timeout: int) -> bool:
+        Main function to collect and upload logs from all Sync Gateway nodes.
+"""
+
+import re
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import cast
+
+import click
+import requests
+import urllib3
+
+SCRIPT_DIR = Path(__file__).parent
+if __name__ == "__main__":
+    sys.path.append(str(SCRIPT_DIR.parents[1]))
+    from environment.aws.common.io import configure_terminal_encoding
+
+    configure_terminal_encoding()
+
+from environment.aws.common.output import header
+from environment.aws.topology_setup.setup_topology import TopologyConfig
+
+SGW_ADMIN_PORT = 4985
+SGW_ADMIN_AUTH = ("admin", "password")
+POLL_INTERVAL_SECS = 15
+
+# The SGW instances use a self-signed certificate
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+
+def _sgcollect_url(scheme: str, hostname: str) -> str:
+    return f"{scheme}://{hostname}:{SGW_ADMIN_PORT}/_sgcollect_info"
+
+
+def start_collection(
+    hostname: str, upload_host: str, customer: str, ticket: str | None
+) -> str:
+    """
+    Start sgcollect_info on a Sync Gateway node.
+
+    Args:
+        hostname (str): The public hostname of the Sync Gateway instance.
+        upload_host (str): The host to upload the collected logs to.
+        customer (str): The customer name to file the upload under.
+        ticket (str | None): Optional ticket number (1-7 digits) grouping the
+            uploads of one run under <customer>/<ticket>/ on the upload host.
+
+    Returns:
+        str: The URL scheme ("https" or "http") that the admin API answered on.
+
+    Raises:
+        Exception: If the admin API is unreachable or rejects the request.
+    """
+    body: dict[str, str | bool] = {
+        "output_dir": "/tmp",
+        "upload": True,
+        "upload_host": upload_host,
+        "customer": customer,
+    }
+    if ticket:
+        body["ticket"] = ticket
+    last_error: Exception | None = None
+    for scheme in ("https", "http"):
+        try:
+            resp = requests.post(
+                _sgcollect_url(scheme, hostname),
+                json=body,
+                auth=SGW_ADMIN_AUTH,
+                verify=False,
+                timeout=30,
+            )
+            resp.raise_for_status()
+            return scheme
+        except (requests.exceptions.SSLError, requests.ConnectionError) as e:
+            last_error = e
+
+    raise Exception(f"Could not reach SGW admin API on {hostname}: {last_error}")
+
+
+def wait_for_collection(scheme: str, hostname: str, timeout: int) -> None:
+    """
+    Poll the sgcollect_info status endpoint until the run finishes.
+
+    Args:
+        scheme (str): The URL scheme the admin API answered on.
+        hostname (str): The public hostname of the Sync Gateway instance.
+        timeout (int): Maximum number of seconds to wait.
+
+    Raises:
+        Exception: If the collection does not finish within the timeout.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        resp = requests.get(
+            _sgcollect_url(scheme, hostname),
+            auth=SGW_ADMIN_AUTH,
+            verify=False,
+            timeout=30,
+        )
+        resp.raise_for_status()
+        if cast(dict, resp.json()).get("status") != "running":
+            return
+
+        click.echo(f"[{hostname}] sgcollect_info still running...")
+        time.sleep(POLL_INTERVAL_SECS)
+
+    raise Exception(
+        f"sgcollect_info on {hostname} did not finish within {timeout} seconds"
+    )
+
+
+@click.command()
+@click.option(
+    "--topology",
+    help="The topology file that was used to start the environment",
+    type=click.Path(exists=True),
+)
+@click.option(
+    "--upload-host",
+    default="uploads.couchbase.com",
+    help="The host to upload the collected logs to",
+)
+@click.option(
+    "--customer",
+    default="sgw-qe",
+    help="The customer name to file the upload under",
+)
+@click.option(
+    "--timeout",
+    default=1800,
+    help="Seconds to wait for each node's collection to finish",
+)
+@click.option(
+    "--sgw-host",
+    multiple=True,
+    help="Explicit SGW hostname(s) to collect from, bypassing terraform state "
+    "(for ad-hoc runs against an environment provisioned elsewhere)",
+)
+@click.option(
+    "--ticket",
+    default=None,
+    help="Ticket number (1-7 digits, e.g. the Jenkins BUILD_NUMBER) grouping "
+    "this run's uploads under <customer>/<ticket>/ on the upload host",
+)
+def cli_entry(
+    topology: str | None,
+    upload_host: str,
+    customer: str,
+    timeout: int,
+    sgw_host: tuple[str, ...],
+    ticket: str | None,
+) -> None:
+    if not main(topology, upload_host, customer, timeout, list(sgw_host), ticket):
+        sys.exit(1)
+
+
+def resolve_sgw_hostnames(topology_file: str | None) -> list[str] | None:
+    """
+    Read the public hostnames of all Sync Gateway nodes from terraform state.
+
+    Args:
+        topology_file (str | None): The topology file that was used to start the environment.
+
+    Returns:
+        list[str] | None: The hostnames, or None if the state could not be read.
+    """
+    topology = TopologyConfig(topology_file) if topology_file else TopologyConfig()
+    try:
+        topology.read_from_terraform(str(SCRIPT_DIR))
+    except Exception as e:
+        click.secho(
+            f"Unable to read SGW hostnames from terraform state, skipping sgcollect: {e}",
+            fg="yellow",
+        )
+        return None
+
+    return [sgw.hostname for sgw in topology.sync_gateways]
+
+
+def collect_node(
+    hostname: str, upload_host: str, customer: str, timeout: int, ticket: str | None
+) -> bool:
+    """
+    Run sgcollect_info on a single node from start to upload completion.
+
+    Args:
+        hostname (str): The public hostname of the Sync Gateway instance.
+        upload_host (str): The host to upload the collected logs to.
+        customer (str): The customer name to file the upload under.
+        timeout (int): Seconds to wait for the collection to finish.
+        ticket (str | None): Optional ticket number grouping this run's uploads.
+
+    Returns:
+        bool: True if the collection succeeded, False otherwise.
+    """
+    try:
+        scheme = start_collection(hostname, upload_host, customer, ticket)
+        wait_for_collection(scheme, hostname, timeout)
+        destination = f"{upload_host}/{customer}" + (f"/{ticket}" if ticket else "")
+        click.secho(f"[{hostname}] Logs uploaded to {destination}", fg="green")
+        return True
+    except Exception as e:
+        click.secho(f"[{hostname}] sgcollect_info failed: {e}", fg="red")
+        return False
+
+
+def main(
+    topology_file: str | None,
+    upload_host: str,
+    customer: str,
+    timeout: int,
+    sgw_hosts: list[str] | None = None,
+    ticket: str | None = None,
+) -> bool:
+    """
+    Collect and upload logs from every Sync Gateway node in the environment,
+    in parallel. Does not return until all collections have finished, so a
+    teardown that runs afterwards cannot destroy a node mid-collection.
+
+    Args:
+        topology_file (str | None): The topology file that was used to start the environment.
+        upload_host (str): The host to upload the collected logs to.
+        customer (str): The customer name to file the upload under.
+        timeout (int): Seconds to wait for each node's collection to finish.
+        sgw_hosts (list[str] | None): Explicit SGW hostnames, bypassing terraform state.
+        ticket (str | None): Optional ticket number grouping this run's uploads.
+
+    Returns:
+        bool: True if every node was collected successfully, False otherwise.
+    """
+    if ticket and not re.fullmatch(r"\d{1,7}", ticket):
+        # SGW rejects malformed tickets with a 400; dropping it keeps the
+        # upload itself (the part that matters) alive.
+        click.secho(f"Ignoring ticket '{ticket}': must be 1 to 7 digits.", fg="yellow")
+        ticket = None
+
+    hostnames = sgw_hosts or resolve_sgw_hostnames(topology_file)
+    if hostnames is None:
+        return False
+
+    if len(hostnames) == 0:
+        click.secho(
+            "No Sync Gateway nodes in topology, nothing to collect.", fg="yellow"
+        )
+        return True
+
+    header(f"Running sgcollect_info on {len(hostnames)} SGW node(s): {hostnames}")
+    # Exiting the `with` block joins every worker (Go's WaitGroup.Wait()),
+    # guaranteeing no collection is still running when teardown proceeds.
+    with ThreadPoolExecutor(max_workers=len(hostnames)) as pool:
+        results = list(
+            pool.map(
+                lambda hostname: collect_node(
+                    hostname, upload_host, customer, timeout, ticket
+                ),
+                hostnames,
+            )
+        )
+
+    return all(results)
+
+
+if __name__ == "__main__":
+    cli_entry()

--- a/environment/aws/sg_collect.py
+++ b/environment/aws/sg_collect.py
@@ -67,6 +67,7 @@ def start_collection(hostname: str) -> str:
         Exception: If the admin API is unreachable or rejects the request.
     """
     body = {"output_dir": SGW_LOG_DIR, "upload": False}
+    last_error: Exception | None = None
     for scheme in ("https", "http"):
         try:
             resp = requests.post(
@@ -85,7 +86,9 @@ def start_collection(hostname: str) -> str:
         ) as e:
             last_error = e
 
-    raise Exception(f"Could not reach SGW admin API on {hostname}: {last_error}")
+    raise Exception(
+        f"Could not reach SGW admin API on {hostname}: {last_error or 'unknown error'}"
+    )
 
 
 def wait_for_collection(scheme: str, hostname: str, timeout: int) -> None:

--- a/environment/aws/sg_collect.py
+++ b/environment/aws/sg_collect.py
@@ -31,7 +31,6 @@ if __name__ == "__main__":
     configure_terminal_encoding()
 
 from environment.aws.common.output import header
-from environment.aws.topology_setup.setup_topology import TopologyConfig
 
 SGW_ADMIN_PORT = 4985
 SGW_ADMIN_AUTH = ("admin", "password")
@@ -279,6 +278,11 @@ def resolve_sgw_hostnames(topology_file: str | None) -> list[str] | None:
     Returns:
         list[str] | None: The hostnames, or None if the state could not be read.
     """
+    # Imported lazily: this drags in the whole topology/test-server machinery,
+    # which callers that pass explicit hostnames (the QE conftest fixture)
+    # never need.
+    from environment.aws.topology_setup.setup_topology import TopologyConfig
+
     topology = TopologyConfig(topology_file) if topology_file else TopologyConfig()
     try:
         topology.read_from_terraform(str(SCRIPT_DIR))

--- a/environment/aws/sg_collect.py
+++ b/environment/aws/sg_collect.py
@@ -170,11 +170,20 @@ def download_zip(hostname: str, filename: str, output_dir: Path) -> Path:
         f"sgcollectinfo-{safe_host}-{filename.removeprefix('sgcollectinfo-')}"
     )
     local_path = output_dir / local_filename
-    with requests.get(_caddy_url(hostname, filename), stream=True, timeout=300) as r:
-        r.raise_for_status()
-        with open(local_path, "wb") as f:
-            for chunk in r.iter_content(chunk_size=1024 * 1024):
-                f.write(chunk)
+    tmp_path = local_path.with_suffix(local_path.suffix + ".part")
+    try:
+        with requests.get(
+            _caddy_url(hostname, filename), stream=True, timeout=300
+        ) as r:
+            r.raise_for_status()
+            with open(tmp_path, "wb") as f:
+                for chunk in r.iter_content(chunk_size=1024 * 1024):
+                    if chunk:
+                        f.write(chunk)
+        tmp_path.replace(local_path)
+    finally:
+        if tmp_path.exists():
+            tmp_path.unlink()
     return local_path
 
 

--- a/environment/aws/sg_collect.py
+++ b/environment/aws/sg_collect.py
@@ -270,15 +270,12 @@ def main(
     header(f"Running sgcollect_info on {len(hostnames)} SGW node(s): {hostnames}")
     # Exiting the `with` block joins every worker (Go's WaitGroup.Wait()),
     # guaranteeing no collection is still running when teardown proceeds.
-    with ThreadPoolExecutor(max_workers=len(hostnames)) as pool:
-        results = list(
-            pool.map(
-                lambda hostname: collect_node(
-                    hostname, upload_host, customer, timeout, ticket
-                ),
-                hostnames,
-            )
-        )
+with ThreadPoolExecutor(max_workers=len(hostnames)) as pool:
+    futures = [
+        pool.submit(collect_node, hostname, upload_host, customer, timeout, ticket)
+        for hostname in hostnames
+    ]
+    results = [f.result() for f in futures]
 
     return all(results)
 

--- a/environment/aws/sg_collect.py
+++ b/environment/aws/sg_collect.py
@@ -115,8 +115,14 @@ def wait_for_collection(scheme: str, hostname: str, timeout: int) -> None:
             timeout=30,
         )
         resp.raise_for_status()
-        if cast(dict, resp.json()).get("status") != "running":
+        status_resp = cast(dict, resp.json())
+        status = status_resp.get("status")
+        if status in {"stopped", "completed"}:
             return
+        if status != "running":
+            raise Exception(
+                f"sgcollect_info on {hostname} ended with status={status!r}: {status_resp.get('error')}"
+            )
 
         click.echo(f"[{hostname}] sgcollect_info still running...")
         time.sleep(POLL_INTERVAL_SECS)

--- a/environment/aws/sg_collect.py
+++ b/environment/aws/sg_collect.py
@@ -107,26 +107,26 @@ def wait_for_collection(scheme: str, hostname: str, timeout: int) -> None:
         Exception: If the collection does not finish within the timeout.
     """
     deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        resp = requests.get(
-            _sgcollect_url(scheme, hostname),
-            auth=SGW_ADMIN_AUTH,
-            verify=False,
-            timeout=30,
-        )
-        resp.raise_for_status()
-        status_resp = cast(dict, resp.json())
-        status = status_resp.get("status")
-        if status in {"stopped", "completed"}:
-            return
-        if status != "running":
-            raise Exception(
-                f"sgcollect_info on {hostname} ended with status={status!r}: {status_resp.get('error')}"
+    with requests.Session() as session:
+        while time.monotonic() < deadline:
+            resp = session.get(
+                _sgcollect_url(scheme, hostname),
+                auth=SGW_ADMIN_AUTH,
+                verify=False,
+                timeout=30,
             )
+            resp.raise_for_status()
+            status_resp = cast(dict, resp.json())
+            status = status_resp.get("status")
+            if status in {"stopped", "completed"}:
+                return
+            if status != "running":
+                raise Exception(
+                    f"sgcollect_info on {hostname} ended with status={status!r}: {status_resp.get('error')}"
+                )
 
-        click.echo(f"[{hostname}] sgcollect_info still running...")
-        time.sleep(POLL_INTERVAL_SECS)
-
+            click.echo(f"[{hostname}] sgcollect_info still running...")
+            time.sleep(POLL_INTERVAL_SECS)
     raise Exception(
         f"sgcollect_info on {hostname} did not finish within {timeout} seconds"
     )

--- a/environment/aws/sg_collect.py
+++ b/environment/aws/sg_collect.py
@@ -115,13 +115,15 @@ def wait_for_collection(scheme: str, hostname: str, timeout: int) -> None:
             status = status_resp.get("status")
             if status in {"stopped", "completed"}:
                 return
-            if status != "running":
-                raise Exception(
-                    f"sgcollect_info on {hostname} ended with status={status!r}: {status_resp.get('error')}"
+            if status in {"running", "started"}:
+                click.echo(
+                    f"[{hostname}] sgcollect_info still running (status={status})..."
                 )
-
-            click.echo(f"[{hostname}] sgcollect_info still running...")
-            time.sleep(POLL_INTERVAL_SECS)
+                time.sleep(POLL_INTERVAL_SECS)
+                continue
+            raise Exception(
+                f"sgcollect_info on {hostname} ended with status={status!r}: {status_resp.get('error')}"
+            )
     raise Exception(
         f"sgcollect_info on {hostname} did not finish within {timeout} seconds"
     )

--- a/environment/aws/sg_collect.py
+++ b/environment/aws/sg_collect.py
@@ -150,7 +150,7 @@ def list_sgcollect_zips(hostname: str) -> set[str]:
         # Fallback: Caddy may return HTML in some configurations.
         import re
 
-        return set(re.findall(r"sgcollectinfo-[^\"\s<>]+\\.zip", resp.text))
+        return set(re.findall(r"sgcollectinfo-[^\"\s<>]+\.zip", resp.text))
 
     files = {
         entry.get("name")

--- a/jenkins/pipelines/QE/sgw/teardown.sh
+++ b/jenkins/pipelines/QE/sgw/teardown.sh
@@ -8,13 +8,10 @@ source $SCRIPT_DIR/../../shared/config.sh
 export PYTHONPATH=$SCRIPT_DIR/../../../
 pushd $AWS_ENVIRONMENT_DIR
 
-# Best-effort sg_collect upload; failures must never stop teardown (avoid leaked EC2s).
-# BUILD_NUMBER (set by Jenkins) is truncated to the last 7 digits to satisfy SGW ticket validation.
-ticket_opt=()
-if [[ -n "${BUILD_NUMBER-}" ]]; then
-  ticket_opt=(--ticket "${BUILD_NUMBER: -7}")
-fi
-uv run ./sg_collect.py --topology topology_setup/topology.json "${ticket_opt[@]}" || \
+# Best-effort sg_collect; failures must never stop teardown (avoid leaked EC2s).
+# Zips land in the QE tests dir and move_artifacts places them in
+# TS_ARTIFACTS_DIR, Jenkins archives them under its normal retention.
+uv run ./sg_collect.py --topology topology_setup/topology.json --output-dir "$QE_TESTS_DIR" || \
   echo "WARNING: sg_collect.py failed; continuing with teardown"
 move_artifacts
 

--- a/jenkins/pipelines/QE/sgw/teardown.sh
+++ b/jenkins/pipelines/QE/sgw/teardown.sh
@@ -7,12 +7,6 @@ source $SCRIPT_DIR/../../shared/config.sh
 
 export PYTHONPATH=$SCRIPT_DIR/../../../
 pushd $AWS_ENVIRONMENT_DIR
-
-# Best-effort sg_collect; failures must never stop teardown (avoid leaked EC2s).
-# Zips land in the QE tests dir and move_artifacts places them in
-# TS_ARTIFACTS_DIR, Jenkins archives them under its normal retention.
-uv run ./sg_collect.py --topology topology_setup/topology.json --output-dir "$QE_TESTS_DIR" || \
-  echo "WARNING: sg_collect.py failed; continuing with teardown"
 move_artifacts
 
 uv run ./stop_backend.py --topology topology_setup/topology.json

--- a/jenkins/pipelines/QE/sgw/teardown.sh
+++ b/jenkins/pipelines/QE/sgw/teardown.sh
@@ -7,6 +7,13 @@ source $SCRIPT_DIR/../../shared/config.sh
 
 export PYTHONPATH=$SCRIPT_DIR/../../../
 pushd $AWS_ENVIRONMENT_DIR
+
+# Best-effort sg_collect upload; must never block teardown (leaked EC2s).
+# BUILD_NUMBER (set by Jenkins) groups the run's uploads under one
+# "ticket" folder in the supportal.
+uv run ./sg_collect.py --topology topology_setup/topology.json \
+    ${BUILD_NUMBER:+--ticket "$BUILD_NUMBER"} || \
+    echo "WARNING: sgcollect_info failed; continuing with teardown"
 move_artifacts
 
 uv run ./stop_backend.py --topology topology_setup/topology.json

--- a/jenkins/pipelines/QE/sgw/teardown.sh
+++ b/jenkins/pipelines/QE/sgw/teardown.sh
@@ -8,9 +8,9 @@ source $SCRIPT_DIR/../../shared/config.sh
 export PYTHONPATH=$SCRIPT_DIR/../../../
 pushd $AWS_ENVIRONMENT_DIR
 
-# Best-effort sg_collect upload; must never block teardown (leaked EC2s).
+# Best-effort sg_collect upload; failures must never stop teardown (avoid leaked EC2s).
 # BUILD_NUMBER (set by Jenkins) groups the run's uploads under one
-# "ticket" folder in the supportal.
+# "<customer>/<ticket>/" folder in the support portal.
 uv run ./sg_collect.py --topology topology_setup/topology.json \
     ${BUILD_NUMBER:+--ticket "${BUILD_NUMBER: -7}"} || \
     echo "WARNING: sg_collect.py failed; continuing with teardown"

--- a/jenkins/pipelines/QE/sgw/teardown.sh
+++ b/jenkins/pipelines/QE/sgw/teardown.sh
@@ -12,8 +12,8 @@ pushd $AWS_ENVIRONMENT_DIR
 # BUILD_NUMBER (set by Jenkins) groups the run's uploads under one
 # "ticket" folder in the supportal.
 uv run ./sg_collect.py --topology topology_setup/topology.json \
-    ${BUILD_NUMBER:+--ticket "$BUILD_NUMBER"} || \
-    echo "WARNING: sgcollect_info failed; continuing with teardown"
+    ${BUILD_NUMBER:+--ticket "${BUILD_NUMBER: -7}"} || \
+    echo "WARNING: sg_collect.py failed; continuing with teardown"
 move_artifacts
 
 uv run ./stop_backend.py --topology topology_setup/topology.json

--- a/jenkins/pipelines/QE/sgw/teardown.sh
+++ b/jenkins/pipelines/QE/sgw/teardown.sh
@@ -9,11 +9,13 @@ export PYTHONPATH=$SCRIPT_DIR/../../../
 pushd $AWS_ENVIRONMENT_DIR
 
 # Best-effort sg_collect upload; failures must never stop teardown (avoid leaked EC2s).
-# BUILD_NUMBER (set by Jenkins) groups the run's uploads under one
-# "<customer>/<ticket>/" folder in the support portal.
-uv run ./sg_collect.py --topology topology_setup/topology.json \
-    ${BUILD_NUMBER:+--ticket "${BUILD_NUMBER: -7}"} || \
-    echo "WARNING: sg_collect.py failed; continuing with teardown"
+# BUILD_NUMBER (set by Jenkins) is truncated to the last 7 digits to satisfy SGW ticket validation.
+ticket_opt=()
+if [[ -n "${BUILD_NUMBER-}" ]]; then
+  ticket_opt=(--ticket "${BUILD_NUMBER: -7}")
+fi
+uv run ./sg_collect.py --topology topology_setup/topology.json "${ticket_opt[@]}" || \
+  echo "WARNING: sg_collect.py failed; continuing with teardown"
 move_artifacts
 
 uv run ./stop_backend.py --topology topology_setup/topology.json

--- a/jenkins/pipelines/shared/config.sh
+++ b/jenkins/pipelines/shared/config.sh
@@ -33,6 +33,9 @@ function move_artifacts() {
     mv "$src_dir/junit_result.xml" "$dst_dir/junit_result.xml" || true
     # SGW diagnostics downloaded by sg_collect.py during teardown; moving
     # them here gets them archived (and later purged) by Jenkins retention.
+    # Purge zips left by earlier builds first — the workspace persists and
+    # zips have unique names, so they'd accumulate into every build's archive.
+    rm -f "$dst_dir"/sgcollectinfo-*.zip
     mv "$src_dir"/sgcollectinfo-*.zip "$dst_dir/" 2> /dev/null || true
 }
 

--- a/jenkins/pipelines/shared/config.sh
+++ b/jenkins/pipelines/shared/config.sh
@@ -31,6 +31,9 @@ function move_artifacts() {
     # Include the JUnit XML so each platform's results are preserved per
     # artifacts dir in a multi-pipeline (matrix) build.
     mv "$src_dir/junit_result.xml" "$dst_dir/junit_result.xml" || true
+    # SGW diagnostics downloaded by sg_collect.py during teardown; moving
+    # them here gets them archived (and later purged) by Jenkins retention.
+    mv "$src_dir"/sgcollectinfo-*.zip "$dst_dir/" 2> /dev/null || true
 }
 
 find_dir() {

--- a/tests/QE/conftest.py
+++ b/tests/QE/conftest.py
@@ -52,7 +52,9 @@ async def collect_sgw_logs(cblpytest, request):
 
         hostnames = [sg.hostname for sg in cblpytest.sync_gateways]
         if not hostnames:
-            print("🧾 SGW log collection skipped: no Sync Gateways available in this session")
+            print(
+                "🧾 SGW log collection skipped: no Sync Gateways available in this session"
+            )
             return
         ok = await asyncio.to_thread(
             sg_collect_main,

--- a/tests/QE/conftest.py
+++ b/tests/QE/conftest.py
@@ -44,17 +44,24 @@ async def collect_sgw_logs(cblpytest, request):
         print("🧾 SGW log collection skipped: no SGW-marked tests in this session")
         return
 
-    sys.path.append(str(Path(__file__).parents[2]))
-    from environment.aws.sg_collect import main as sg_collect_main
-
     try:
+        repo_root = str(Path(__file__).resolve().parents[2])
+        if repo_root not in sys.path:
+            sys.path.insert(0, repo_root)
+        from environment.aws.sg_collect import main as sg_collect_main
+
         hostnames = [sg.hostname for sg in cblpytest.sync_gateways]
-        sg_collect_main(
+        ok = await asyncio.to_thread(
+            sg_collect_main,
             None,
             output_dir=os.path.dirname(os.path.abspath(__file__)),
             timeout=1800,
             sgw_hosts=hostnames,
         )
+        if not ok:
+            print(
+                "🧾 SGW log collection finished with failures (non-fatal); see logs above."
+            )
     except Exception as e:
         print(f"🧾 SGW log collection failed (non-fatal): {e}")
 

--- a/tests/QE/conftest.py
+++ b/tests/QE/conftest.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+import sys
 from pathlib import Path
 
 import pytest
@@ -7,6 +8,10 @@ import pytest_asyncio
 from cbltest.api.couchbaseserver import CouchbaseServer
 from cbltest.api.syncgateway import SyncGateway
 from cbltest.utils import verify_lfs_checkout
+
+# Markers identifying SGW-focused tests; a session that ran none of these
+# (e.g. a CBL-focused platform run) skips SGW log collection (for now).
+SGW_LOG_MARKERS = ("sgw", "upg_sgw")
 
 
 # This is used to inject the full path to the dataset folder
@@ -16,6 +21,42 @@ def dataset_path() -> Path:
     verify_lfs_checkout()
     script_path = os.path.abspath(os.path.dirname(__file__))
     return Path(script_path, "..", "..", "dataset", "sg")
+
+
+@pytest_asyncio.fixture(scope="session", autouse=True)
+async def collect_sgw_logs(cblpytest, request):
+    """
+    After the last test of the session, run sgcollect_info on every SGW node
+    (in parallel) and download the zips next to this file, where the pipeline
+    teardown's move_artifacts places them in the Jenkins artifacts directory.
+
+    Runs while the environment is still up (pytest exits before teardown.sh),
+    and only when the session executed at least one SGW-focused test (for now),
+    so CBL-focused runs are unaffected. Never fails the session.
+    """
+    yield
+
+    if not any(
+        item.get_closest_marker(marker)
+        for item in request.session.items
+        for marker in SGW_LOG_MARKERS
+    ):
+        print("🧾 SGW log collection skipped: no SGW-marked tests in this session")
+        return
+
+    sys.path.append(str(Path(__file__).parents[2]))
+    from environment.aws.sg_collect import main as sg_collect_main
+
+    try:
+        hostnames = [sg.hostname for sg in cblpytest.sync_gateways]
+        sg_collect_main(
+            None,
+            output_dir=os.path.dirname(os.path.abspath(__file__)),
+            timeout=1800,
+            sgw_hosts=hostnames,
+        )
+    except Exception as e:
+        print(f"🧾 SGW log collection failed (non-fatal): {e}")
 
 
 @pytest_asyncio.fixture(scope="function", autouse=True)

--- a/tests/QE/conftest.py
+++ b/tests/QE/conftest.py
@@ -51,6 +51,9 @@ async def collect_sgw_logs(cblpytest, request):
         from environment.aws.sg_collect import main as sg_collect_main
 
         hostnames = [sg.hostname for sg in cblpytest.sync_gateways]
+        if not hostnames:
+            print("🧾 SGW log collection skipped: no Sync Gateways available in this session")
+            return
         ok = await asyncio.to_thread(
             sg_collect_main,
             None,


### PR DESCRIPTION
[CBG-5487](https://jira.issues.couchbase.com/browse/CBG-5487)

This PR adds sg_collect post test suite run. Very small changes, created the method to run curl commands on all nodes for sg_collect to dump the logs into SUPPORTAL.

### KEYS : 
1. sg collect is triggered in `tests/QE/conftest.py` as a session fixture for a suite if one of the tests in it was marked with `sgw` pytest marker this PR. I plan on adding this into SGW for dev_e2e LATER in a different ticket, once the corrections and comments on this are finalized for sure.
2. They are run on all nodes in parallel because QE uses 3 SGs and sequential led to about 17mins of extra test runtime plus what we already face.
3. They dump the logs into the Jenkins job itself as its build artifacts. Hence they stay temporarily compared to the previous approach.
4. Kept the logic in a new file `environment/aws/sg_collect.py` which is very much similar to `stop_backend.py`.

I have tried to keep the code as concisie and clean, and as parallel and fast, AND AS THREAD-SAFE + RACE-SAFE as possible. 
Please give recommendations for improvements in this.

[CBG-5487]: https://couchbasecloud.atlassian.net/browse/CBG-5487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ