### PR TITLE
CBG-5574 download matching cbbackupmgr to server

### DIFF
--- a/environment/local/run_sync_gateway.py
+++ b/environment/local/run_sync_gateway.py
@@ -1,14 +1,42 @@
 #!/usr/bin/env python3
+import json
 import pathlib
 import sys
 
 import click
+import requests
+from cbltest.configparser import CouchbaseServerInfo
 
 SCRIPT_DIR = pathlib.Path(__file__).parent.resolve()
 if __name__ == "__main__":
     sys.path.append(str(SCRIPT_DIR.parent.parent))
 
+from environment.aws import download_tool
 from environment.aws.topology_setup.test_server_platforms.exe_bridge import ExeBridge
+
+SYNC_GATEWAY_CONFIG_DIR = SCRIPT_DIR / "sync_gateway_config"
+SYNC_GATEWAY_CONFIG = {
+    "rosmar": SYNC_GATEWAY_CONFIG_DIR / "basic_sync_gateway_rosmar.json",
+    "cbs": SYNC_GATEWAY_CONFIG_DIR / "basic_sync_gateway_cbs.json",
+}
+TEST_CONFIG = {
+    "rosmar": SCRIPT_DIR / "rosmar_config.json",
+    "cbs": SCRIPT_DIR / "cbs_config.json",
+}
+
+
+def get_cbs_version() -> str:
+    """Query the Couchbase Server instance in cbs_config.json for its release version."""
+    config = json.loads(TEST_CONFIG["cbs"].read_text())
+    cbs_info = CouchbaseServerInfo(config["couchbase-servers"][0])
+
+    r = requests.get(
+        f"http://{cbs_info.hostname}:8091/pools",
+        auth=(cbs_info.admin_user, cbs_info.admin_password),
+        timeout=10,
+    )
+    r.raise_for_status()
+    return r.json()["implementationVersion"].split("-")[0]
 
 
 @click.command()
@@ -32,13 +60,12 @@ def main(start, stop, server):
     # We only need config if starting
     config_path = None
     if start:
