### PR TITLE
CBG-4946: Add min_edge_servers pytest marker

### DIFF
--- a/client/src/cbltest/plugins/required_topology.py
+++ b/client/src/cbltest/plugins/required_topology.py
@@ -8,6 +8,7 @@ _min_test_servers_key: Final[str] = "min_test_servers"
 _min_sync_gateways_key: Final[str] = "min_sync_gateways"
 _min_couchbase_servers_key: Final[str] = "min_couchbase_servers"
 _min_load_balancers_key: Final[str] = "min_load_balancers"
+_min_edge_servers_key: Final[str] = "min_edge_servers"
 
 # This plugin adds test markers to check that the required topology is present
 # in the TDK config file.  If not, the test will be skipped.
@@ -32,6 +33,10 @@ def pytest_configure(config: pytest.Config) -> None:
         "markers",
         f"{_min_load_balancers_key}(min): Require at least `min` load balancers to be available",
     )
+    config.addinivalue_line(
+        "markers",
+        f"{_min_edge_servers_key}(min): Require at least `min` edge servers to be available",
+    )
 
 
 # This is run before each test to determine if there are enough backend
@@ -41,12 +46,14 @@ def pytest_runtest_setup(item: pytest.Item):
     min_sync_gateways_mark = item.get_closest_marker(_min_sync_gateways_key)
     min_couchbase_servers_mark = item.get_closest_marker(_min_couchbase_servers_key)
     min_load_balancers_mark = item.get_closest_marker(_min_load_balancers_key)
+    min_edge_servers_mark = item.get_closest_marker(_min_edge_servers_key)
 
     if (
         min_test_servers_mark is None
         and min_sync_gateways_mark is None
         and min_couchbase_servers_mark is None
         and min_load_balancers_mark is None
+        and min_edge_servers_mark is None
     ):
         return
 
@@ -73,3 +80,4 @@ def pytest_runtest_setup(item: pytest.Item):
     check(min_sync_gateways_mark, config.sync_gateways, "Sync Gateways")
     check(min_couchbase_servers_mark, config.couchbase_servers, "Couchbase Servers")
     check(min_load_balancers_mark, config.load_balancers, "Load Balancers")
+    check(min_edge_servers_mark, config.edge_servers, "Edge Servers")

--- a/tests/QE/edge_server/test_authentication.py
+++ b/tests/QE/edge_server/test_authentication.py
@@ -7,6 +7,7 @@ from cbltest.api.cbltestclass import CBLTestClass
 SCRIPT_DIR = str(Path(__file__).parent)
 
 
+@pytest.mark.min_edge_servers(1)
 class TestAuthentication(CBLTestClass):
     @pytest.mark.asyncio(loop_scope="session")
     async def test_basic_auth(self, cblpytest: CBLPyTest) -> None:

--- a/tests/QE/edge_server/test_blobs.py
+++ b/tests/QE/edge_server/test_blobs.py
@@ -11,6 +11,7 @@ from cbltest.api.syncgateway import PutDatabasePayload
 SCRIPT_DIR = str(Path(__file__).parent)
 
 
