### PR TITLE
Add comprehensive documentation for newcomers and clarify architecture

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,9 +129,9 @@ AWS orchestrator scripts run from the root workspace — there is **no** separat
 
 ## Recurring Patterns (Know Before Editing)
 
-1. **Jenkins per-platform `setup_test.py`** — every file under `jenkins/pipelines/{dev_e2e,QE}/{platform}/` is a thin click wrapper calling `setup_test(...)` from `jenkins/pipelines/shared/`. Only `platform_name`, `topology_file`, and `config_file` differ.
+1. **Jenkins per-platform `setup_test.py`** — most files under `jenkins/pipelines/{dev_e2e,QE}/{platform}/` are thin click wrappers calling `setup_test(...)` from `jenkins/pipelines/shared/`, differing only in `platform_name`, `topology_file`, and `config_file`. Exceptions: `QE/es` and `QE/multiplatform` don't use the shared wrapper — they call `environment.aws.start_backend.script_entry` directly.
 2. **`conftest.py` `dataset_path` fixtures** — three near-identical copies in `tests/dev_e2e/`, `tests/QE/`, `client/smoke_tests/` differing only in relative depth to `dataset/sg/`.
-3. **Server build scripts** — every platform under `servers/` follows: `download_cbl.sh` → `build_*.sh` → package.
+3. **Server build scripts** — the `download_cbl.sh` → `build_*.sh` → package chain applies to the `c` and `ios` platforms; `dotnet` only has `build_cli.sh`/`.ps1`, `jak` builds via Gradle, and `javascript` via `npm`.
 4. **AWS setup scripts** — every `environment/aws/*_setup/setup_*.py` follows: SSH via `paramiko` → SFTP upload → `remote_exec` → start service (Docker / systemd).
 
 ## CI/CD

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ System-level test harness for Couchbase Lite releases across all supported platf
 | Path             | Contents                                                                                  | Sub-doc                                     |
 |------------------|-------------------------------------------------------------------------------------------|---------------------------------------------|
 | `client/`        | `cbltest` Python framework, pytest plugins, request/response API                          | [client/AGENTS.md](client/AGENTS.md)        |
-| `tests/`         | `dev_e2e/` (12 test modules + 1 data helper) and `QE/` (20 tests + 12 edge-server tests)  | [tests/AGENTS.md](tests/AGENTS.md)          |
+| `tests/`         | `dev_e2e/` (developer E2E tests) and `QE/` (QA suite + an edge-server sub-suite)          | [tests/AGENTS.md](tests/AGENTS.md)          |
 | `servers/`       | Per-platform test servers: `c/`, `dotnet/`, `ios/`, `jak/`, `javascript/`                 | [servers/AGENTS.md](servers/AGENTS.md)      |
 | `environment/`   | `aws/` (Terraform + orchestrator), `docker/`, `LogSlurp/`, `otel-collector/`              | [environment/AGENTS.md](environment/AGENTS.md) |
 | `jenkins/`       | CI/CD pipelines under `pipelines/{dev_e2e,QE}/{platform}/`                                | [jenkins/AGENTS.md](jenkins/AGENTS.md)      |

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,8 +1,71 @@
-# Couchbase Lite System Test Harness
+# Couchbase Lite System Test Harness (TDK)
 
-Glossary of terms whose meaning in this repo differs from their common usage.
-This file is a glossary only — no implementation details, no decisions (those
-live in `docs/adr/`).
+The system that drives per-platform Couchbase Lite test servers against a
+Sync Gateway + Couchbase Server backend to verify a Couchbase Lite release.
+This glossary fixes the words newcomers most often confuse. It is a glossary
+only — no implementation details, no decisions (those live in `docs/adr/`).
+
+## Language
+
+### The three things that sound like "server"
+
+Never write bare "server" in docs — it collides three ways. Always disambiguate:
+
+**Test Server**:
+The per-platform executable (C, .NET, iOS, JVM, JS) that hosts a Couchbase
+Lite instance and runs operations on command from the Client. Always two
+words. Built against a specific CBL SDK version: from `release/X.Y` for
+shipped version lines, from `main` for the current line.
+_Avoid_: server, test-server, CBL server
+
+**Sync Gateway (SGW)**:
+The sync and access layer between Couchbase Lite and Couchbase Server. Part of
+the Backend.
+_Avoid_: gateway, sg
+
+**Couchbase Server (CBS)**:
+The backend database behind Sync Gateway. Part of the Backend.
+_Avoid_: server, couchbase, cb server
+
+**Backend**:
+Sync Gateway + Couchbase Server together — the cloud side a Test Server
+replicates against. Provisioned on AWS for CI.
+_Avoid_: cloud, environment, infra
+
+### Driving the tests
+
+**Client (TDK)**:
+The Python framework (`cbltest`) that configures the Backend, instructs Test
+Servers, and reports results. It is the orchestrator, not a Couchbase Lite
+client app.
+_Avoid_: harness, framework, driver, app
+
+**Test**:
+A Python codelet (pytest function) run inside the Client that configures a
+Backend and instructs Test Servers. Distinct from the operations a Test Server
+performs on its behalf.
+_Avoid_: test case, scenario
+
+### What runs where
+
+**Topology**:
+A declarative description of the shape to provision — which Test Servers (and
+platforms/versions), how many SGW/CBS, how they wire together. The request you
+hand the Orchestrator.
+_Avoid_: layout, setup, environment spec
+
+**Config (config.json)**:
+The contract pytest consumes: where everything actually lives (Test Server
+URLs, SGW/CBS hostnames). The single source of truth for a run. Usually
+generated from a Topology + real IPs by the Orchestrator, but can be written by
+hand for a custom environment — generation is just the least-friction path.
+_Avoid_: settings, test config
+
+**Orchestrator**:
+The tooling under `environment/aws/` that takes a Topology, provisions the
+Backend and Test Servers, and emits a Config. One way to produce a Config, not
+the only possible one.
+_Avoid_: provisioner, deployer
 
 ## Branching
 
@@ -21,8 +84,3 @@ for the current/in-development CBL version line.
 A Couchbase Lite `major.minor` series (e.g. `3.2`, `4.0`) whose SDK shares a
 compatible API surface. Each line maps to at most one `release/X.Y` branch.
 _Avoid_: release, version (unqualified).