-        config_dir = SCRIPT_DIR / "sync_gateway_config"
-        config_file = (
-            "basic_sync_gateway_rosmar.json"
-            if server == "rosmar"
-            else "basic_sync_gateway_cbs.json"
-        )
-        config_path = str(config_dir / config_file)
+        config_path = str(SYNC_GATEWAY_CONFIG[server])
+        if server == "cbs":
+            cbs_version = get_cbs_version()
+            download_tool.download_tool(
+                download_tool.ToolName.BackupManager, cbs_version
+            )
 
     bridge = ExeBridge(
         exe_path=exe_path,

--- a/environment/local/start_local.py
+++ b/environment/local/start_local.py
@@ -29,7 +29,6 @@ SCRIPT_DIR = pathlib.Path(__file__).parent
 if __name__ == "__main__":
     sys.path.append(str(SCRIPT_DIR.parent.parent))
 
-from environment.aws import download_tool
 from environment.aws.topology_setup import setup_topology
 
 TOPOLOGY_CONFIG = SCRIPT_DIR / "topology.json"
@@ -61,9 +60,6 @@ def main(build_testserver: str | None):
     topology_config = setup_topology.TopologyConfig(config_input=config)
 
     setup_topology.main(topology_config)
-
-    # hard code cbbackupmgr 8.0.0 for ease of use
-    download_tool.download_tool(download_tool.ToolName.BackupManager, version="8.0.0")
 
 
 def get_cbl_platform() -> str:


### PR DESCRIPTION
CBG-5574 download matching cbbackupmgr to server

Note: the dataset backups are taken with server 7.6.7 and supporting an earlier version of Couchbase Server might not be supported.

Example successful output: https://jenkins.sgwdev.com/job/Couchbase%20Lite%20E2E/30/
Example failing output: https://jenkins.sgwdev.com/job/Couchbase%20Lite%20E2E/18/

Closes a gap where restoring a bucket from 7.6 with cbbackupmgr from 8.0 would try to create a 128 vBucket bucket while the snapshot expected 1024 vBuckets from the 7.6.6 cluster.

Fixes a bug here:

```
--------------------------------- Captured Log ---------------------------------
INFO     CBL:logging.py:115 Starting test: test_nonconflict_case_3
INFO     CBL:logging.py:115 Moving to step 1:
INFO     CBL:logging.py:115 	Delete Sync Gateway 'upgrade' database if exists
INFO     CBL:logging.py:115 Moving to step 2:
INFO     CBL:logging.py:115 	Restore Couchbase Server Bucket using `upgrade` dataset
--------------------------------- Captured Out ---------------------------------
Warning: The backup "2025-10-16T21_51_59.666222332Z" is from a newer cluster version (7.6.7) than the cluster it is being restored to (7.6.6). This is NOT supported and a successful restore is not guaranteed.

Restoring backup '2025-10-16T21_51_59.666222332Z'
Creating remote bucket 'upgrade' if it doesn't exist                0 items / 0B
[........................................................................] 0.00%

| Transfer
| --------
| Status | Avg Transfer Rate | Started At                      | Finished At                     | Duration |
| Failed | 0B/s              | Thu, 09 Jul 2026 07:59:05 +0000 | Thu, 09 Jul 2026 07:59:05 +0000 | 7ms      |

Error restoring cluster: transfer failed due to error: failed to execute cluster operations: failed to execute bucket operation for bucket 'upgrade': failed to automatically create bucket 'upgrade': failed to create bucket 'upgrade': failed to execute request: unexpected status code 400 for 'POST' request to '/pools/default/buckets', {"errors":{"numVBuckets":"Support for variable number of vbuckets is not enabled"},"summaries":{"ramSummary":{"total":3221225472,"otherBuckets":0,"nodesCount":1,"perNodeMegs":512,"thisAlloc":536870912,"thisUsed":0,"free":2684354560},"hddSummary":{"total":102888095744,"otherData":8231047659,"otherBuckets":0,"thisUsed":0,"free":94657048085}}}
```

Note: these tests do still fail with errors like see CBG-5579:

```
tests/dev_e2e/test_replication_upgrade.py:806: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
tests/shared/upgrade_test_helpers.py:94: in do_upgrade_replication_test
    pre_remote_doc = await sg.get_document("upgrade", doc_id)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
client/src/cbltest/api/syncgateway.py:1265: in get_document
    response = await self._send_request(
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
self = <cbltest.api.syncgateway.SyncGateway object at 0x77fd7cbea7b0>
method = 'get', path = '/upgrade._default._default/conflict_6', payload = None
params = None, session = <aiohttp.client.ClientSession object at 0x77fd7cbea480>
    async def _send_request(
        self,
        method: str,
        path: str,
        payload: JSONSerializable | None = None,
        params: dict[str, str] | None = None,
        session: ClientSession | None = None,
    ) -> Any:
        if session is None:
            session = self.__session
        with self._tracer.start_as_current_span(
            "send_request", attributes={"http.method": method, "http.path": path}
        ):
            headers = (
                {"Content-Type": "application/json"} if payload is not None else None
            )
            data = "" if payload is None else payload.serialize()
            writer = get_next_writer()
            writer.write_begin(
                f"Sync Gateway [{self.__http_url}] -> {method.upper()} {path}", data
            )
            cbl_trace(f"Sending {method.upper()} {path} to {self.__http_url}")
            resp = await session.request(
                method, path, data=data, headers=headers, params=params
            )
            if resp.content_type.startswith("application/json"):
                ret_val = await resp.json()
                data = dumps(ret_val, indent=2)
            else:
                data = await resp.text()
                ret_val = data
            cbl_trace(f"Received {resp.status} from {method.upper()} {path}")
            writer.write_end(
                f"Sync Gateway [{self.__http_url}] <- {method.upper()} {path} {resp.status}",
                data,
            )
            if not resp.ok:
>               raise CblSyncGatewayBadResponseError(
                    resp.status, f"{method} {path} returned {resp.status}: {data}"
                )
E               cbltest.api.error.CblSyncGatewayBadResponseError: get /upgrade._default._default/conflict_6 returned 503: {
E                 "error": "Service Unavailable",
E                 "reason": "DB is currently under maintenance"
E               }
```