### PR TITLE
Avoid reparsing config in test fixtures

### DIFF
--- a/client/AGENTS.md
+++ b/client/AGENTS.md
@@ -81,15 +81,14 @@ client/
 ### `CBLPyTest` — the entry point
 
 ```python
-cblpytest = await CBLPyTest.create(config_path, ...)
+cblpytest = await CBLPyTest.create(parsed_config, ...)
 ```
 
-It:
-1. Parses the JSON config → `ParsedConfig`
-2. Creates a `RequestFactory` (HTTP transport)
-3. Creates `TestServer[]`, `SyncGateway[]`, `CouchbaseServer[]`, `EdgeServer[]`, `LoadBalancer[]`
-4. Resolves the API version — queries every test server, requires consensus
-5. Starts a session on each test server
+Takes an already-parsed `ParsedConfig` (the `cblpytest` pytest fixture parses the `--config` JSON once in `pytest_configure` and stashes it on `pytest.Config`; see `plugins/cblpytest_fixture.py`). It:
+1. Creates a `RequestFactory` (HTTP transport)
+2. Creates `TestServer[]`, `SyncGateway[]`, `CouchbaseServer[]`, `EdgeServer[]`, `LoadBalancer[]`
+3. Resolves the API version — queries every test server, requires consensus
+4. Starts a session on each test server
 
 Exposed properties: `.request_factory`, `.test_servers`, `.sync_gateways`, `.couchbase_servers`, `.edge_servers`, `.load_balancers`, `.config`, `.log_level`, `.extra_props`.
 

--- a/client/src/cbltest/__init__.py
+++ b/client/src/cbltest/__init__.py
@@ -7,14 +7,12 @@ from .api.couchbaseserver import CouchbaseServer
 from .api.edgeserver import EdgeServer
 from .api.syncgateway import SyncGateway
 from .api.testserver import TestServer
-from .assertions import _assert_not_null
 from .configparser import (
     CouchbaseServerInfo,
     EdgeServerInfo,
     ParsedConfig,
     SyncGatewayInfo,
     TestServerInfo,
-    _parse_config,
 )
 from .extrapropsparser import _parse_extra_props
 from .globals import CBLPyTestGlobal
@@ -31,7 +29,7 @@ class CBLPyTest:
 
     @property
     def config(self) -> ParsedConfig:
-        """Gets the config as parsed from the provided JSON file path"""
+        """Gets the config that was provided"""
         return self.__config
 
     @property
@@ -76,14 +74,14 @@ class CBLPyTest:
 
     @staticmethod
     async def create(
-        config_path: str,
+        config: ParsedConfig,
         log_level: LogLevel = LogLevel.VERBOSE,
         extra_props_path: str | None = None,
         test_server_only: bool = False,
         dataset_version: str = "4.0",
     ):
         ret_val = CBLPyTest(
-            config_path, log_level, extra_props_path, test_server_only, dataset_version
+            config, log_level, extra_props_path, test_server_only, dataset_version
         )
         if not ret_val.extra_props.get("auto_start_tdk_page", True):
             CBLPyTestGlobal.auto_start_tdk_page = False
@@ -105,14 +103,13 @@ class CBLPyTest:
 
     def __init__(
         self,
-        config_path: str,
+        config: ParsedConfig,
         log_level: LogLevel = LogLevel.VERBOSE,
         extra_props_path: str | None = None,
         test_server_only: bool = False,
         dataset_version: str = "4.0",
     ):
-        _assert_not_null(config_path, "config_path")
-        self.__config = _parse_config(config_path)
+        self.__config = config
         self.__log_level = LogLevel(log_level)
         cbl_setLogLevel(self.__log_level)
         self.__extra_props = {}

--- a/client/src/cbltest/plugins/cblpytest_fixture.py
+++ b/client/src/cbltest/plugins/cblpytest_fixture.py
@@ -1,6 +1,9 @@
+from typing import Final, cast
+
 import pytest
 import pytest_asyncio
 from cbltest import CBLPyTest
+from cbltest.configparser import ParsedConfig, _parse_config
 from opentelemetry import trace
 from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
 from opentelemetry.sdk.resources import SERVICE_NAME, Resource