-
-**test server**:
-A per-platform binary built against a specific CBL SDK version and driven by the
-Python test suite. Built from `release/X.Y` for shipped lines, from `main` for the
-current line.

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -11,17 +11,17 @@ in doubt about a word, that glossary is the source of truth.
 
 Three roles, and the thing that ties them together:
 
-```
-   ┌────────────────────┐        instructs        ┌──────────────────────────┐
-   │   Client (TDK)      │ ──────────────────────▶ │      Test Servers        │
-   │  Python `cbltest`   │                         │  C │ .NET │ iOS │ JVM │ JS │
-   │  runs the Tests     │                         │ (one per CBL platform)   │
-   └─────────┬───────────┘                         └────────────┬─────────────┘
-             │ configures                                        │ replicates against
-             ▼                                                   ▼
-        ┌──────────────────────────── Backend ────────────────────────────┐
-        │   Sync Gateway (SGW)   ◀────────────▶   Couchbase Server (CBS)   │
-        └──────────────────────────────────────────────────────────────────┘
+```mermaid
+flowchart TD
+    Client["Client (TDK) Python 'cbltest' runs the Tests"] ==>|instructs| Platforms["Test Servers (one per CBL platform)  |  C  |  .NET  |  iOS  |  JVM  |  JS"]
+
+    subgraph Backend ["Backend"]
+        direction LR
+        SGW["Sync Gateway (SGW)"] <==> CBS["Couchbase Server (CBS)"]
+    end
+
+    Client ==>|configures| SGW
+    Platforms ==>|replicates against| CBS
 ```
 
 - The **Client** (the Python `cbltest` framework) is the brain. It runs the
@@ -72,9 +72,16 @@ first. Full prerequisites and details live in
 2. **Provision the Backend + Test Servers** from a Topology:
    ```bash
    cd environment/aws
-   uv run python start_backend.py --topology topology_setup/topology.json
+   uv run python start_backend.py \
+     --topology topology_setup/topology.json \
+     --tdk-config-in <template.json> \
+     --tdk-config-out config.json
    ```
-   This emits a `config.json` into the test suite directory.
+   `--tdk-config-in` is a required template (schema + `api-version`; see
+   `client/smoke_tests/config_in.json`) that gets the real hostnames the
+   Orchestrator provisioned merged into it. `--tdk-config-out` is optional —
+   without it the resulting `config.json` is written to stdout instead of a
+   file.
 3. **Run the Tests** against that config:
    ```bash
    cd tests/dev_e2e
@@ -121,7 +128,7 @@ Run a single Test against an existing `config.json`:
 
 ```bash
 cd tests/dev_e2e
-uv run pytest -x -v --config config.json test_basic_replication.py::TestBasicReplication::test_push_pull
+uv run pytest -x -v --config config.json test_basic_replication.py::TestBasicReplication::test_push_and_pull
 ```
 
 Start here:

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -1,0 +1,148 @@
+# Onboarding
+
+This repo is large, but the shape is simple once the vocabulary clicks. Most
+newcomer confusion is *conceptual*, not mechanical — so start here, not with
+the build scripts.
+
+Terms in **bold** below are defined precisely in [CONTEXT.md](CONTEXT.md). When
+in doubt about a word, that glossary is the source of truth.
+
+## The mental model
+
+Three roles, and the thing that ties them together:
+
+```
+   ┌────────────────────┐        instructs        ┌──────────────────────────┐
+   │   Client (TDK)      │ ──────────────────────▶ │      Test Servers        │
+   │  Python `cbltest`   │                         │  C │ .NET │ iOS │ JVM │ JS │
+   │  runs the Tests     │                         │ (one per CBL platform)   │
+   └─────────┬───────────┘                         └────────────┬─────────────┘
+             │ configures                                        │ replicates against
+             ▼                                                   ▼
+        ┌──────────────────────────── Backend ────────────────────────────┐
+        │   Sync Gateway (SGW)   ◀────────────▶   Couchbase Server (CBS)   │
+        └──────────────────────────────────────────────────────────────────┘
+```
+
+- The **Client** (the Python `cbltest` framework) is the brain. It runs the
+  **Tests**, configures the **Backend**, and tells the **Test Servers** what to
+  do. It is *not* a Couchbase Lite client app.
+- A **Test Server** is a per-platform executable hosting one Couchbase Lite
+  instance. The Client drives it; it does the actual CBL work. ("Test Server"
+  is always two words — bare "server" is ambiguous here, see below.)
+- The **Backend** is **Sync Gateway (SGW)** + **Couchbase Server (CBS)** — the
+  cloud side the Test Servers replicate against.
+
+> **The "server" trap:** three different things sound like "server" — the
+> **Test Server**, **Sync Gateway**, and **Couchbase Server**. They are not
+> interchangeable. The glossary bans the bare word for this reason.
+
+### Topology vs. config.json
+
+The other thing that trips people up: there are two JSON files and they are not
+the same.
+
+- A **Topology** describes the *shape you want provisioned* — which Test
+  Servers (platforms, CBL versions), how many SGW/CBS, how they wire up. It is
+  the **request** you hand the **Orchestrator**.
+- **config.json** describes *where everything actually is* — Test Server URLs,
+  SGW/CBS hostnames. It is the **contract pytest consumes**, and the single
+  source of truth for a run.
+
+config.json is normally **generated** from a Topology + the real IPs the
+Orchestrator provisioned — so **don't hand-edit a generated config.json**. That
+generation path is just the lowest-friction option, though: nothing stops you
+writing a config.json by hand for a custom environment, or building a different
+orchestrator entirely. config.json is the interface; the Topology/Orchestrator
+is one (blessed) way to produce it.
+
+## How a run actually happens (AWS)
+
+AWS is the canonical path — it's what CI uses and what you should reach for
+first. Full prerequisites and details live in
+[environment/aws/README.md](environment/aws/README.md).
+
+```
+ Topology JSON  ──▶  Orchestrator  ──▶  config.json  ──▶  pytest
+ (what to make)     (start_backend)    (where it is)     (the Tests)
+```
+
+1. **Authenticate:** `aws sso login` (see the orchestrator README for IAM
+   prerequisites).
+2. **Provision the Backend + Test Servers** from a Topology:
+   ```bash
+   cd environment/aws
+   uv run python start_backend.py --topology topology_setup/topology.json
+   ```
+   This emits a `config.json` into the test suite directory.
+3. **Run the Tests** against that config:
+   ```bash
+   cd tests/dev_e2e
+   uv run pytest -x -v --config config.json test_basic_replication.py
+   ```
+4. **Tear it down** when finished:
+   ```bash
+   cd environment/aws
+   uv run python stop_backend.py --topology topology_setup/topology.json
+   ```
+
+Starter Topology files for single-platform runs live in
+`jenkins/pipelines/dev_e2e/<platform>/topologies/` (e.g.
+`topology_single_macos.json`, `topology_single_ios.json`).
+
+## I own a Test Server
+
+You're responsible for one platform's Test Server under `servers/`. Each
+platform follows the same chain — `download_cbl` → `build_*` → package — but the
+toolchain differs (CMake for C, `dotnet` for .NET, Xcode for iOS, Gradle for
+JVM, Vite/npm for JS). Your starting points:
+
+- [servers/AGENTS.md](servers/AGENTS.md) — the per-platform build/run map.
+- `servers/<your-platform>/` — your build scripts and platform README.
+- In a Topology, your platform is named by a platform string (e.g. `c_macos`,
+  `swift_ios`) with `download: true` to fetch a prebuilt Test Server, or
+  `false`/omitted to build it. The prebuild Jenkins job builds and uploads these
+  artifacts.
+
+## I write Tests
+
+Tests are Python codelets run inside the Client. Anatomy:
+
+- Subclass `CBLTestClass`; decorate each test with
+  `@pytest.mark.asyncio(loop_scope="session")`.
+- Declare what the Test needs with topology markers:
+  `@pytest.mark.min_test_servers(1)`, `@pytest.mark.min_sync_gateways(1)`,
+  `@pytest.mark.min_couchbase_servers(1)`.
+- Use the `cblpytest` fixture (`.test_servers[]`, `.sync_gateways[]`,
+  `.couchbase_servers[]`, …) and the `dataset_path` fixture.
+- Call `self.mark_test_step("…")` to narrate steps in the logs.
+
+Run a single Test against an existing `config.json`:
+
+```bash
+cd tests/dev_e2e
+uv run pytest -x -v --config config.json test_basic_replication.py::TestBasicReplication::test_push_pull
+```
+
+Start here:
+[tests/AGENTS.md](tests/AGENTS.md) and [client/AGENTS.md](client/AGENTS.md).
+
+## Next steps & custom environments
+
+- **Repo-wide architecture:** [AGENTS.md](AGENTS.md) and
+  [docs/architecture.agents.md](docs/architecture.agents.md).
+- **Why is it built this way?** (per-platform Test Servers, a Python driver, a
+  versioned protocol) — [docs/adr/](docs/adr/).
+- **Custom / hand-rolled environment:** write your own `config.json` pointing at
+  whatever Test Servers + Backend you control, and run pytest against it. No
+  Orchestrator required.
+- **Custom Sync Gateway builds (niche):** if you're iterating on a local or
+  custom-built SGW, [environment/local/](environment/local/README.md) can run an
+  in-memory `rosmar` SGW or a build from source against a locally-launched Test
+  Server — e.g.
+  `uv run environment/local/run_sync_gateway.py --start --server rosmar`, then
+  `pytest --config environment/local/rosmar_config.json`. This is *not* the
+  supported path for normal test runs; reach for AWS instead.
+
+> The Docker environment under `environment/docker/` is **deprecated** — it may
+> still work but is unmaintained.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ system tests (tests requiring more than one device, e.g., a
 Couchbase Lite instance and a Sync Gateway) needed to verify
 a Couchbase Lite release.
 
