### PR TITLE
CBG-5575 modify test_CBL_SG_replication_with_rev_messages to not use * channel

### DIFF
--- a/client/src/cbltest/api/syncgateway.py
+++ b/client/src/cbltest/api/syncgateway.py
@@ -1425,6 +1425,15 @@ class _SyncGatewayBase:
         ):
             return await self._send_request("GET", f"/{db_name}/_config")
 
+    async def is_using_views(self, db_name: str) -> bool:
+        """
+        Determines whether the given Sync Gateway database is using views rather than GSI.
+
+        :param db_name: The name of the database to check
+        """
+        config = await self.get_database_config(db_name)
+        return not config.get("enable_shared_bucket_access", True)
+
     async def get_document_revision_public(
         self,
         db_name: str,

--- a/client/src/cbltest/api/syncgateway.py
+++ b/client/src/cbltest/api/syncgateway.py
@@ -1426,10 +1426,13 @@ class _SyncGatewayBase:
             return await self._send_request("GET", f"/{db_name}/_config")
 
     async def is_using_views(self, db_name: str) -> bool:
-        """
-        Determines whether the given Sync Gateway database is using views rather than GSI.
+        """Determine whether the given Sync Gateway database is using views rather than GSI.
 
-        :param db_name: The name of the database to check
+        Args:
+            db_name: The name of the database to check.
+
+        Returns:
+            True if the database is configured with enable_shared_bucket_access=false.
         """
         config = await self.get_database_config(db_name)
         return not config.get("enable_shared_bucket_access", True)

--- a/dataset/sg/short_expiry-sg.json
+++ b/dataset/sg/short_expiry-sg.json
@@ -1,1 +1,1 @@
-{"_id": "doc1", "scope": "_default", "collection": "_default", "channels": ["*"], "type": "test", "value": "This is a test document for short_expiry dataset."} 
+{"_id": "doc1", "scope": "_default", "collection": "_default", "channels": ["ChannelA"], "type": "test", "value": "This is a test document for short_expiry dataset."}

--- a/spec/tests/QE/test_replication_functional.md
+++ b/spec/tests/QE/test_replication_functional.md
@@ -40,7 +40,7 @@ Test replication behavior with role-based access control.
 
 Test replication behavior with revision messages and document purging.
 
-Parametrized over `channel`: `*` (wildcard) and `A` (an explicit channel name),
+Parametrized over `channel`: `*` (wildcard) and `ChannelA` (an explicit channel name),
 used as the `channels` value on every document created in this test. Both
 variants are otherwise identical — user1 keeps its default dataset-configured
 `*` access in both cases. When `channel` is `*` and Sync Gateway is configured

--- a/spec/tests/QE/test_replication_functional.md
+++ b/spec/tests/QE/test_replication_functional.md
@@ -40,6 +40,16 @@ Test replication behavior with role-based access control.
 
 Test replication behavior with revision messages and document purging.
 
+Parametrized over `channel`: `*` (wildcard) and `A` (an explicit channel name),
+used as the `channels` value on every document created in this test. Both
+variants are otherwise identical — user1 keeps its default dataset-configured
+`*` access in both cases. When `channel` is `*` and Sync Gateway is configured
+to use views (i.e. `enable_shared_bucket_access` is disabled), the "Verify
+replication completed successfully" step is skipped: checking the progress on
+documents explicitly assigned the `*` channel will show `completed: false`
+instead of `true` when running with views. There are no other non progress
+side effects. See CBG-5573 and CBL-8624.
+
 1. Reset SG and load `short_expiry` dataset.
 2. Reset local database.
 3. Create initial document in CBL.
@@ -67,7 +77,7 @@ Test replication behavior with revision messages and document purging.
     * continuous: false
     * credentials: user1/pass
 16. Wait for pull replication to finish.
-17. Verify replication completed successfully.
+17. Verify replication completed successfully (skipped for `channel` `*` on views — see above).
 18. Verify all docs from SGW replicated successfully:
     * Should have: doc1 (from dataset), doc_2, doc_3 (created docs)
     * Should NOT have: doc_1 (purged document)

--- a/tests/QE/test_replication_functional.py
+++ b/tests/QE/test_replication_functional.py
@@ -321,7 +321,7 @@ class TestReplicationFunctional(CBLTestClass):
         await cblpytest.test_servers[0].cleanup()
 
     @pytest.mark.asyncio(loop_scope="session")
-    @pytest.mark.parametrize("channel", ["*", "A"])
+    @pytest.mark.parametrize("channel", ["*", "ChannelA"])
     async def test_CBL_SG_replication_with_rev_messages(
         self, cblpytest: CBLPyTest, dataset_path: Path, channel: str
     ):

--- a/tests/QE/test_replication_functional.py
+++ b/tests/QE/test_replication_functional.py
@@ -321,8 +321,9 @@ class TestReplicationFunctional(CBLTestClass):
         await cblpytest.test_servers[0].cleanup()
 
     @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.parametrize("channel", ["*", "A"])
     async def test_CBL_SG_replication_with_rev_messages(
-        self, cblpytest: CBLPyTest, dataset_path: Path
+        self, cblpytest: CBLPyTest, dataset_path: Path, channel: str
     ):
         self.mark_test_step("Reset SG and load `short_expiry` dataset.")
         cloud = cblpytest.simple_cloud()
@@ -340,7 +341,7 @@ class TestReplicationFunctional(CBLTestClass):
                     {
                         "type": "test_doc",
                         "content": "This is the first document that will be purged",
-                        "channels": ["*"],
+                        "channels": [channel],
                         "created_in": "CBL",
                     }
                 ],
@@ -402,7 +403,7 @@ class TestReplicationFunctional(CBLTestClass):
                     {
                         "type": "flush_doc",
                         "content": "This document will help flush doc_1 from rev cache",
-                        "channels": ["*"],
+                        "channels": [channel],
                         "created_in": "CBL",
                     }
                 ],
@@ -414,7 +415,7 @@ class TestReplicationFunctional(CBLTestClass):
                     {
                         "type": "flush_doc",
                         "content": "This document will also help flush doc_1 from rev cache",
-                        "channels": ["*"],
+                        "channels": [channel],
                         "created_in": "CBL",
                     }
                 ],
@@ -477,9 +478,15 @@ class TestReplicationFunctional(CBLTestClass):
         )
 
         self.mark_test_step("Verify replication completed successfully")
-        assert status.progress.completed is True, (
-            f"Replication status should be `completed`, but got ={status.progress.completed}"
-        )
+        if channel == "*" and await cloud.sync_gateway.is_using_views("short_expiry"):
+            # Checking the progress on documents explicitly assigned * channel will
+            # show completed: false instead of true when running with views. There
+            # are no other non progress side effects. See CBG-5573 and CBL-8624.
+            pass
+        else:
+            assert status.progress.completed is True, (
+                f"Replication status should be `completed`, but got ={status.progress.completed}"
+            )
 
         self.mark_test_step("""
             Verify all docs from SGW replicated successfully:

--- a/tests/QE/test_replication_multiple_clients.py
+++ b/tests/QE/test_replication_multiple_clients.py
@@ -91,7 +91,7 @@ class TestReplicationMultipleClients(CBLTestClass):
                             "type": "client_doc",
                             "source": "db1",
                             "index": i,
-                            "channels": ["*"],
+                            "channels": ["chan1"],
                         }
                     ],
                 )
@@ -110,7 +110,7 @@ class TestReplicationMultipleClients(CBLTestClass):
                             "type": "client_doc",
                             "source": "db2",
                             "index": i,
-                            "channels": ["*"],
+                            "channels": ["chan1"],
                         }
                     ],
                 )


### PR DESCRIPTION
CBG-5575 modify test_CBL_SG_replication_with_rev_messages to not use * channel

Adding document to * channel explicitly using the sync function exposes two minor bugs when running under views:

1. CBG-5574 Sync Gateway will send duplicate notifications for this change in the changes message.
2. CBL-8624 Couchbase Lite will handle the duplicate rows, but the progress will not be marked as completed.

Since this did catch a real bug, parameterize the test to use a non star channel name and skip the assertion that is flaky as of Sync Gateway and Couchbase Lite 4.1.0.

To protect against further issues of this kind, change code to avoid using `*` channel. This is an anti pattern for users, and for the most part testing against this is going to exercise different code pathways (all docs channel vs channel index, if using GSI).