@@ -11,10 +14,13 @@ from opentelemetry.sdk.trace.export import BatchSpanProcessor
 # It will make a fixture available called "cblpytest" which can
 # be used as an argument to any test that has the TDK installed.
 
+# Other plugins that need the parsed TDK config can read from item.config.stash or request.node.stash.
+parsed_config_key: Final[pytest.StashKey[ParsedConfig]] = pytest.StashKey()
+
 
 @pytest_asyncio.fixture(scope="session")
 async def cblpytest(request: pytest.FixtureRequest):
-    config = request.config.getoption("--config")
+    config = request.config.stash[parsed_config_key]
     log_level = request.config.getoption("--cbl-log-level")
     test_props = request.config.getoption("--test-props")
     otel_endpoint = request.config.getoption("--otel-endpoint")
@@ -73,3 +79,14 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         help="The default dataset version to use for test servers",
         default="4.0",
     )
+
+
+# Parse the TDK config file once up front and stash it on the pytest Config, so that other plugins (and pytest_runtest_setup hooks) can use this.
+def pytest_configure(config: pytest.Config) -> None:
+    config_path_raw = config.getoption("--config")
+    if config_path_raw is None or not isinstance(config_path_raw, str):
+        raise pytest.UsageError(
+            "Unable to get --config option in cblpytest_fixture plugin"
+        )
+
+    config.stash[parsed_config_key] = _parse_config(cast(str, config_path_raw))

--- a/client/src/cbltest/plugins/cblpytest_fixture.py
+++ b/client/src/cbltest/plugins/cblpytest_fixture.py
@@ -14,7 +14,7 @@ from opentelemetry.sdk.trace.export import BatchSpanProcessor
 # It will make a fixture available called "cblpytest" which can
 # be used as an argument to any test that has the TDK installed.
 
-# Other plugins that need the parsed TDK config can read from item.config.stash or request.node.stash.
+# Other plugins that need the parsed TDK config can read from request.config.stash or item.config.stash.
 parsed_config_key: Final[pytest.StashKey[ParsedConfig]] = pytest.StashKey()
 
 

--- a/client/src/cbltest/plugins/required_topology.py
+++ b/client/src/cbltest/plugins/required_topology.py
@@ -1,8 +1,8 @@
-from typing import Final, cast
+from typing import Final
 
 import pytest
-from cbltest.configparser import _parse_config
-from cbltest.logging import cbl_info, cbl_warning
+from cbltest.logging import cbl_info
+from cbltest.plugins.cblpytest_fixture import parsed_config_key
 
 _min_test_servers_key: Final[str] = "min_test_servers"
 _min_sync_gateways_key: Final[str] = "min_sync_gateways"
@@ -50,10 +50,7 @@ def pytest_runtest_setup(item: pytest.Item):
     ):
         return
 
-    config_path_raw = item.config.getoption("--config")
-    if config_path_raw is None or not isinstance(config_path_raw, str):
-        cbl_warning("Unable to get config option in required_topology plugin")
-        return  # Don't fail the test, just don't do validation
+    config = item.config.stash[parsed_config_key]
 
     def check(mark: pytest.Mark | None, value: list, desc: str) -> None:
         if mark is None:
@@ -65,9 +62,6 @@ def pytest_runtest_setup(item: pytest.Item):
                 f"Test requires at least {minimum} {desc}, but only {len(value)} are available."
             )
             pytest.skip(f"Insufficient {desc}")
-
-    config_path = cast(str, config_path_raw)
-    config = _parse_config(config_path)
 
     check(min_test_servers_mark, config.test_servers, "Test Servers")
     check(min_sync_gateways_mark, config.sync_gateways, "Sync Gateways")


### PR DESCRIPTION
Inspired by https://github.com/couchbaselabs/couchbase-lite-tests/pull/434 , use pytest.Stash feature to store a parsed config object in one place.

This can then be accessed by fixtures `request.config.stash` or `item.config.stash` and avoids parsing that file everytime, as well as duplicated parsing logic. See https://docs.pytest.org/en/stable/how-to/writing_hook_functions.html#storing-data-on-items-across-hook-functions

I'm not committed to this PR if you think it is less readable.