+> **New here?** Start with [ONBOARDING.md](ONBOARDING.md) for the mental model
+> and your first run, and [CONTEXT.md](CONTEXT.md) for the vocabulary.
+
 The system consists of 4 components:
 
 * An environment, built with docker compose, that contains one Couchbase Server and one Sync Gateway.

--- a/docs/adr/0001-remote-per-platform-test-servers.md
+++ b/docs/adr/0001-remote-per-platform-test-servers.md
@@ -1,0 +1,40 @@
+# Per-platform Test Servers driven over a uniform remote API
+
+Couchbase Lite ships as an embedded SDK in many languages (C, .NET, Swift,
+Java/Kotlin, JavaScript) running on many OSes and real devices. There is no
+single process or language that can load every CBL variant, and system-level
+behavior (replication, P2P, on-device storage) only reproduces faithfully on
+the real platform. So instead of testing CBL in-process, we run a thin
+**Test Server** on each platform that hosts a real CBL instance and exposes a
+uniform remote API, and drive all of them from one external **Client**.
+
+The compelling reason to disconnect the driver this way is **coordination**: a
+single test run often spans multiple processes across multiple machines and real
+devices (e.g. several CBL peers replicating with each other and with a shared
+Backend). Driving them from one external Client lets a single test orchestrate
+that whole distributed cast in lockstep — something an in-process or
+single-device approach cannot do. A previous attempt used largely the same
+architecture; this iteration keeps it for the same reason.
+
+This is the root of the system's apparent complexity: the extra moving parts
+(per-platform servers, a remote protocol, network transport) buy us *one* test
+definition that coordinates *real* CBL across *every* platform and machine in a
+single run.
+
+## Considered Options
+
+- **Per-platform native test suites** (XCTest for iOS, JUnit for JVM, etc.) —
+  rejected: every scenario would be reimplemented N times and drift across
+  platforms; cross-platform scenarios (e.g. a Swift peer replicating with a
+  .NET peer) become impossible to express in a single platform's framework.
+- **In-process bindings into one driver language** — rejected: can't cover
+  real devices (iOS/Android) or the full platform matrix, masks
+  platform-specific behavior, and — decisively — can't coordinate multiple
+  independent peers/processes across machines in one run.
+
+## Consequences
+
+- A network protocol now sits between test logic and CBL — see
+  [ADR-0003](0003-versioned-test-server-api.md) for how it is versioned.
+- Most platforms need real hardware/VMs, which drives the multi-node provisioning
+  in `environment/aws/`.