+@pytest.mark.min_edge_servers(1)
 class TestBlobs(CBLTestClass):
     @pytest.mark.asyncio(loop_scope="session")
     async def test_blobs_create_delete(

--- a/tests/QE/edge_server/test_changes_feed.py
+++ b/tests/QE/edge_server/test_changes_feed.py
@@ -10,6 +10,7 @@ from cbltest.api.syncgateway import PutDatabasePayload
 SCRIPT_DIR = str(Path(__file__).parent)
 
 
+@pytest.mark.min_edge_servers(1)
 class TestChangesFeed(CBLTestClass):
     @pytest.mark.asyncio(loop_scope="session")
     async def test_changes_feed_longpoll(

--- a/tests/QE/edge_server/test_chaos_scenarios.py
+++ b/tests/QE/edge_server/test_chaos_scenarios.py
@@ -11,6 +11,7 @@ from cbltest.api.json_generator import JSONGenerator
 SCRIPT_DIR = str(Path(__file__).parent)
 
 
+@pytest.mark.min_edge_servers(1)
 class TestEdgeServerChaos(CBLTestClass):
     @pytest.mark.asyncio(loop_scope="session")
     async def test_kill_sgw_mid_replication(self, cblpytest, dataset_path) -> None:
@@ -153,6 +154,7 @@ class TestEdgeServerChaos(CBLTestClass):
         self.mark_test_step("Edge servers replication verified")
         return update_docs
 
+    @pytest.mark.min_edge_servers(3)
     @pytest.mark.asyncio(loop_scope="session")
     async def test_3_edge_with_sync(self, cblpytest, dataset_path) -> None:
         self.mark_test_step("test_3_edge_with_sync")

--- a/tests/QE/edge_server/test_crud.py
+++ b/tests/QE/edge_server/test_crud.py
@@ -8,6 +8,7 @@ from cbltest.api.cbltestclass import CBLTestClass
 SCRIPT_DIR = str(Path(__file__).parent)
 
 
+@pytest.mark.min_edge_servers(1)
 class TestCrud(CBLTestClass):
     @pytest.mark.asyncio(loop_scope="session")
     async def test_basic_information_retrieval(

--- a/tests/QE/edge_server/test_database_edge_server.py
+++ b/tests/QE/edge_server/test_database_edge_server.py
@@ -8,6 +8,7 @@ from cbltest.api.cbltestclass import CBLTestClass
 SCRIPT_DIR = str(Path(__file__).parent)
 
 
+@pytest.mark.min_edge_servers(1)
 class TestDatabase(CBLTestClass):
     @pytest.mark.asyncio(loop_scope="session")
     async def test_edge_server_incorrect_db_config(

--- a/tests/QE/edge_server/test_logging.py
+++ b/tests/QE/edge_server/test_logging.py
@@ -71,6 +71,7 @@ AUDIT_CONFIG_APPLIERS: dict[str, Callable[[dict], None]] = {
 }
 
 
+@pytest.mark.min_edge_servers(1)
 class TestLogging(CBLTestClass):
     @pytest.mark.asyncio(loop_scope="session")
     @pytest.mark.parametrize("audit_mode", ["default", "disabled", "enabled"])

--- a/tests/QE/edge_server/test_query_edge_server.py
+++ b/tests/QE/edge_server/test_query_edge_server.py
@@ -10,6 +10,7 @@ from deepdiff import DeepDiff
 SCRIPT_DIR = str(Path(__file__).parent)
 
 
+@pytest.mark.min_edge_servers(1)
 class TestQueryEdgeServer(CBLTestClass):
     @pytest.mark.asyncio(loop_scope="session")
     async def test_named_queries(

--- a/tests/QE/edge_server/test_replication_edge_server.py
+++ b/tests/QE/edge_server/test_replication_edge_server.py
@@ -9,6 +9,7 @@ from cbltest.api.cbltestclass import CBLTestClass
 SCRIPT_DIR = str(Path(__file__).parent)
 
 
+@pytest.mark.min_edge_servers(1)
 class TestEdgeServerSync(CBLTestClass):
     @pytest.mark.asyncio(loop_scope="session")
     async def test_edge_to_sgw_replication(
@@ -105,6 +106,7 @@ class TestEdgeServerSync(CBLTestClass):
         assert failed, f"Document not purged on Edge server {edge_doc}"
         await edge_server.stop_replication(1)
 
+    @pytest.mark.min_edge_servers(2)
     @pytest.mark.asyncio(loop_scope="session")
     async def test_edge_to_edge_replication(
         self, cblpytest: CBLPyTest, dataset_path: Path

--- a/tests/QE/edge_server/test_replication_sanity.py
+++ b/tests/QE/edge_server/test_replication_sanity.py
@@ -15,6 +15,7 @@ from cbltest.api.syncgateway import PutDatabasePayload
 SCRIPT_DIR = str(Path(__file__).parent)
 
 
+@pytest.mark.min_edge_servers(1)
 class TestReplicationSanity(CBLTestClass):
     @pytest.mark.asyncio(loop_scope="session")
     async def test_replication_sanity(

--- a/tests/QE/edge_server/test_system.py
+++ b/tests/QE/edge_server/test_system.py
@@ -33,6 +33,7 @@ def _updated_doc_body(doc_id: str) -> dict[str, Any]:
     }
 
 
+@pytest.mark.min_edge_servers(1)
 class TestSystem(CBLTestClass):
     async def _setup_system_test(self, cblpytest: CBLPyTest):
         """Create bucket, 10 docs, Sync Gateway db, Edge Server db; verify 10 docs on both.

--- a/tests/QE/edge_server/test_ttl_expires.py
+++ b/tests/QE/edge_server/test_ttl_expires.py
@@ -11,6 +11,7 @@ from cbltest.api.error import CblEdgeServerBadResponseError
 SCRIPT_DIR = str(Path(__file__).parent)
 
 
+@pytest.mark.min_edge_servers(1)
 class TestTTLExpires(CBLTestClass):
     @pytest.mark.asyncio(loop_scope="session")
     async def test_ttl_5s(self, cblpytest: CBLPyTest, dataset_path: Path) -> None:


### PR DESCRIPTION
Adds a min_edge_servers topology marker, mirroring the existing min_test_servers/min_sync_gateways/min_couchbase_servers/min_load_balancers markers.