--- a/docs/adr/0002-tests-authored-once-in-python.md
+++ b/docs/adr/0002-tests-authored-once-in-python.md
@@ -1,0 +1,25 @@
+# Tests authored once in Python, not per-platform
+
+Given per-platform Test Servers ([ADR-0001](0001-remote-per-platform-test-servers.md)),
+the test logic itself lives in one place: Python (`pytest` + `aiohttp`),
+in the `cbltest` Client. Each scenario is written once and runs against every
+platform's Test Server by sending the same sequence of remote commands. Python
+was chosen as the driver language because it was the language most familiar
+across both the development and QE departments at the time — the people who
+author and maintain the tests.
+
+## Considered Options
+
+- **Author tests in each platform's native language/framework** — rejected for
+  the divergence and duplication reasons in ADR-0001.
+- **A bespoke test DSL/config format** — rejected: a real programming language
+  with async, fixtures, and assertions is more expressive and lower-maintenance
+  than a custom runner.
+
+## Consequences
+
+- Test authors need only Python + the `cbltest` API, never the target
+  platform's toolchain.
+- The Client must speak a stable contract to servers written in five different
+  languages — hence the versioned API in
+  [ADR-0003](0003-versioned-test-server-api.md).

--- a/docs/adr/0003-versioned-test-server-api.md
+++ b/docs/adr/0003-versioned-test-server-api.md
@@ -1,0 +1,20 @@
+# Versioned request/response API between Client and Test Servers
+
+The Client drives Test Servers written in five languages, and a single Client
+must work against multiple Couchbase Lite releases at once (the matrix spans
+older and newer CBL builds). To keep these decoupled, the Client↔Test Server
+protocol is explicitly versioned: every request carries a `CBLTest-API-Version`
+header, and the Client implements each version side-by-side under
+`client/src/cbltest/v1/` and `v2/`, registered via `@register_request` /
+`@register_body`. `version.py::available_api_version()` is the source of truth.
+
+This lets a Test Server and the Client negotiate a common version at startup, so
+platforms can adopt a new API version on their own schedule without breaking the
+existing test matrix.
+
+## Consequences
+
+- Adding API surface means picking a version and registering request/response
+  bodies under the matching `vN/` package — not editing a shared monolith.
+- The OpenAPI spec in `spec/api/api.yaml` is the cross-language contract all
+  Test Server implementations target.

--- a/docs/adr/0003-versioned-test-server-api.md
+++ b/docs/adr/0003-versioned-test-server-api.md
@@ -3,8 +3,9 @@
 The Client drives Test Servers written in five languages, and a single Client
 must work against multiple Couchbase Lite releases at once (the matrix spans
 older and newer CBL builds). To keep these decoupled, the Client↔Test Server
-protocol is explicitly versioned: every request carries a `CBLTest-API-Version`
-header, and the Client implements each version side-by-side under
+protocol is explicitly versioned: every versioned request carries a
+`CBLTest-API-Version` header (the initial unversioned `GET /` handshake is the
+one exception), and the Client implements each version side-by-side under
 `client/src/cbltest/v1/` and `v2/`, registered via `@register_request` /
 `@register_body`. `version.py::available_api_version()` is the source of truth.
 

--- a/environment/aws/README.md
+++ b/environment/aws/README.md
@@ -134,39 +134,31 @@ These scripts are designed to be run either via `uv run`, or imported and called
 ### Starting
 
 ```
-usage: start_backend.py [-h] [--cbs-version CBS_VERSION] [--tdk-config-out TDK_CONFIG_OUT]
-                        [--topology TOPOLOGY] [--no-terraform-apply] [--no-cbs-provision] [--no-sgw-provision]
-                        [--no-ls-provision] [--no-ts-run] [--sgw-url SGW_URL]
-                        --tdk-config-in TDK_CONFIG_IN
+Usage: start_backend.py [OPTIONS]
 
-Prepare an AWS EC2 environment for running E2E tests
+  Prepare an AWS EC2 environment for running E2E tests.
 
-optional arguments:
-  -h, --help            show this help message and exit
-  --cbs-version CBS_VERSION
-                        The version of Couchbase Server to install.
-  --tdk-config-out TDK_CONFIG_OUT
-                        The path to the write the resulting TDK configuration file (stdout if empty)
-  --topology TOPOLOGY   The path to the topology configuration file
-  --no-terraform-apply  Skip terraform apply step
-  --no-cbs-provision    Skip Couchbase Server provisioning step
-  --no-sgw-provision    Skip Sync Gateway provisioning step
-  --no-ls-provision     Skip Logslurp provisioning step
-  --no-ts-run           Skip test server install and run step
-
-conditionally required arguments:
-  --sgw-url SGW_URL     The URL of Sync Gateway to install (required if using SGW)
-
-required arguments:
-  --tdk-config-in TDK_CONFIG_IN
-                        The path to the input TDK configuration file
+Options:
+  --topology TOPOLOGY    The path to the topology configuration file
+  --tdk-config-in PATH   The path to the input (template) TDK configuration file  [required]
+  --tdk-config-out PATH  The path to write the resulting TDK configuration file (stdout if empty)
+  --no-terraform-apply   Skip terraform apply step
+  --no-cbs-provision     Skip Couchbase Server provisioning step
+  --no-sgw-provision     Skip Sync Gateway provisioning step
+  --no-es-provision      Skip Edge Server provisioning step
+  --no-lb-provision      Skip load balancer provisioning step
+  --no-ls-provision      Skip LogSlurp provisioning step
+  --no-ts-run            Skip test server install and run step
+  --help                 Show this message and exit
 ```
 
-The Sync Gateway URL and Couchbase Server version properties should be self explanatory but the others are as follows:
+The main arguments are:
 
-- TDK config in: A template TDK compatible config file.
-- TDK config out: An optional file to write the resulting TDK config file to (otherwise it will go to stdout)
-- Topology is the toplogy JSON file that will describe how to set up AWS instances (see the [topology README](./topology_setup/README.md) for more information.)
+- TDK config in: A template TDK-compatible config file (required).
+- TDK config out: An optional file to write the resulting TDK config to (otherwise it goes to stdout).
+- Topology: The topology JSON file describing how to set up the AWS instances (see the [topology README](./topology_setup/README.md) for more information).
+
+> **Note:** Couchbase Server and Sync Gateway versions are no longer set on the command line. They now come from the topology file — `defaults.cbs.version` / `defaults.sgw.version`, or the per-cluster / per-gateway `version` fields. The `--no-*-provision` flags let you stand up only a subset of the environment.
 
 
 ### Stopping

--- a/environment/aws/README.md
+++ b/environment/aws/README.md
@@ -1,6 +1,6 @@
 # AWS Scripted Backend
 
-**TL;DR This is mostly supplemental information.  If you are looking for what you need to understand to use this system, skip to [Prerequisites](#step-0-prerequisites) and [Putting it all together](#putting-it-all-together)**
+**TL;DR This is mostly supplemental information.  If you are looking for what you need to understand to use this system, skip to [Prerequisites](#prerequisites) and [Putting it all together](#putting-it-all-together)**
 
 The way it works from a high level is as follows.  The starting point is an environment set up as in the following:
 
@@ -89,7 +89,7 @@ It's not enough to simply spin up virtual machines.  The creator (i.e. the perso
 
 "read" here means that there is a permanent resource created in the AWS account already.  "created" means that resources must be provisioned for a particular session.
 
-Creating and destroying these resources is as simple as running `terraform apply` and `terraform destroy` respectively.  You can add the following to avoid the console prompting you:  `-var=keyname=<keyname-from-step-0> -auto-approve`.  Other useful variables are `logslurp`, which is a bool indicating whether or not logslurp is needed, `sgw_count` which is the number of EC2 instances to create for SGW, and `server_count` which is the number of EC2 instances to create for Couchbase Server.  These default to `true`, `1`, and `1`.
+Creating and destroying these resources is as simple as running `terraform apply` and `terraform destroy` respectively.  You can add `-auto-approve` to avoid the console prompting you.  The SSH key pair is generated automatically by Terraform (`aws_key_pair.ec2`) — there is no `keyname` variable to set.  Other useful variables are `logslurp`, which is a bool indicating whether or not logslurp is needed, `sgw_count` which is the number of EC2 instances to create for SGW, and `server_count` which is the number of EC2 instances to create for Couchbase Server.  These default to `true`, `1`, and `1`.
 
 ## Deployment
 
@@ -101,8 +101,8 @@ Once the resources are in place, they need to have the appropriate software inst
 
 The rough set of steps for Couchbase Server is as follows:
 
-- Configure system (disable transparent huge pages and turn down swappiness as described in Couchbase docs)
-- Download and install Couchbase Server RPM
+- Configure system (install Docker, sudoers rules for the `couchbase-server` service, Caddy/shell2http)
+- Run Couchbase Server as a Docker container (`couchbase/server:enterprise-<version>`)
 - Configure node for use (init cluster, setup auth and users, etc)
 
 For Sync Gateway:
@@ -129,7 +129,7 @@ This scripted backend also builds / downloads test servers for deployment to var
 
 Starting and stopping the system has dedicated python scripts.
 
-These scripts are designed to be run either via `uv run`, or imported and called from another python script if desired.  If you skipped here from the beginning, be sure to review the [Prerequisites](#step-0-prerequisites).
+These scripts are designed to be run either via `uv run`, or imported and called from another python script if desired.  If you skipped here from the beginning, be sure to review the [Prerequisites](#prerequisites).
 
 ### Starting
 
@@ -164,13 +164,22 @@ The main arguments are:
 ### Stopping
 
 ```
-usage: stop_backend.py [-h] [--topology TOPOLOGY]
+Usage: stop_backend.py [OPTIONS]
 
-Tear down a previously created E2E AWS EC2 testing backend
-
-optional arguments:
-  -h, --help           show this help message and exit
-  --topology TOPOLOGY  The topology file that was used to start the environment
+Options:
+  --topology PATH      The topology file that was used to start the
+                       environment
+  --destroy-sgw        Destroy only Sync Gateway instances
+  --sgw-index INTEGER  Specific SGW instance index to destroy (0-based, only
+                       with --destroy-sgw)
+  --destroy-cbs        Destroy only Couchbase Server instances
+  --destroy-es         Destroy only Edge Server instances
+  --destroy-lb         Destroy only Load Balancer instances
+  --destroy-ls         Destroy only Logslurp instances
+  --no-ts-stop         Do not stop test servers
+  --no-full-destroy    Do not destroy all terraform managed resources if no
+                       specific component is selected
+  --help               Show this message and exit.
 ```
 
-The stop script only has one argument which is the topology file that was used to run start_backend above.  If no file was provided to start_backend, it means the default was used and you should also give no argument to stop_backend so that it also uses the default.
+`--topology` should point at the same topology file used to run `start_backend.py` above (default if none was given).  Without any `--destroy-*` flag, `stop_backend.py` runs a full `terraform destroy`; the `--destroy-*` flags target individual components instead, and `--no-ts-stop`/`--no-full-destroy` narrow the teardown further.

--- a/environment/aws/topology_setup/download_test_server.py
+++ b/environment/aws/topology_setup/download_test_server.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+
+"""
+This module builds and optionally uploads Couchbase Lite test servers to the latestbuilds server.
+It includes functions for checking if an upload already exists, compressing the server package, and uploading the package via SFTP.
+
+Functions:
+    upload_exists(server: TestServer) -> bool:
+        Check if the server package already exists on the latestbuilds server.
+
+    main() -> None:
+        Main function to build and optionally upload the Couchbase Lite test server.
+"""
+
+import sys
+from argparse import ArgumentParser
+from io import TextIOWrapper
+from pathlib import Path
+
+if __name__ == "__main__":
+    SCRIPT_DIR = Path(__file__).resolve().parent
+    sys.path.append(str(SCRIPT_DIR.parents[2]))
+    if isinstance(sys.stdout, TextIOWrapper):
+        sys.stdout.reconfigure(encoding="utf-8")
+
+from environment.aws.topology_setup.test_server import TestServer
+
+
+def main() -> None:
+    """
+    Main function to build and optionally upload the Couchbase Lite test server.
+
+    Parses command-line arguments to determine the platform, version, and whether to upload the built server.
+    Builds the test server and uploads it to the latestbuilds server if requested.
+
+    Raises:
+        SystemExit: If the LATESTBUILDS_PASSWORD environment variable is not set or if the upload is not requested.
+    """
+    parser = ArgumentParser("Downloads a given test server")
+    parser.add_argument("platform", type=str, help="The platform to build")
+    parser.add_argument("version", type=str, help="The version of CBL to use")
+
+    args = parser.parse_args()
+    server = TestServer.create(args.platform, args.version)
+    server.download()
+
+
+if __name__ == "__main__":
+    main()
+else:
+    raise RuntimeError(
+        "This script is not intended to be imported as a module. Please run it directly."
+    )

--- a/environment/aws/topology_setup/download_test_server.py
+++ b/environment/aws/topology_setup/download_test_server.py
@@ -1,15 +1,13 @@
 #!/usr/bin/env python3
 
 """
-This module builds and optionally uploads Couchbase Lite test servers to the latestbuilds server.
-It includes functions for checking if an upload already exists, compressing the server package, and uploading the package via SFTP.
+CLI entry point that downloads a prebuilt Couchbase Lite test server package
+for a given platform and version.
 
 Functions:
-    upload_exists(server: TestServer) -> bool:
-        Check if the server package already exists on the latestbuilds server.
-
     main() -> None:
-        Main function to build and optionally upload the Couchbase Lite test server.
+        Parses platform/version from argv and downloads the matching test
+        server package via TestServer.download().
 """
 
 import sys
@@ -28,13 +26,8 @@ from environment.aws.topology_setup.test_server import TestServer
 
 def main() -> None:
     """
-    Main function to build and optionally upload the Couchbase Lite test server.
-
-    Parses command-line arguments to determine the platform, version, and whether to upload the built server.
-    Builds the test server and uploads it to the latestbuilds server if requested.
-
-    Raises:
-        SystemExit: If the LATESTBUILDS_PASSWORD environment variable is not set or if the upload is not requested.
+    Parses `platform` and `version` from argv, then downloads the matching
+    prebuilt test server package via TestServer.download().
     """
     parser = ArgumentParser("Downloads a given test server")
     parser.add_argument("platform", type=str, help="The platform to build")

--- a/environment/local/README.md
+++ b/environment/local/README.md
@@ -42,6 +42,13 @@ To start the local test server (CBL-C):
 uv run environment/local/start_local.py
 ```
 
+By default this downloads a prebuilt test server. To build it from source
+instead, pass `--build-testserver` with a version string:
+
+```bash
+uv run environment/local/start_local.py --build-testserver 4.0.3
+```
+
 ## Running Tests
 
 After starting the environment, you can run tests against it:

--- a/servers/AGENTS.md
+++ b/servers/AGENTS.md
@@ -121,7 +121,7 @@ jak/
 └── webservice/                 # Web service variant
 ```
 
-Build: `cd <variant> && ./gradlew build`
+Build: `cd <variant> && ./gradlew jar -PcblVersion=<version>-<build> -PdatasetVersion=<ver>` (`assembleRelease` for `android`) — `-PcblVersion` is required, Gradle fails at configure time without it.
 
 ### JavaScript (`javascript/`)
 
@@ -169,7 +169,7 @@ When adding a new endpoint, **every** platform must be updated. Examples:
 
 ## Deployment Registration
 
-Each platform is registered for AWS deployment in [environment/aws/topology_setup/test_server_platforms/](../environment/aws/topology_setup/test_server_platforms/). All registered classes extend `TestServer` and implement `PlatformBridge` (`validate`, `install`, `run`, `stop`, `uninstall`, `get_ip`).
+Each platform is registered for AWS deployment in [environment/aws/topology_setup/test_server_platforms/](../environment/aws/topology_setup/test_server_platforms/). All registered classes extend `TestServer`, whose `create_bridge()` returns a `PlatformBridge` implementation (`validate`, `install`, `run`, `stop`, `uninstall`, `get_ip`).
 
 | File | Registered Platform Keys |
 |---|---|
@@ -195,7 +195,7 @@ Each platform is registered for AWS deployment in [environment/aws/topology_setu
 ```bash
 # C
 cd servers/c && ./scripts/build_macos.sh 4.0.0 43 && cd build/out/bin && ./testserver
-cd servers/c && ./scripts/build_linux.sh   4.0.0 43
+cd servers/c && ./scripts/build_linux.sh   enterprise 4.0.0 43
 cd servers/c && ./scripts/build_ios.sh     all 4.0.0 43
 cd servers/c && ./scripts/build_android.sh all enterprise 4.0.0 43
 cd servers/c && .\scripts\build_wins.ps1 -Edition enterprise -Version 4.0.0 -Build 43   # PowerShell
@@ -205,10 +205,10 @@ cd servers/c && .\scripts\build_wins.ps1 -Edition enterprise -Version 4.0.0 -Bui
 # iOS
 cd servers/ios && ./Scripts/build.sh all enterprise 4.0.0 43
 
-# JVM
-cd servers/jak/desktop    && ./gradlew build
-cd servers/jak/android    && ./gradlew build
-cd servers/jak/webservice && ./gradlew build
+# JVM (CBL version required via -PcblVersion, or Gradle fails at configure time)
+cd servers/jak/desktop    && ./gradlew jar            -PcblVersion=4.0.0-43 -PdatasetVersion=3.2
+cd servers/jak/android    && ./gradlew assembleRelease -PcblVersion=4.0.0-43 -PdatasetVersion=3.2
+cd servers/jak/webservice && ./gradlew jar            -PcblVersion=4.0.0-43 -PdatasetVersion=3.2
 
 # JavaScript
 cd servers/javascript && npm install && npm run dev

--- a/servers/AGENTS.md
+++ b/servers/AGENTS.md
@@ -87,10 +87,10 @@ dotnet/
 │   ├── Services/
 │   ├── Router.cs
 │   └── TestServer.cs
-└── scripts/                    # build_cli.sh, run_cli.sh, …
+└── scripts/                    # legacy helper scripts (not the build path)
 ```
 
-Build (CLI): `./scripts/build_cli.sh` → `dotnet publish`
+Build: via the orchestrator — `dotnet_register.py::build()` runs `dotnet publish` (after pinning the `Couchbase.Lite.Enterprise` package version). There is no standalone build script.
 
 ### iOS (`ios/`)
 
@@ -195,13 +195,12 @@ Each platform is registered for AWS deployment in [environment/aws/topology_setu
 ```bash
 # C
 cd servers/c && ./scripts/build_macos.sh 4.0.0 43 && cd build/out/bin && ./testserver
-cd servers/c && ./scripts/build_linux.sh   enterprise 4.0.0 43
-cd servers/c && ./scripts/build_ios.sh     enterprise 4.0.0 43
-cd servers/c && ./scripts/build_android.sh enterprise 4.0.0 43
-cd servers/c && .\scripts\build_wins.ps1 -Version 4.0.0 -BuildNum 43   # PowerShell
+cd servers/c && ./scripts/build_linux.sh   4.0.0 43
+cd servers/c && ./scripts/build_ios.sh     all 4.0.0 43
+cd servers/c && ./scripts/build_android.sh all enterprise 4.0.0 43
+cd servers/c && .\scripts\build_wins.ps1 -Edition enterprise -Version 4.0.0 -Build 43   # PowerShell
 
-# .NET
-cd servers/dotnet && ./scripts/build_cli.sh && ./scripts/run_cli.sh
+# .NET — built via the orchestrator (dotnet_register.py runs `dotnet publish`), no standalone build script
 
 # iOS
 cd servers/ios && ./Scripts/build.sh all enterprise 4.0.0 43

--- a/servers/c/README.md
+++ b/servers/c/README.md
@@ -68,13 +68,13 @@ The next step is to download CBL library.
 #### macOS, iOS, Android, Linux
 
 ```
-./scripts/download_cbl.sh macos enterprise 4.0.0
+./scripts/download_cbl.sh macos enterprise 4.0.0 43
 ```
 
 #### Windows
 
 ```
-.\scripts\download_cbl.ps1 enterprise 4.0.0
+.\scripts\download_cbl.ps1 enterprise 4.0.0 43
 ```
 
 ### Development Projects

--- a/servers/c/README.md
+++ b/servers/c/README.md
@@ -40,7 +40,7 @@ cd build/out/bin
 ### linux
 
 ```
-./scripts/build_linux.sh 4.0.0 43
+./scripts/build_linux.sh enterprise 4.0.0 43
 cd build/out/bin
 ./testserver
 ```

--- a/servers/c/scripts/build_wins.ps1
+++ b/servers/c/scripts/build_wins.ps1
@@ -1,7 +1,7 @@
 param(
     [Parameter(Mandatory=$true)][string]$Edition,
     [Parameter(Mandatory=$true)][string]$Version,
-    [Parameter(Mandatory=$true)][string]$Build,
+    [Parameter(Mandatory=$true)][string]$Build
 )
 
 $DOWNLOAD_DIR="$PSScriptRoot\..\downloaded"

--- a/servers/dotnet/README.md
+++ b/servers/dotnet/README.md
@@ -1,0 +1,39 @@
+# .NET TestServer
+
+The .NET implementation of the Couchbase Lite test server. Two entry points
+share the logic in `testserver.logic`:
+
+- `testserver/` — a .NET MAUI app targeting `net10.0-ios`, `net10.0-maccatalyst`,
+  and `net10.0-android` (iOS, Mac Catalyst, Android).
+- `testserver.cli/` — a `net8.0` console app for Windows / desktop.
+- `testserver.logic/` — shared server logic (handlers, routing) used by both.
+
+## Requirements
+
+- .NET SDK — versions are pinned by `global.json`. The MAUI app needs the .NET 10
+  SDK plus the MAUI workloads; the CLI needs .NET 8.
+- For the MAUI (mobile / Mac Catalyst) targets: Visual Studio or Rider with the
+  MAUI workload installed.
+- NuGet feeds are configured in `nuget.config`.
+
+## Build and Run
+
+Build with the standard .NET toolchain, either from an IDE (open
+`testserver.sln`) or the CLI. For the desktop / Windows CLI server:
+
+```
+dotnet build testserver.sln
+dotnet run --project testserver.cli
+```
+
+The MAUI app (`testserver`) is built and deployed to a device, simulator, or Mac
+Catalyst from your IDE in the usual way. Running .NET apps locally is assumed
+knowledge — this README only documents what is specific to this project.
+
+> In CI the server is built by the orchestrator
+> (`environment/aws/topology_setup/test_server_platforms/dotnet_register.py`),
+> which runs `dotnet publish` after pinning the `Couchbase.Lite.Enterprise`
+> package version. There is no standalone build script.
+
+See [servers/AGENTS.md](../AGENTS.md) for the layered architecture every server
+shares and the full endpoint list.

--- a/servers/jak/README.md
+++ b/servers/jak/README.md
@@ -1,0 +1,71 @@
+# JVM / Kotlin TestServer (`jak`)
+
+The Java/Kotlin implementation of the Couchbase Lite test server, sharing code in
+`shared/` across three variants:
+
+- `desktop/` — JVM desktop server (runnable JAR)
+- `webservice/` — Jetty-hosted web service
+- `android/` — Android app (APK)
+
+Couchbase Lite is pulled in as a Gradle dependency (selected by `-PcblVersion`),
+so there is no separate download step. The server's own version lives in
+`version.txt`.
+
+## Requirements
+
+- Java 17+
+- Android: Android Studio + SDK (for the `android` variant)
+- The Gradle wrapper (`gradlew`) is bundled in each variant — no separate Gradle
+  install needed.
+
+## Build
+
+Each variant builds from its own directory with the Gradle wrapper, passing the
+CBL version (`<version>-<build>`) and dataset version. These are the same
+invocations the orchestrator's `java_register.py` uses.
+
+Desktop and web service (produce a runnable JAR):
+
+```
+cd desktop      # or: cd webservice
+./gradlew jar -PcblVersion=4.0.0-43 -PdatasetVersion=3.2
+```
+
+Android (produces an APK):
+
+```
+cd android
+./gradlew assembleRelease -PcblVersion=4.0.0-43 -PdatasetVersion=3.2
+```
+
+On Windows use `gradlew.bat` and add `--no-daemon`.
+
+## Run
+
+**Desktop** — run the built JAR with the `server` argument:
+
+```
+java -jar desktop/app/build/libs/CBLTestServer-Java-Desktop-<server-version>_<cbl-version>.jar server
+```
+
+**Web service** — start / stop via Gradle (Jetty):
+
+```
+cd webservice
+./gradlew jettyStart -PcblVersion=4.0.0-43 -PdatasetVersion=3.2   # start
+./gradlew appStop    -PcblVersion=4.0.0-43 -PdatasetVersion=3.2   # stop
+```
+
+**Android** — install the built APK on a device / emulator (app id
+`com.couchbase.lite.android.mobiletest`):
+
+```
+adb install android/app/build/outputs/apk/release/app-release.apk
+```
+
+> On Linux the desktop / web service variants need the Couchbase Lite Java
+> support libraries (`libstdc++.so.6`, …) on `LD_LIBRARY_PATH`; the orchestrator
+> downloads these automatically (see `java_register.py`).
+
+See [servers/AGENTS.md](../AGENTS.md) for the shared architecture and the full
+endpoint list.

--- a/servers/javascript/README.md
+++ b/servers/javascript/README.md
@@ -1,0 +1,36 @@
+# JavaScript TestServer
+
+The TypeScript / browser implementation of the Couchbase Lite test server, built
+on `@couchbase/lite-js`. Unlike the other platforms it talks to the test client
+over **WebSocket** rather than HTTP (handled on the client side by
+`client/src/cbltest/websocket_router.py`).
+
+## Requirements
+
+- Node.js + npm
+- Couchbase Lite is an npm dependency (`@couchbase/lite-js`).
+
+## Build and Run
+
+```
+npm install
+npm run dev
+```
+
+`npm run dev` starts the Vite dev server, which hosts the test server in the
+browser. On connecting, the server exchanges an initial `Hello` WebSocket
+message in place of the HTTP API-version / server-ID headers the other platforms
+use.
+
+## Tests and Linting
+
+```
+npm test             # Vitest (run once)
+npm run test:browser # Vitest in a real browser (Playwright)
+npm run test:watch   # Vitest in watch mode
+npm run lint         # ESLint
+npm run lint:fix     # ESLint with autofix
+```
+
+See [servers/AGENTS.md](../AGENTS.md) for the shared architecture, the WebSocket
+transport notes, and the full endpoint list.

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -5,8 +5,8 @@ The two Python test suites that exercise Couchbase Lite via the `cbltest` framew
 ## Scope
 
 You own everything under `tests/`:
-- `tests/dev_e2e/` — Developer E2E (12 test modules + `test_replication_filter_data.py` data helper)
-- `tests/QE/` — QA suite (21 test files + 12 edge-server tests)
+- `tests/dev_e2e/` — Developer E2E tests (plus a `test_replication_filter_data.py` data helper)
+- `tests/QE/` — QA suite, including an edge-server sub-suite
 - `tests/.tools/` — binary tools used during tests (e.g. `cbbackupmgr`)
 
 You do **not** own `client/`, `servers/`, `environment/`, or `jenkins/`, but you understand how they wire into your tests.
@@ -57,7 +57,7 @@ tests/
 │   ├── test_upg_sgw.py
 │   ├── test_users_channels.py
 │   ├── test_xattrs.py
-│   └── edge_server/                    # Edge Server sub-suite (12 tests)
+│   └── edge_server/                    # Edge Server sub-suite
 │       ├── test_authentication.py
 │       ├── test_blobs.py
 │       ├── test_changes_feed.py

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -7,6 +7,7 @@ The two Python test suites that exercise Couchbase Lite via the `cbltest` framew
 You own everything under `tests/`:
 - `tests/dev_e2e/` — Developer E2E tests (plus a `test_replication_filter_data.py` data helper)
 - `tests/QE/` — QA suite, including an edge-server sub-suite
+- `tests/shared/` — helpers shared across suites (e.g. `upgrade_test_helpers.py`)
 - `tests/.tools/` — binary tools used during tests (e.g. `cbbackupmgr`)
 
 You do **not** own `client/`, `servers/`, `environment/`, or `jenkins/`, but you understand how they wire into your tests.
@@ -49,6 +50,7 @@ tests/
 │   ├── test_replication_eventing.py
 │   ├── test_replication_functional.py
 │   ├── test_replication_multiple_clients.py
+│   ├── test_replication_upgrade_delta_sync.py
 │   ├── test_replicator_encryption_hook.py
 │   ├── test_rolling_upgrade_sgw.py
 │   ├── test_server_setup.py
@@ -70,6 +72,9 @@ tests/
 │       ├── test_replication_sanity.py
 │       ├── test_system.py
 │       └── test_ttl_expires.py
+│
+├── shared/                              # Helpers shared across dev_e2e/QE
+│   └── upgrade_test_helpers.py
 │
 └── .tools/
     └── cbbackupmgr/                    # Couchbase Backup Manager binary
@@ -131,6 +136,7 @@ class TestFeatureName(CBLTestClass):
 | `@pytest.mark.min_sync_gateways(N)` | Topology: ≥ N SGW |
 | `@pytest.mark.min_couchbase_servers(N)` | Topology: ≥ N CBS |
 | `@pytest.mark.min_load_balancers(N)` | Topology: ≥ N load balancers |
+| `@pytest.mark.min_edge_servers(N)` | Topology: ≥ N edge servers |
 | `@pytest.mark.asyncio(loop_scope="session")` | **Required on every async test** |
 
 ## dev_e2e vs QE


### PR DESCRIPTION
This commit adds and updates documentation to make the project more accessible to new contributors:

- ONBOARDING.md: Quick mental model, first-run guide, and role-based starting points (Topology vs Config, AWS flow, per-platform servers)
- CONTEXT.md: Terminology glossary fixing common "server" confusion and clarifying vocabulary (Test Server, SGW, CBS, Backend, Client, Topology)
- docs/adr/: Three architecture decision records explaining why we built per-platform servers (0001), chose Python for test authoring (0002), and versioned the Test Server API (0003)
- servers/{dotnet,jak,javascript}/README.md: New per-platform build/run guides (dotnet MAUI + CLI, Java desktop/web/android, TypeScript/WebSocket)
- servers/c/README.md: Fix download_cbl.sh examples with build number param
- Updated AGENTS.md across multiple directories to reflect current state and remove stale metrics (test counts)
- Updated environment/aws/README.md to reflect new --no-es/lb-provision flags and topology-driven versioning
- Added environment/aws/topology_setup/download_test_server.py script
- Updated environment/local/README.md with --build-testserver example