### PR TITLE
Support multiple Sync Gateway in a CouchbaseCloud

### DIFF
--- a/client/src/cbltest/__init__.py
+++ b/client/src/cbltest/__init__.py
@@ -215,8 +215,8 @@ class CBLPyTest:
 
         if len(self.couchbase_servers) == 0:
             if self.sync_gateways[0].using_rosmar:
-                return CouchbaseCloud(self.sync_gateways[0], None)
+                return CouchbaseCloud([self.sync_gateways[0]], None)
 
             raise CblTestError("No Couchbase Servers available in config")
 
-        return CouchbaseCloud(self.sync_gateways[0], self.couchbase_servers[0])
+        return CouchbaseCloud([self.sync_gateways[0]], self.couchbase_servers[0])

--- a/client/src/cbltest/api/cloud.py
+++ b/client/src/cbltest/api/cloud.py
@@ -7,6 +7,7 @@ from opentelemetry.trace import get_tracer
 from cbltest.api.couchbaseserver import CouchbaseServer
 from cbltest.api.error import CblSyncGatewayBadResponseError, CblTestError
 from cbltest.api.syncgateway import PutDatabasePayload, SyncGateway
+from cbltest.api.syncgatewaycluster import SyncGatewayCluster
 from cbltest.assertions import _assert_not_null
 from cbltest.jsonhelper import _get_typed_required
 from cbltest.utils import _try_n_times
@@ -15,22 +16,41 @@ from cbltest.version import VERSION
 
 class CouchbaseCloud:
     """
-    A class that performs operations that require coordination between both Sync Gateway and Couchbase Server
+    A class that performs operations that require coordination between both Sync Gateway
+    and Couchbase Server.
     """
 
-    def __init__(self, sync_gateway: SyncGateway, server: CouchbaseServer | None):
-        self.__sync_gateway = sync_gateway
+    def __init__(
+        self,
+        sync_gateways: list[SyncGateway],
+        server: CouchbaseServer | None,
+    ):
+        if not sync_gateways:
+            raise CblTestError("At least one Sync Gateway must be provided")
+        self.__sync_gateways = sync_gateways
+        self.__sync_gateway_cluster = SyncGatewayCluster(sync_gateways)
+
         if server:
             self.__couchbase_server: CouchbaseServer = server
-        elif not sync_gateway.using_rosmar:
+        elif len(self.__sync_gateways) > 1:
+            raise CblTestError(
+                "Couchbase Server must be provided when configuring multiple Sync Gateway nodes"
+            )
+        elif not self.__sync_gateways[0].using_rosmar:
             raise CblTestError(
                 "Couchbase Server must be provided if Sync Gateway is not using Rosmar"
             )
         self.__tracer = get_tracer(__name__, VERSION)
 
     @property
-    def sync_gateway(self) -> SyncGateway:
-        return self.__sync_gateway
+    def sync_gateways(self) -> list[SyncGateway]:
+        """All Sync Gateway nodes managed by this Couchbase Cloud instance."""
+        return self.__sync_gateways
+
+    @property
+    def sync_gateway_cluster(self) -> SyncGatewayCluster:
+        """A `SyncGatewayCluster` view over all Sync Gateway nodes managed by this instance."""
+        return self.__sync_gateway_cluster
 
     @property
     def couchbase_server(self) -> CouchbaseServer:
@@ -41,7 +61,7 @@ class CouchbaseCloud:
         return self.__couchbase_server
 
     def _create_collections(self, db_payload: PutDatabasePayload) -> None:
-        if self.sync_gateway.using_rosmar:
+        if self.__sync_gateways[0].using_rosmar:
             return
         for scope in db_payload.scopes():
             self.__couchbase_server.create_collections(
@@ -117,21 +137,22 @@ class CouchbaseCloud:
                         nested_config[k] = addition[k]
 
             db_payload: PutDatabasePayload = PutDatabasePayload(dataset_config)
+            sg = self.__sync_gateways[0]
             try:
                 # buckets and collections are implicitly created when using Rosmar
-                if not self.sync_gateway.using_rosmar:
+                if not sg.using_rosmar:
                     self.couchbase_server.create_bucket(db_payload.bucket)
                     self._create_collections(db_payload)
-                await self.__sync_gateway.put_database(dataset_name, db_payload)
+                await sg.put_database(dataset_name, db_payload)
             except CblSyncGatewayBadResponseError as e:
                 if e.code != 412:
                     raise
 
                 current_span.add_event("Handle HTTP 412")
-                await self.__sync_gateway.delete_database(dataset_name)
+                await sg.delete_database(dataset_name)
                 await self.drop_bucket(db_payload.bucket)
-                await self.__sync_gateway.wait_for_no_databases(db_payload.bucket)
-                if not self.sync_gateway.using_rosmar:
+                await self.sync_gateway_cluster.wait_for_no_databases(db_payload.bucket)
+                if not sg.using_rosmar:
                     self.__couchbase_server.create_bucket(db_payload.bucket)
                     self._create_collections(db_payload)
 
@@ -146,26 +167,28 @@ class CouchbaseCloud:
                     # will not be able to return the pending-to-removed indexes created for the collections.
                     self._wait_for_all_indexed_removed(db_payload.bucket)
 
-                await self.__sync_gateway.put_database(dataset_name, db_payload)
+                await sg.put_database(dataset_name, db_payload)
 
             for user in users:
                 user_dict = _get_typed_required(users, user, dict)
-                await self.__sync_gateway.add_user(
+                await sg.add_user(
                     dataset_name,
                     user,
                     user_dict["password"],
                     user_dict["collection_access"],
                 )
 
-            await self.__sync_gateway.load_dataset(dataset_name, data_filepath)
+            await sg.load_dataset(dataset_name, data_filepath)
+
+            if len(self.__sync_gateways) > 1:
+                await self.sync_gateway_cluster.wait_for_db_online(dataset_name)
 
     async def drop_bucket(self, bucket_name: str):
         """Drop the bucket from the backing cluster."""
-        if self.sync_gateway.using_rosmar:
+        sg = self.__sync_gateways[0]
+        if sg.using_rosmar:
             try:
-                await self.sync_gateway._send_request(
-                    "delete", f"/_rosmar/{bucket_name}"
-                )
+                await sg._send_request("delete", f"/_rosmar/{bucket_name}")
             except CblSyncGatewayBadResponseError as e:
                 if e.code != 404:
                     raise

--- a/client/src/cbltest/api/syncgateway.py
+++ b/client/src/cbltest/api/syncgateway.py
@@ -2067,7 +2067,7 @@ class SyncGateway(_SyncGatewayBase):
         reraise=True,
         retry=tenacity.retry_if_exception_type(AssertionError),
     )
-    async def wait_for_no_databases(self, bucket_name: str):
+    async def _wait_for_no_databases(self, bucket_name: str):
         dbs = await self.get_all_databases_verbose()
         for db in dbs.values():
             assert db.bucket != bucket_name, (

--- a/client/src/cbltest/api/syncgatewaycluster.py
+++ b/client/src/cbltest/api/syncgatewaycluster.py
@@ -15,9 +15,11 @@ class SyncGatewayCluster:
         """Gets the Sync Gateway nodes that make up this cluster"""
         return self.__sync_gateways
 
-    def __init__(self, sync_gateways: list[SyncGateway]):
-        self.__sync_gateways = sync_gateways
-        self.__round_robin_index = 0
+def __init__(self, sync_gateways: list[SyncGateway]):
+    if not sync_gateways:
+        raise ValueError("At least one Sync Gateway must be provided")
+    self.__sync_gateways = sync_gateways
+    self.__round_robin_index = 0
 
     @property
     def round_robin_node(self) -> SyncGateway:

--- a/client/src/cbltest/api/syncgatewaycluster.py
+++ b/client/src/cbltest/api/syncgatewaycluster.py
@@ -10,16 +10,16 @@ class SyncGatewayCluster:
     of them.
     """
 
+    def __init__(self, sync_gateways: list[SyncGateway]):
+        if not sync_gateways:
+            raise ValueError("At least one Sync Gateway must be provided")
+        self.__sync_gateways = sync_gateways
+        self.__round_robin_index = 0
+
     @property
     def sync_gateways(self) -> list[SyncGateway]:
         """Gets the Sync Gateway nodes that make up this cluster"""
         return self.__sync_gateways
-
-def __init__(self, sync_gateways: list[SyncGateway]):
-    if not sync_gateways:
-        raise ValueError("At least one Sync Gateway must be provided")
-    self.__sync_gateways = sync_gateways
-    self.__round_robin_index = 0
 
     @property
     def round_robin_node(self) -> SyncGateway:

--- a/client/src/cbltest/api/syncgatewaycluster.py
+++ b/client/src/cbltest/api/syncgatewaycluster.py
@@ -1,4 +1,5 @@
 import asyncio
+import random
 
 from cbltest.api.syncgateway import SyncGateway
 
@@ -16,6 +17,24 @@ class SyncGatewayCluster:
 
     def __init__(self, sync_gateways: list[SyncGateway]):
         self.__sync_gateways = sync_gateways
+        self.__round_robin_index = 0
+
+    @property
+    def round_robin_node(self) -> SyncGateway:
+        """
+        Gets the next Sync Gateway node in the cluster, cycling through all nodes in
+        order across successive accesses.
+        """
+        node = self.__sync_gateways[self.__round_robin_index]
+        self.__round_robin_index = (self.__round_robin_index + 1) % len(
+            self.__sync_gateways
+        )
+        return node
+
+    @property
+    def random_node(self) -> SyncGateway:
+        """Gets a uniformly random Sync Gateway node from the cluster."""
+        return random.choice(self.__sync_gateways)
 
     async def wait_for_db_online(
         self,
@@ -61,4 +80,15 @@ class SyncGatewayCluster:
                 )
                 for sg in self.__sync_gateways
             )
+        )
+
+    async def wait_for_no_databases(self, bucket_name: str) -> None:
+        """
+        Wait until every node in the cluster no longer backs any database with the
+        given bucket, polling all nodes concurrently.
+
+        :param bucket_name: Bucket name to check for.
+        """
+        await asyncio.gather(
+            *(sg._wait_for_no_databases(bucket_name) for sg in self.__sync_gateways)
         )

--- a/client/tests/conftest.py
+++ b/client/tests/conftest.py
@@ -1,0 +1,20 @@
+from contextlib import contextmanager
+from unittest.mock import patch
+
+from cbltest.api import syncgateway
+
+
+@contextmanager
+def fake_sync_gateways(count: int):
+    with (
+        patch("cbltest.api.syncgateway.ClientSession", autospec=True),
+        patch("cbltest.api.syncgateway.requests.get", autospec=True),
+    ):
+        yield [
+            syncgateway.SyncGateway(
+                url="https://example.com",
+                username="user",
+                password="pass",
+            )
+            for _ in range(count)
+        ]

--- a/client/tests/test_cloud.py
+++ b/client/tests/test_cloud.py
@@ -2,22 +2,17 @@ from contextlib import contextmanager
 from unittest.mock import patch
 
 import pytest
-from cbltest.api import couchbaseserver, syncgateway
+from cbltest.api import couchbaseserver
 from cbltest.api.cloud import CouchbaseCloud
 from cbltest.api.error import CblTestError
+from cbltest.api.syncgatewaycluster import SyncGatewayCluster
+from conftest import fake_sync_gateways
 
 
 @contextmanager
 def fake_sync_gateway():
-    with (
-        patch("cbltest.api.syncgateway.ClientSession", autospec=True),
-        patch("cbltest.api.syncgateway.requests.get", autospec=True),
-    ):
-        yield syncgateway.SyncGateway(
-            url="https://example.com",
-            username="user",
-            password="pass",
-        )
+    with fake_sync_gateways(1) as gateways:
+        yield gateways[0]
 
 
 def test_cloud_without_couchbase_server():
@@ -27,10 +22,10 @@ def test_cloud_without_couchbase_server():
             CblTestError,
             match="Couchbase Server must be provided if Sync Gateway",
         ):
-            CouchbaseCloud(sync_gateway, None)
+            CouchbaseCloud([sync_gateway], None)
 
     with fake_sync_gateway() as sync_gateway:
-        cloud = CouchbaseCloud(sync_gateway, None)
+        cloud = CouchbaseCloud([sync_gateway], None)
     with pytest.raises(
         CblTestError,
         match="Couchbase Server is not available",
@@ -46,5 +41,28 @@ def test_cloud_with_couchbase_server():
             password="pass",
         )
     with fake_sync_gateway() as sync_gateway:
-        cloud = CouchbaseCloud(sync_gateway, cbs)
+        cloud = CouchbaseCloud([sync_gateway], cbs)
     assert cloud.couchbase_server is cbs
+
+
+def test_cloud_with_multiple_sync_gateways():
+    with patch("cbltest.api.couchbaseserver.Cluster", autospec=True):
+        cbs = couchbaseserver.CouchbaseServer(
+            url="https://example.com",
+            username="user",
+            password="pass",
+        )
+    with fake_sync_gateways(3) as sync_gateways:
+        cloud = CouchbaseCloud(sync_gateways, cbs)
+        assert cloud.sync_gateways == sync_gateways
+        assert isinstance(cloud.sync_gateway_cluster, SyncGatewayCluster)
+        assert cloud.sync_gateway_cluster.sync_gateways == sync_gateways
+
+
+def test_cloud_multiple_sync_gateways_requires_couchbase_server():
+    with fake_sync_gateways(2) as sync_gateways:
+        with pytest.raises(
+            CblTestError,
+            match="Couchbase Server must be provided when configuring multiple Sync Gateway nodes",
+        ):
+            CouchbaseCloud(sync_gateways, None)

--- a/client/tests/test_syncgatewaycluster.py
+++ b/client/tests/test_syncgatewaycluster.py
@@ -1,0 +1,31 @@
+from cbltest.api.syncgatewaycluster import SyncGatewayCluster
+from conftest import fake_sync_gateways
+
+
+def test_round_robin_node_cycles_through_all_nodes():
+    with fake_sync_gateways(3) as sync_gateways:
+        cluster = SyncGatewayCluster(sync_gateways)
+        picks = [cluster.round_robin_node for _ in range(7)]
+        assert picks == [
+            sync_gateways[0],
+            sync_gateways[1],
+            sync_gateways[2],
+            sync_gateways[0],
+            sync_gateways[1],
+            sync_gateways[2],
+            sync_gateways[0],
+        ]
+
+
+def test_round_robin_node_single_node():
+    with fake_sync_gateways(1) as sync_gateways:
+        cluster = SyncGatewayCluster(sync_gateways)
+        for _ in range(3):
+            assert cluster.round_robin_node is sync_gateways[0]
+
+
+def test_random_node_returns_a_cluster_member():
+    with fake_sync_gateways(3) as sync_gateways:
+        cluster = SyncGatewayCluster(sync_gateways)
+        for _ in range(20):
+            assert cluster.random_node in sync_gateways

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -94,7 +94,7 @@ class TestFeatureName(CBLTestClass):
     @pytest.mark.asyncio(loop_scope="session")
     async def test_something(self, cblpytest: CBLPyTest, dataset_path: Path) -> None:
         self.mark_test_step("Reset SG and load `names` dataset")
-        cloud = CouchbaseCloud(cblpytest.sync_gateways[0], cblpytest.couchbase_servers[0])
+        cloud = CouchbaseCloud([cblpytest.sync_gateways[0]], cblpytest.couchbase_servers[0])
         await cloud.configure_dataset(dataset_path, "names")
 
         self.mark_test_step("Reset local database, and load `names` dataset")

--- a/tests/QE/edge_server/test_chaos_scenarios.py
+++ b/tests/QE/edge_server/test_chaos_scenarios.py
@@ -18,7 +18,7 @@ class TestEdgeServerChaos(CBLTestClass):
         self.mark_test_step("test_edge_to_sgw_replication")
         cloud = cblpytest.simple_cloud()
         await cloud.configure_dataset(dataset_path, "travel")
-        sgw = cloud.sync_gateway
+        sgw = cloud.sync_gateways[0]
         source_db = sgw.replication_url("travel")
 
         self.mark_test_step("Configure Edge Server with travel dataset")

--- a/tests/QE/edge_server/test_replication_edge_server.py
+++ b/tests/QE/edge_server/test_replication_edge_server.py
@@ -17,9 +17,9 @@ class TestEdgeServerSync(CBLTestClass):
     ):
         self.mark_test_step("test_edge_to_sgw_replication")
         cloud = cblpytest.simple_cloud()
+        sync_gateway = cloud.sync_gateways[0]
         await cloud.configure_dataset(dataset_path, "travel")
-        sgw = cloud.sync_gateway
-        source_db = sgw.replication_url("travel")
+        source_db = sync_gateway.replication_url("travel")
 
         self.mark_test_step("Configure Edge Server with travel dataset")
         config_path = f"{SCRIPT_DIR}/config/test_sgw_edge_server.json"
@@ -48,7 +48,7 @@ class TestEdgeServerSync(CBLTestClass):
             )
 
             # Get from SGW
-            sgw_docs = await sgw.get_all_documents(
+            sgw_docs = await sync_gateway.get_all_documents(
                 "travel", scope="travel", collection=collection.split(".")[1]
             )
 
@@ -71,7 +71,7 @@ class TestEdgeServerSync(CBLTestClass):
             update_doc, "airline_10000", "travel", collection="travel.airlines", ttl=30
         )
 
-        sgw_doc_new = await sgw.get_document(
+        sgw_doc_new = await sync_gateway.get_document(
             db_name="travel",
             scope="travel",
             collection="airlines",
@@ -85,7 +85,7 @@ class TestEdgeServerSync(CBLTestClass):
         self.mark_test_step(
             "Verify TTL document purged on Edge server and not Sync Gateway"
         )
-        sgw_doc_new = await sgw.get_document(
+        sgw_doc_new = await sync_gateway.get_document(
             db_name="travel",
             scope="travel",
             collection="airlines",

--- a/tests/QE/test_delta_sync.py
+++ b/tests/QE/test_delta_sync.py
@@ -30,6 +30,7 @@ class TestDeltaSync(CBLTestClass):
             "Reset SG and load `travel` dataset with delta sync enabled"
         )
         cloud = cblpytest.simple_cloud()
+        sync_gateway = cloud.sync_gateways[0]
         await cloud.configure_dataset(dataset_path, "travel", ["delta_sync"])
 
         self.mark_test_step("Reset local database, and load `travel` dataset.")
@@ -48,11 +49,11 @@ class TestDeltaSync(CBLTestClass):
         """)
         replicator = Replicator(
             db,
-            cloud.sync_gateway.replication_url("travel"),
+            sync_gateway.replication_url("travel"),
             collections=[ReplicatorCollectionEntry(["travel.hotels"])],
             replicator_type=ReplicatorType.PULL,
             authenticator=ReplicatorBasicAuthenticator("user1", "pass"),
-            pinned_server_cert=cloud.sync_gateway.tls_cert(),
+            pinned_server_cert=sync_gateway.tls_cert(),
             enable_document_listener=True,
         )
         await replicator.start()
@@ -66,7 +67,7 @@ class TestDeltaSync(CBLTestClass):
         self.mark_test_step("Check that all docs are replicated correctly.")
         await compare_local_and_remote(
             db,
-            cloud.sync_gateway,
+            sync_gateway,
             ReplicatorType.PULL,
             "travel",
             ["travel.hotels"],
@@ -77,10 +78,10 @@ class TestDeltaSync(CBLTestClass):
         )
 
         self.mark_test_step("Record baseline bytes before update")
-        read_pull_bytes_before, _ = await cloud.sync_gateway.bytes_transferred("travel")
+        read_pull_bytes_before, _ = await sync_gateway.bytes_transferred("travel")
 
         self.mark_test_step("Get existing document size for comparison")
-        original_doc = await cloud.sync_gateway.get_document(
+        original_doc = await sync_gateway.get_document(
             "travel", "hotel_400", "travel", "hotels"
         )
         assert original_doc is not None, "Document hotel_400 should exist"
@@ -97,7 +98,7 @@ class TestDeltaSync(CBLTestClass):
                 {"name": "Updated Hotel"},
             )
         ]
-        await cloud.sync_gateway.update_documents("travel", updates, "travel", "hotels")
+        await sync_gateway.update_documents("travel", updates, "travel", "hotels")
 
         self.mark_test_step("Start the same replicator again to pull the update")
         await replicator.start()
@@ -120,7 +121,7 @@ class TestDeltaSync(CBLTestClass):
         assert events, "Expected documents to be processed"
 
         self.mark_test_step("Record bytes transferred after delta sync")
-        read_pull_bytes_after, _ = await cloud.sync_gateway.bytes_transferred("travel")
+        read_pull_bytes_after, _ = await sync_gateway.bytes_transferred("travel")
 
         self.mark_test_step("Verify the document was updated correctly in CBL")
         updated_cbl_doc = await db.get_document(
@@ -149,6 +150,7 @@ class TestDeltaSync(CBLTestClass):
             "Reset SG and load `travel` dataset with delta sync enabled"
         )
         cloud = cblpytest.simple_cloud()
+        sync_gateway = cloud.sync_gateways[0]
         await cloud.configure_dataset(dataset_path, "travel", ["delta_sync"])
 
         self.mark_test_step("Reset local database, and load `travel` dataset.")
@@ -167,11 +169,11 @@ class TestDeltaSync(CBLTestClass):
         """)
         replicator = Replicator(
             db,
-            cloud.sync_gateway.replication_url("travel"),
+            sync_gateway.replication_url("travel"),
             collections=[ReplicatorCollectionEntry(["travel.hotels"])],
             replicator_type=ReplicatorType.PULL,
             authenticator=ReplicatorBasicAuthenticator("user1", "pass"),
-            pinned_server_cert=cloud.sync_gateway.tls_cert(),
+            pinned_server_cert=sync_gateway.tls_cert(),
             enable_document_listener=True,
         )
         await replicator.start()
@@ -185,7 +187,7 @@ class TestDeltaSync(CBLTestClass):
         self.mark_test_step("Check that all docs are replicated correctly.")
         await compare_local_and_remote(
             db,
-            cloud.sync_gateway,
+            sync_gateway,
             ReplicatorType.PULL,
             "travel",
             ["travel.hotels"],
@@ -196,10 +198,10 @@ class TestDeltaSync(CBLTestClass):
         )
 
         self.mark_test_step("Get baseline bytes before update")
-        read_pull_bytes_before, _ = await cloud.sync_gateway.bytes_transferred("travel")
+        read_pull_bytes_before, _ = await sync_gateway.bytes_transferred("travel")
 
         self.mark_test_step("Get existing document size for comparison")
-        original_doc = await cloud.sync_gateway.get_document(
+        original_doc = await sync_gateway.get_document(
             "travel", "hotel_400", "travel", "hotels"
         )
         assert original_doc is not None, "Document hotel_400 should exist"
@@ -216,7 +218,7 @@ class TestDeltaSync(CBLTestClass):
                 {"name": "SGW", "nested": {"name": "I am a nested field"}},
             )
         ]
-        await cloud.sync_gateway.update_documents("travel", updates, "travel", "hotels")
+        await sync_gateway.update_documents("travel", updates, "travel", "hotels")
 
         self.mark_test_step("Start the same replicator again:")
         await replicator.start()
@@ -254,7 +256,7 @@ class TestDeltaSync(CBLTestClass):
         )
 
         self.mark_test_step("Record the bytes transferred")
-        read_pull_bytes_after, _ = await cloud.sync_gateway.bytes_transferred("travel")
+        read_pull_bytes_after, _ = await sync_gateway.bytes_transferred("travel")
 
         self.mark_test_step(
             "Verify delta sync bytes transferred is less than doc size."
@@ -274,6 +276,7 @@ class TestDeltaSync(CBLTestClass):
             "Reset SG and load `travel` dataset with delta sync enabled"
         )
         cloud = cblpytest.simple_cloud()
+        sync_gateway = cloud.sync_gateways[0]
         await cloud.configure_dataset(dataset_path, "travel", ["delta_sync"])
 
         self.mark_test_step("Reset local database, and load `travel` dataset.")
@@ -292,11 +295,11 @@ class TestDeltaSync(CBLTestClass):
         """)
         replicator = Replicator(
             db,
-            cloud.sync_gateway.replication_url("travel"),
+            sync_gateway.replication_url("travel"),
             collections=[ReplicatorCollectionEntry(["travel.hotels"])],
             replicator_type=ReplicatorType.PULL,
             authenticator=ReplicatorBasicAuthenticator("user1", "pass"),
-            pinned_server_cert=cloud.sync_gateway.tls_cert(),
+            pinned_server_cert=sync_gateway.tls_cert(),
             enable_document_listener=True,
         )
         await replicator.start()
@@ -310,7 +313,7 @@ class TestDeltaSync(CBLTestClass):
         self.mark_test_step("Check that all docs are replicated correctly.")
         await compare_local_and_remote(
             db,
-            cloud.sync_gateway,
+            sync_gateway,
             ReplicatorType.PULL,
             "travel",
             ["travel.hotels"],
@@ -321,10 +324,10 @@ class TestDeltaSync(CBLTestClass):
         )
 
         self.mark_test_step("Get baseline bytes before update")
-        bytes_pull_before, _ = await cloud.sync_gateway.bytes_transferred("travel")
+        bytes_pull_before, _ = await sync_gateway.bytes_transferred("travel")
 
         self.mark_test_step("Get existing document size for comparison")
-        original_doc = await cloud.sync_gateway.get_document(
+        original_doc = await sync_gateway.get_document(
             "travel", "hotel_400", "travel", "hotels"
         )
         assert original_doc is not None, "Document hotel_400 should exist"
@@ -342,7 +345,7 @@ class TestDeltaSync(CBLTestClass):
                 {"utf8": utf8_body},
             )
         ]
-        await cloud.sync_gateway.update_documents("travel", updates, "travel", "hotels")
+        await sync_gateway.update_documents("travel", updates, "travel", "hotels")
 
         self.mark_test_step("Start the same replicator again.")
         await replicator.start()
@@ -374,7 +377,7 @@ class TestDeltaSync(CBLTestClass):
         )
 
         self.mark_test_step("Record the bytes transferred again this time.")
-        bytes_pull_after, _ = await cloud.sync_gateway.bytes_transferred("travel")
+        bytes_pull_after, _ = await sync_gateway.bytes_transferred("travel")
 
         self.mark_test_step(
             "Verify only delta is updated while replicating UTF-8 content."
@@ -394,6 +397,7 @@ class TestDeltaSync(CBLTestClass):
             "Reset SG and load `travel` dataset with delta sync enabled"
         )
         cloud = cblpytest.simple_cloud()
+        sync_gateway = cloud.sync_gateways[0]
         await cloud.configure_dataset(dataset_path, "travel", ["delta_sync"])
 
         self.mark_test_step("Reset local database, and load `travel` dataset.")
@@ -412,11 +416,11 @@ class TestDeltaSync(CBLTestClass):
         """)
         replicator = Replicator(
             db,
-            cloud.sync_gateway.replication_url("travel"),
+            sync_gateway.replication_url("travel"),
             collections=[ReplicatorCollectionEntry(["travel.hotels"])],
             replicator_type=ReplicatorType.PULL,
             authenticator=ReplicatorBasicAuthenticator("user1", "pass"),
-            pinned_server_cert=cloud.sync_gateway.tls_cert(),
+            pinned_server_cert=sync_gateway.tls_cert(),
             enable_document_listener=True,
         )
         await replicator.start()
@@ -430,7 +434,7 @@ class TestDeltaSync(CBLTestClass):
         self.mark_test_step("Verify docs are replicated correctly")
         await compare_local_and_remote(
             db,
-            cloud.sync_gateway,
+            sync_gateway,
             ReplicatorType.PULL,
             "travel",
             ["travel.hotels"],
@@ -441,10 +445,10 @@ class TestDeltaSync(CBLTestClass):
         )
 
         self.mark_test_step("Record the bytes transferred")
-        bytes_read_before, _ = await cloud.sync_gateway.bytes_transferred("travel")
+        bytes_read_before, _ = await sync_gateway.bytes_transferred("travel")
 
         self.mark_test_step("Get existing document size for comparison")
-        original_doc = await cloud.sync_gateway.get_document(
+        original_doc = await sync_gateway.get_document(
             "travel", "hotel_400", "travel", "hotels"
         )
         assert original_doc is not None, "Document hotel_400 should exist"
@@ -457,7 +461,7 @@ class TestDeltaSync(CBLTestClass):
         updates = [
             DocumentUpdateEntry("hotel_400", original_doc.revid, {"name": "SGW"})
         ]
-        await cloud.sync_gateway.update_documents("travel", updates, "travel", "hotels")
+        await sync_gateway.update_documents("travel", updates, "travel", "hotels")
 
         self.mark_test_step("Start the same replicator again.")
         await replicator.start()
@@ -489,7 +493,7 @@ class TestDeltaSync(CBLTestClass):
         )
 
         self.mark_test_step("Record the bytes transferred")
-        bytes_read_after, _ = await cloud.sync_gateway.bytes_transferred("travel")
+        bytes_read_after, _ = await sync_gateway.bytes_transferred("travel")
 
         self.mark_test_step("Verify delta transferred is less than doc size.")
         delta_bytes_transferred = bytes_read_after - bytes_read_before
@@ -520,11 +524,11 @@ class TestDeltaSync(CBLTestClass):
         """)
         replicator = Replicator(
             db,
-            cloud.sync_gateway.replication_url("posts"),
+            sync_gateway.replication_url("posts"),
             collections=[ReplicatorCollectionEntry(["_default.posts"])],
             replicator_type=ReplicatorType.PULL,
             authenticator=ReplicatorBasicAuthenticator("user1", "pass"),
-            pinned_server_cert=cloud.sync_gateway.tls_cert(),
+            pinned_server_cert=sync_gateway.tls_cert(),
             enable_document_listener=True,
         )
         await replicator.start()
@@ -538,17 +542,17 @@ class TestDeltaSync(CBLTestClass):
         self.mark_test_step("Verify docs are replicated correctly")
         await compare_local_and_remote(
             db,
-            cloud.sync_gateway,
+            sync_gateway,
             ReplicatorType.PULL,
             "posts",
             ["_default.posts"],
         )
 
         self.mark_test_step("Record the bytes transferred")
-        bytes_read_before, _ = await cloud.sync_gateway.bytes_transferred("posts")
+        bytes_read_before, _ = await sync_gateway.bytes_transferred("posts")
 
         self.mark_test_step("Get existing document size for comparison")
-        original_doc = await cloud.sync_gateway.get_document(
+        original_doc = await sync_gateway.get_document(
             "posts", "post_1", collection="posts"
         )
         assert original_doc is not None, "Document should exist in SGW"
@@ -557,7 +561,7 @@ class TestDeltaSync(CBLTestClass):
             Update docs in SGW:
                 * Modify the `name` field of the doc (small change).
         """)
-        await cloud.sync_gateway.upsert_documents(
+        await sync_gateway.upsert_documents(
             "posts",
             [
                 DocumentUpdateEntry(
@@ -599,7 +603,7 @@ class TestDeltaSync(CBLTestClass):
         )
 
         self.mark_test_step("Record the bytes transferred")
-        bytes_read_after, _ = await cloud.sync_gateway.bytes_transferred("posts")
+        bytes_read_after, _ = await sync_gateway.bytes_transferred("posts")
 
         self.mark_test_step(
             "Verify delta transferred equivalent to doc size (full doc transfer)."
@@ -622,10 +626,11 @@ class TestDeltaSync(CBLTestClass):
                 * has a rev_cache size of 1.
         """)
         cloud = cblpytest.simple_cloud()
+        sync_gateway = cloud.sync_gateways[0]
         await cloud.configure_dataset(dataset_path, "short_expiry", ["delta_sync"])
 
         self.mark_test_step("Verify SGW config has correct revision expiry settings")
-        db_config = await cloud.sync_gateway.get_database_config("short_expiry")
+        db_config = await sync_gateway.get_database_config("short_expiry")
 
         assert db_config.get("old_rev_expiry_seconds") == 10, (
             f"Expected old_rev_expiry_seconds to be 10, got {db_config.get('old_rev_expiry_seconds')}"
@@ -652,11 +657,11 @@ class TestDeltaSync(CBLTestClass):
         """)
         replicator = Replicator(
             db,
-            cloud.sync_gateway.replication_url("short_expiry"),
+            sync_gateway.replication_url("short_expiry"),
             collections=[ReplicatorCollectionEntry(["_default._default"])],
             replicator_type=ReplicatorType.PULL,
             authenticator=ReplicatorBasicAuthenticator("user1", "pass"),
-            pinned_server_cert=cloud.sync_gateway.tls_cert(),
+            pinned_server_cert=sync_gateway.tls_cert(),
             enable_document_listener=True,
         )
         await replicator.start()
@@ -679,16 +684,12 @@ class TestDeltaSync(CBLTestClass):
         )
 
         self.mark_test_step("Record the bytes transferred.")
-        read_pull_bytes_before, _ = await cloud.sync_gateway.bytes_transferred(
-            "short_expiry"
-        )
+        read_pull_bytes_before, _ = await sync_gateway.bytes_transferred("short_expiry")
 
         self.mark_test_step(
             "Get the current document state and revision before update."
         )
-        sgw_doc_before_update = await cloud.sync_gateway.get_document(
-            "short_expiry", "doc1"
-        )
+        sgw_doc_before_update = await sync_gateway.get_document("short_expiry", "doc1")
         assert sgw_doc_before_update is not None, "Document should exist in SGW"
         assert sgw_doc_before_update.body.get("type") == "test", (
             "Expected doc to have `type` as `test`"
@@ -699,8 +700,7 @@ class TestDeltaSync(CBLTestClass):
         self.mark_test_step(
             "Verify old revision body is accessible before expiry through public API."
         )
-        sg = cloud.sync_gateway
-        old_rev_doc = await sg.get_document_revision_public(
+        old_rev_doc = await sync_gateway.get_document_revision_public(
             "short_expiry", "doc1", old_revision, BasicAuth("user1", "pass", "ascii")
         )
 
@@ -715,7 +715,7 @@ class TestDeltaSync(CBLTestClass):
             Update docs in SGW:
                 * Modify content in document "doc1": `"name": "SGW"` (small change)
         """)
-        await cloud.sync_gateway.upsert_documents(
+        await sync_gateway.upsert_documents(
             "short_expiry",
             [
                 DocumentUpdateEntry(
@@ -731,7 +731,7 @@ class TestDeltaSync(CBLTestClass):
 
         self.mark_test_step("Verify old revision is not accessible through public API.")
         try:
-            expired_rev_doc = await sg.get_document_revision_public(
+            expired_rev_doc = await sync_gateway.get_document_revision_public(
                 "short_expiry",
                 "doc1",
                 old_revision,
@@ -755,9 +755,7 @@ class TestDeltaSync(CBLTestClass):
         )
 
         self.mark_test_step("Record the bytes transferred post expiry.")
-        read_pull_bytes_after, _ = await cloud.sync_gateway.bytes_transferred(
-            "short_expiry"
-        )
+        read_pull_bytes_after, _ = await sync_gateway.bytes_transferred("short_expiry")
         delta_bytes_read = read_pull_bytes_after - read_pull_bytes_before
 
         self.mark_test_step("""
@@ -783,6 +781,7 @@ class TestDeltaSync(CBLTestClass):
             "Reset SG and load `travel` dataset with delta sync enabled."
         )
         cloud = cblpytest.simple_cloud()
+        sync_gateway = cloud.sync_gateways[0]
         await cloud.configure_dataset(dataset_path, "travel", ["delta_sync"])
 
         self.mark_test_step("Reset local database, and load `travel` dataset.")
@@ -801,11 +800,11 @@ class TestDeltaSync(CBLTestClass):
         """)
         replicator = Replicator(
             db,
-            cloud.sync_gateway.replication_url("travel"),
+            sync_gateway.replication_url("travel"),
             collections=[ReplicatorCollectionEntry(["travel.hotels"])],
             replicator_type=ReplicatorType.PULL,
             authenticator=ReplicatorBasicAuthenticator("user1", "pass"),
-            pinned_server_cert=cloud.sync_gateway.tls_cert(),
+            pinned_server_cert=sync_gateway.tls_cert(),
         )
         await replicator.start()
 
@@ -816,7 +815,7 @@ class TestDeltaSync(CBLTestClass):
         )
 
         self.mark_test_step("Record the bytes transferred")
-        bytes_read_before, _ = await cloud.sync_gateway.bytes_transferred("travel")
+        bytes_read_before, _ = await sync_gateway.bytes_transferred("travel")
 
         self.mark_test_step("Verify docs are replicated correctly.")
         lite_all_docs = await db.get_all_documents("travel.hotels")
@@ -828,11 +827,11 @@ class TestDeltaSync(CBLTestClass):
             Update docs in SGW:
                 * Update the same hotel document with identical content (no real change)
         """)
-        original_doc = await cloud.sync_gateway.get_document(
+        original_doc = await sync_gateway.get_document(
             "travel", "hotel_400", "travel", "hotels"
         )
         assert original_doc is not None, "Document hotel_400 should exist"
-        await cloud.sync_gateway.update_documents(
+        await sync_gateway.update_documents(
             "travel",
             [DocumentUpdateEntry("hotel_400", original_doc.revid, {})],
             "travel",
@@ -849,7 +848,7 @@ class TestDeltaSync(CBLTestClass):
         )
 
         self.mark_test_step("Record the bytes transferred")
-        bytes_read_after, _ = await cloud.sync_gateway.bytes_transferred("travel")
+        bytes_read_after, _ = await sync_gateway.bytes_transferred("travel")
 
         self.mark_test_step("Get the original document size.")
         original_doc_size = len(json.dumps(original_doc.body).encode("utf-8"))
@@ -870,6 +869,7 @@ class TestDeltaSync(CBLTestClass):
             "Reset SG and load `travel` dataset with delta sync enabled."
         )
         cloud = cblpytest.simple_cloud()
+        sync_gateway = cloud.sync_gateways[0]
         await cloud.configure_dataset(dataset_path, "travel", ["delta_sync"])
 
         self.mark_test_step("Reset local database, and load `travel` dataset.")
@@ -888,11 +888,11 @@ class TestDeltaSync(CBLTestClass):
         """)
         replicator = Replicator(
             db,
-            cloud.sync_gateway.replication_url("travel"),
+            sync_gateway.replication_url("travel"),
             collections=[ReplicatorCollectionEntry(["travel.hotels"])],
             replicator_type=ReplicatorType.PULL,
             authenticator=ReplicatorBasicAuthenticator("user1", "pass"),
-            pinned_server_cert=cloud.sync_gateway.tls_cert(),
+            pinned_server_cert=sync_gateway.tls_cert(),
             enable_document_listener=True,
         )
         await replicator.start()
@@ -908,20 +908,20 @@ class TestDeltaSync(CBLTestClass):
         assert len(lite_all_docs["travel.hotels"]) == 700, (
             f"Incorrect number of initial documents replicated (expected 700; got {len(lite_all_docs['travel.hotels'])})"
         )
-        original_doc = await cloud.sync_gateway.get_document(
+        original_doc = await sync_gateway.get_document(
             "travel", "hotel_400", "travel", "hotels"
         )
         assert original_doc is not None, "Document should exist in SGW"
 
         self.mark_test_step("Get delta stats.")
-        bytes_read_before, _ = await cloud.sync_gateway.bytes_transferred("travel")
+        bytes_read_before, _ = await sync_gateway.bytes_transferred("travel")
 
         self.mark_test_step("""
             Update docs in SGW:
                 * Update the same hotel document with much larger content (>2x original size)
         """)
         large_doc_body = "X" * 2_000_000
-        await cloud.sync_gateway.update_documents(
+        await sync_gateway.update_documents(
             "travel",
             [
                 DocumentUpdateEntry(
@@ -953,7 +953,7 @@ class TestDeltaSync(CBLTestClass):
         )
 
         self.mark_test_step("Get delta stats.")
-        bytes_read_after, _ = await cloud.sync_gateway.bytes_transferred("travel")
+        bytes_read_after, _ = await sync_gateway.bytes_transferred("travel")
 
         self.mark_test_step("Verify document is replicated correctly.")
         cbl_doc = await db.get_document(DocumentEntry("travel.hotels", "hotel_400"))

--- a/tests/QE/test_no_conflicts.py
+++ b/tests/QE/test_no_conflicts.py
@@ -31,6 +31,7 @@ class TestNoConflicts(CBLTestClass):
     ):
         self.mark_test_step("Reset SG and load `posts` dataset")
         cloud = cblpytest.simple_cloud()
+        sync_gateway = cloud.sync_gateways[0]
         await cloud.configure_dataset(dataset_path, "posts")
 
         self.mark_test_step("Reset local database and load `posts` dataset")
@@ -50,12 +51,12 @@ class TestNoConflicts(CBLTestClass):
         """)
         replicator = Replicator(
             db,
-            cloud.sync_gateway.replication_url("posts"),
+            sync_gateway.replication_url("posts"),
             collections=[ReplicatorCollectionEntry(["_default.posts"])],
             replicator_type=ReplicatorType.PULL,
             continuous=True,
             authenticator=ReplicatorBasicAuthenticator("user1", "pass"),
-            pinned_server_cert=cloud.sync_gateway.tls_cert(),
+            pinned_server_cert=sync_gateway.tls_cert(),
         )
         await replicator.start()
 
@@ -71,7 +72,7 @@ class TestNoConflicts(CBLTestClass):
         )
 
         self.mark_test_step("Create docs in SG")
-        await cloud.sync_gateway.update_documents(
+        await sync_gateway.update_documents(
             "posts",
             [DocumentUpdateEntry("post_1000", None, {"channels": ["group1"]})],
             collection="posts",
@@ -83,7 +84,7 @@ class TestNoConflicts(CBLTestClass):
                 * In CBL: `"title"`: `"CBL Update"`
         """)
         await asyncio.gather(
-            cloud.sync_gateway.update_documents(
+            sync_gateway.update_documents(
                 "posts",
                 [
                     DocumentUpdateEntry(
@@ -108,12 +109,12 @@ class TestNoConflicts(CBLTestClass):
                 * credentials: user1/pass""")
         replicator2 = Replicator(
             db,
-            cloud.sync_gateway.replication_url("posts"),
+            sync_gateway.replication_url("posts"),
             collections=[ReplicatorCollectionEntry(["_default.posts"])],
             replicator_type=ReplicatorType.PUSH,
             continuous=True,
             authenticator=ReplicatorBasicAuthenticator("user1", "pass"),
-            pinned_server_cert=cloud.sync_gateway.tls_cert(),
+            pinned_server_cert=sync_gateway.tls_cert(),
         )
         await replicator2.start()
 
@@ -139,7 +140,7 @@ class TestNoConflicts(CBLTestClass):
         assert cbl_doc.id == "post_1000", (
             f"Incorrect document ID (expected post_1000; got {cbl_doc.id})"
         )
-        sg_doc = await cloud.sync_gateway.get_document(
+        sg_doc = await sync_gateway.get_document(
             "posts", "post_1000", collection="posts"
         )
         assert sg_doc is not None, "Document not found"
@@ -169,7 +170,7 @@ class TestNoConflicts(CBLTestClass):
         )
 
         self.mark_test_step("Verify docs got replicated to SGW with CBL updates.")
-        sg_doc = await cloud.sync_gateway.get_document(
+        sg_doc = await sync_gateway.get_document(
             "posts", "post_1000", collection="posts"
         )
         assert sg_doc is not None, "Document not found"
@@ -185,6 +186,7 @@ class TestNoConflicts(CBLTestClass):
     ):
         self.mark_test_step("Reset SG and load `posts` dataset")
         cloud = cblpytest.simple_cloud()
+        sync_gateway = cloud.sync_gateways[0]
         await cloud.configure_dataset(dataset_path, "posts")
 
         self.mark_test_step(
@@ -307,11 +309,11 @@ class TestNoConflicts(CBLTestClass):
         """)
         replicator = Replicator(
             db3,
-            cloud.sync_gateway.replication_url("posts"),
+            sync_gateway.replication_url("posts"),
             collections=[ReplicatorCollectionEntry(["_default.posts"])],
             continuous=True,
             authenticator=ReplicatorBasicAuthenticator("user1", "pass"),
-            pinned_server_cert=cloud.sync_gateway.tls_cert(),
+            pinned_server_cert=sync_gateway.tls_cert(),
         )
         await replicator.start()
 
@@ -324,7 +326,7 @@ class TestNoConflicts(CBLTestClass):
         self.mark_test_step(
             "Verify replication was successful and document content in SGW."
         )
-        sg_doc = await cloud.sync_gateway.get_document(
+        sg_doc = await sync_gateway.get_document(
             "posts", "post_1000", collection="posts"
         )
         assert sg_doc is not None, "Document should exist in SGW"
@@ -352,6 +354,7 @@ class TestNoConflicts(CBLTestClass):
     ):
         self.mark_test_step("Reset SG and load `posts` dataset")
         cloud = cblpytest.simple_cloud()
+        sync_gateway = cloud.sync_gateways[0]
         await cloud.configure_dataset(dataset_path, "posts")
 
         self.mark_test_step(
@@ -374,7 +377,7 @@ class TestNoConflicts(CBLTestClass):
         )[0]
 
         self.mark_test_step("Create a new doc in SG: `post_1000`.")
-        await cloud.sync_gateway.update_documents(
+        await sync_gateway.update_documents(
             "posts",
             [DocumentUpdateEntry("post_1000", None, {"channels": ["group1"]})],
             collection="posts",
@@ -391,29 +394,29 @@ class TestNoConflicts(CBLTestClass):
         """)
         repl1 = Replicator(
             db1,
-            cloud.sync_gateway.replication_url("posts"),
+            sync_gateway.replication_url("posts"),
             collections=[ReplicatorCollectionEntry(["_default.posts"])],
             continuous=True,
             authenticator=ReplicatorBasicAuthenticator("user1", "pass"),
-            pinned_server_cert=cloud.sync_gateway.tls_cert(),
+            pinned_server_cert=sync_gateway.tls_cert(),
         )
         await repl1.start()
         repl2 = Replicator(
             db2,
-            cloud.sync_gateway.replication_url("posts"),
+            sync_gateway.replication_url("posts"),
             collections=[ReplicatorCollectionEntry(["_default.posts"])],
             continuous=True,
             authenticator=ReplicatorBasicAuthenticator("user1", "pass"),
-            pinned_server_cert=cloud.sync_gateway.tls_cert(),
+            pinned_server_cert=sync_gateway.tls_cert(),
         )
         await repl2.start()
         repl3 = Replicator(
             db3,
-            cloud.sync_gateway.replication_url("posts"),
+            sync_gateway.replication_url("posts"),
             collections=[ReplicatorCollectionEntry(["_default.posts"])],
             continuous=True,
             authenticator=ReplicatorBasicAuthenticator("user1", "pass"),
-            pinned_server_cert=cloud.sync_gateway.tls_cert(),
+            pinned_server_cert=sync_gateway.tls_cert(),
         )
         await repl3.start()
 
@@ -448,7 +451,7 @@ class TestNoConflicts(CBLTestClass):
                 * In DB3: `"title": "CBL3 Update 1"`
         """)
         await asyncio.gather(
-            cloud.sync_gateway.update_documents(
+            sync_gateway.update_documents(
                 "posts",
                 [
                     DocumentUpdateEntry(
@@ -491,7 +494,7 @@ class TestNoConflicts(CBLTestClass):
         cbl1_doc = await db1.get_document(DocumentEntry("_default.posts", "post_1000"))
         cbl2_doc = await db2.get_document(DocumentEntry("_default.posts", "post_1000"))
         cbl3_doc = await db3.get_document(DocumentEntry("_default.posts", "post_1000"))
-        sg_doc = await cloud.sync_gateway.get_document(
+        sg_doc = await sync_gateway.get_document(
             "posts", "post_1000", collection="posts"
         )
         assert sg_doc is not None, "Document should exist in SGW"
@@ -545,7 +548,7 @@ class TestNoConflicts(CBLTestClass):
         cbl1_doc = await db1.get_document(DocumentEntry("_default.posts", "post_1000"))
         cbl2_doc = await db2.get_document(DocumentEntry("_default.posts", "post_1000"))
         cbl3_doc = await db3.get_document(DocumentEntry("_default.posts", "post_1000"))
-        sg_doc = await cloud.sync_gateway.get_document(
+        sg_doc = await sync_gateway.get_document(
             "posts", "post_1000", collection="posts"
         )
         assert sg_doc is not None, "Document should exist in SGW"

--- a/tests/QE/test_replication_eventing.py
+++ b/tests/QE/test_replication_eventing.py
@@ -23,6 +23,7 @@ class TestReplicationEventing(CBLTestClass):
     ):
         self.mark_test_step("Reset SG and load `names` dataset.")
         cloud = cblpytest.simple_cloud()
+        sync_gateway = cloud.sync_gateways[0]
         await cloud.configure_dataset(dataset_path, "names")
 
         self.mark_test_step("Reset local database, and load `names` dataset.")
@@ -41,10 +42,10 @@ class TestReplicationEventing(CBLTestClass):
         """)
         replicator = Replicator(
             db,
-            cloud.sync_gateway.replication_url("names"),
+            sync_gateway.replication_url("names"),
             collections=[ReplicatorCollectionEntry(["_default._default"])],
             authenticator=ReplicatorBasicAuthenticator("user1", "pass"),
-            pinned_server_cert=cloud.sync_gateway.tls_cert(),
+            pinned_server_cert=sync_gateway.tls_cert(),
         )
         await replicator.start()
 
@@ -100,7 +101,7 @@ class TestReplicationEventing(CBLTestClass):
 
         self.mark_test_step("Verify document was not replicated.")
         docs_after = await db.get_all_documents("_default._default")
-        sgw_docs_after = await cloud.sync_gateway.get_all_documents("names")
+        sgw_docs_after = await sync_gateway.get_all_documents("names")
         assert len(sgw_docs_after.rows) < len(docs_after["_default._default"]), (
             f"Expected no successful document updates but found {len(sgw_docs_after.rows)}"
         )
@@ -110,7 +111,7 @@ class TestReplicationEventing(CBLTestClass):
         assert large_doc is None, "Large document should not be replicated"
         try:
             with pytest.raises(Exception) as excinfo:
-                await cloud.sync_gateway.get_document("names", "large_doc")
+                await sync_gateway.get_document("names", "large_doc")
             assert "404" in str(excinfo.value) or "returned 404" in str(excinfo.value)
         except Exception as e:
             print(e)

--- a/tests/QE/test_replication_functional.py
+++ b/tests/QE/test_replication_functional.py
@@ -21,6 +21,7 @@ class TestReplicationFunctional(CBLTestClass):
     async def test_roles_replication(self, cblpytest: CBLPyTest, dataset_path: Path):
         self.mark_test_step("Reset SG and load `posts` dataset.")
         cloud = cblpytest.simple_cloud()
+        sync_gateway = cloud.sync_gateways[0]
         await cloud.configure_dataset(dataset_path, "posts")
 
         self.mark_test_step("Reset local database and load `posts` dataset.")
@@ -31,7 +32,7 @@ class TestReplicationFunctional(CBLTestClass):
         )[0]
 
         self.mark_test_step("Create test user 'testuser' with no initial roles.")
-        await cloud.sync_gateway.add_user(
+        await sync_gateway.add_user(
             "posts",
             "testuser",
             password="testpass",
@@ -45,17 +46,17 @@ class TestReplicationFunctional(CBLTestClass):
         )
 
         self.mark_test_step("Create role1 with access to group1 channel.")
-        await cloud.sync_gateway.add_role(
+        await sync_gateway.add_role(
             "posts", "role1", {"_default": {"posts": {"admin_channels": ["group1"]}}}
         )
 
         self.mark_test_step("Create role2 with access to group2 channel.")
-        await cloud.sync_gateway.add_role(
+        await sync_gateway.add_role(
             "posts", "role2", {"_default": {"posts": {"admin_channels": ["group2"]}}}
         )
 
         self.mark_test_step("Assign only role1 to testuser initially.")
-        await cloud.sync_gateway.add_user(
+        await sync_gateway.add_user(
             "posts",
             "testuser",
             password="testpass",
@@ -71,7 +72,7 @@ class TestReplicationFunctional(CBLTestClass):
 
         self.mark_test_step("Create initial documents in both channels on SGW.")
         # Documents in group1 channel (should be accessible)
-        await cloud.sync_gateway.update_documents(
+        await sync_gateway.update_documents(
             "posts",
             [
                 DocumentUpdateEntry(
@@ -98,7 +99,7 @@ class TestReplicationFunctional(CBLTestClass):
             collection="posts",
         )
         # Documents in group2 channel (should NOT be accessible initially)
-        await cloud.sync_gateway.update_documents(
+        await sync_gateway.update_documents(
             "posts",
             [
                 DocumentUpdateEntry(
@@ -135,11 +136,11 @@ class TestReplicationFunctional(CBLTestClass):
         """)
         replicator = Replicator(
             db,
-            cloud.sync_gateway.replication_url("posts"),
+            sync_gateway.replication_url("posts"),
             collections=[ReplicatorCollectionEntry(["_default.posts"])],
             replicator_type=ReplicatorType.PULL,
             authenticator=ReplicatorBasicAuthenticator("testuser", "testpass"),
-            pinned_server_cert=cloud.sync_gateway.tls_cert(),
+            pinned_server_cert=sync_gateway.tls_cert(),
         )
         await replicator.start()
 
@@ -182,7 +183,7 @@ class TestReplicationFunctional(CBLTestClass):
         )
 
         self.mark_test_step("Add role2 to testuser to grant access to group2 channel.")
-        await cloud.sync_gateway.add_user(
+        await sync_gateway.add_user(
             "posts",
             "testuser",
             password="testpass",
@@ -198,7 +199,7 @@ class TestReplicationFunctional(CBLTestClass):
 
         self.mark_test_step("Add new documents to SGW in both channels.")
         # New documents in group1 channel
-        await cloud.sync_gateway.update_documents(
+        await sync_gateway.update_documents(
             "posts",
             [
                 DocumentUpdateEntry(
@@ -225,7 +226,7 @@ class TestReplicationFunctional(CBLTestClass):
             collection="posts",
         )
         # New documents in group2 channel
-        await cloud.sync_gateway.update_documents(
+        await sync_gateway.update_documents(
             "posts",
             [
                 DocumentUpdateEntry(
@@ -326,6 +327,7 @@ class TestReplicationFunctional(CBLTestClass):
     ):
         self.mark_test_step("Reset SG and load `short_expiry` dataset.")
         cloud = cblpytest.simple_cloud()
+        sync_gateway = cloud.sync_gateways[0]
         await cloud.configure_dataset(dataset_path, "short_expiry")
 
         self.mark_test_step("Reset local database")
@@ -356,12 +358,12 @@ class TestReplicationFunctional(CBLTestClass):
         """)
         push_replicator = Replicator(
             db,
-            cloud.sync_gateway.replication_url("short_expiry"),
+            sync_gateway.replication_url("short_expiry"),
             collections=[ReplicatorCollectionEntry(["_default._default"])],
             replicator_type=ReplicatorType.PUSH,
             continuous=True,
             authenticator=ReplicatorBasicAuthenticator("user1", "pass"),
-            pinned_server_cert=cloud.sync_gateway.tls_cert(),
+            pinned_server_cert=sync_gateway.tls_cert(),
         )
         await push_replicator.start()
 
@@ -372,19 +374,19 @@ class TestReplicationFunctional(CBLTestClass):
         )
 
         self.mark_test_step("Verify doc_1 exists in SGW.")
-        sgw_doc = await cloud.sync_gateway.get_document(
+        sgw_doc = await sync_gateway.get_document(
             "short_expiry", "doc_1", "_default", "_default"
         )
         assert sgw_doc is not None, "doc_1 should exist in SGW after push replication"
         assert sgw_doc.body["type"] == "test_doc", "doc_1 should have correct content"
 
         self.mark_test_step("Purge doc_1 from SGW.")
-        await cloud.sync_gateway.purge_document(
+        await sync_gateway.purge_document(
             "doc_1", "short_expiry", "_default", "_default"
         )
 
         self.mark_test_step("Verify doc_1 is purged from SGW")
-        all_docs = await cloud.sync_gateway.get_all_documents("short_expiry")
+        all_docs = await sync_gateway.get_all_documents("short_expiry")
         sgw_doc_ids = {row.id for row in all_docs.rows}
         assert "doc_1" not in sgw_doc_ids, (
             f"doc_1 should be purged from SGW, but found in: {sgw_doc_ids}"
@@ -434,7 +436,7 @@ class TestReplicationFunctional(CBLTestClass):
         )
 
         self.mark_test_step("Verify documents exist in SGW.")
-        all_docs_after = await cloud.sync_gateway.get_all_documents("short_expiry")
+        all_docs_after = await sync_gateway.get_all_documents("short_expiry")
         sgw_doc_ids_after = {row.id for row in all_docs_after.rows}
         assert "doc_2" in sgw_doc_ids_after, (
             f"doc_2 should exist in SGW, found: {sgw_doc_ids_after}"
@@ -462,11 +464,11 @@ class TestReplicationFunctional(CBLTestClass):
         """)
         pull_replicator = Replicator(
             db_recreated,
-            cloud.sync_gateway.replication_url("short_expiry"),
+            sync_gateway.replication_url("short_expiry"),
             collections=[ReplicatorCollectionEntry(["_default._default"])],
             replicator_type=ReplicatorType.PULL,
             authenticator=ReplicatorBasicAuthenticator("user1", "pass"),
-            pinned_server_cert=cloud.sync_gateway.tls_cert(),
+            pinned_server_cert=sync_gateway.tls_cert(),
         )
         await pull_replicator.start()
 
@@ -524,6 +526,7 @@ class TestReplicationFunctional(CBLTestClass):
     ):
         self.mark_test_step("Reset SG and load `posts` dataset.")
         cloud = cblpytest.simple_cloud()
+        sync_gateway = cloud.sync_gateways[0]
         await cloud.configure_dataset(dataset_path, "posts")
 
         self.mark_test_step("Reset local database and load `posts` dataset.")
@@ -534,7 +537,7 @@ class TestReplicationFunctional(CBLTestClass):
         )[0]
 
         self.mark_test_step("Create test user 'testuser' with no initial access.")
-        await cloud.sync_gateway.add_user(
+        await sync_gateway.add_user(
             "posts",
             "testuser",
             password="testpass",
@@ -542,12 +545,12 @@ class TestReplicationFunctional(CBLTestClass):
         )
 
         self.mark_test_step("Create role 'testrole' with access to group1 channel.")
-        await cloud.sync_gateway.add_role(
+        await sync_gateway.add_role(
             "posts", "testrole", {"_default": {"posts": {"admin_channels": ["group1"]}}}
         )
 
         self.mark_test_step("Assign testrole to testuser.")
-        await cloud.sync_gateway.add_user(
+        await sync_gateway.add_user(
             "posts",
             "testuser",
             password="testpass",
@@ -556,7 +559,7 @@ class TestReplicationFunctional(CBLTestClass):
         )
 
         self.mark_test_step("Create initial documents in group1 channel on SGW")
-        await cloud.sync_gateway.update_documents(
+        await sync_gateway.update_documents(
             "posts",
             [
                 DocumentUpdateEntry(
@@ -593,12 +596,12 @@ class TestReplicationFunctional(CBLTestClass):
         """)
         pull_replicator = Replicator(
             db,
-            cloud.sync_gateway.replication_url("posts"),
+            sync_gateway.replication_url("posts"),
             collections=[ReplicatorCollectionEntry(["_default.posts"])],
             replicator_type=ReplicatorType.PULL,
             continuous=True,
             authenticator=ReplicatorBasicAuthenticator("testuser", "testpass"),
-            pinned_server_cert=cloud.sync_gateway.tls_cert(),
+            pinned_server_cert=sync_gateway.tls_cert(),
         )
         await pull_replicator.start()
 
@@ -636,14 +639,14 @@ class TestReplicationFunctional(CBLTestClass):
         )
 
         self.mark_test_step("Change testrole's channel access from group1 to group2.")
-        await cloud.sync_gateway.add_role(
+        await sync_gateway.add_role(
             "posts", "testrole", {"_default": {"posts": {"admin_channels": ["group2"]}}}
         )
 
         self.mark_test_step(
             "Add new documents to SGW in group1 channel (should NOT be accessible)."
         )
-        await cloud.sync_gateway.update_documents(
+        await sync_gateway.update_documents(
             "posts",
             [
                 DocumentUpdateEntry(
@@ -673,7 +676,7 @@ class TestReplicationFunctional(CBLTestClass):
         self.mark_test_step(
             "Add new documents to SGW in group2 channel (should be accessible)."
         )
-        await cloud.sync_gateway.update_documents(
+        await sync_gateway.update_documents(
             "posts",
             [
                 DocumentUpdateEntry(
@@ -757,16 +760,17 @@ class TestReplicationFunctional(CBLTestClass):
         await self.skip_if_sgw_not(cblpytest.sync_gateways[0], "<=4.0.0")
         self.mark_test_step("Reset SG and load `posts` dataset.")
         cloud = cblpytest.simple_cloud()
+        sync_gateway = cloud.sync_gateways[0]
         await cloud.configure_dataset(dataset_path, "posts")
 
         self.mark_test_step("Create two users with access to different channels.")
-        await cloud.sync_gateway.add_user(
+        await sync_gateway.add_user(
             "posts",
             "user1",
             password="pass1",
             collection_access={"_default": {"posts": {"admin_channels": ["channel1"]}}},
         )
-        await cloud.sync_gateway.add_user(
+        await sync_gateway.add_user(
             "posts",
             "user2",
             password="pass2",
@@ -774,7 +778,7 @@ class TestReplicationFunctional(CBLTestClass):
         )
 
         self.mark_test_step("Create initial documents in both channels.")
-        await cloud.sync_gateway.update_documents(
+        await sync_gateway.update_documents(
             "posts",
             [
                 DocumentUpdateEntry(
@@ -808,10 +812,10 @@ class TestReplicationFunctional(CBLTestClass):
         self.mark_test_step(
             "Create conflicts by having both users update the same documents."
         )
-        doc1 = await cloud.sync_gateway.get_document(
+        doc1 = await sync_gateway.get_document(
             "posts", "shared_doc1", "_default", "posts"
         )
-        doc2 = await cloud.sync_gateway.get_document(
+        doc2 = await sync_gateway.get_document(
             "posts", "shared_doc2", "_default", "posts"
         )
         assert doc1 is not None, "Document shared_doc1 not found in SGW"
@@ -819,7 +823,7 @@ class TestReplicationFunctional(CBLTestClass):
         assert doc1.revid is not None, "Document shared_doc1 has no revision ID"
         assert doc2.revid is not None, "Document shared_doc2 has no revision ID"
 
-        await cloud.sync_gateway.update_documents(
+        await sync_gateway.update_documents(
             "posts",
             [
                 DocumentUpdateEntry(
@@ -850,7 +854,7 @@ class TestReplicationFunctional(CBLTestClass):
             collection="posts",
         )
 
-        await cloud.sync_gateway.update_documents(
+        await sync_gateway.update_documents(
             "posts",
             [
                 DocumentUpdateEntry(
@@ -891,23 +895,23 @@ class TestReplicationFunctional(CBLTestClass):
         self.mark_test_step("Start push-pull replication for both users.")
         replicator1 = Replicator(
             db,
-            cloud.sync_gateway.replication_url("posts"),
+            sync_gateway.replication_url("posts"),
             collections=[ReplicatorCollectionEntry(["_default.posts"])],
             replicator_type=ReplicatorType.PUSH_AND_PULL,
             continuous=True,
             authenticator=ReplicatorBasicAuthenticator("user1", "pass1"),
-            pinned_server_cert=cloud.sync_gateway.tls_cert(),
+            pinned_server_cert=sync_gateway.tls_cert(),
         )
         await replicator1.start()
 
         replicator2 = Replicator(
             db,
-            cloud.sync_gateway.replication_url("posts"),
+            sync_gateway.replication_url("posts"),
             collections=[ReplicatorCollectionEntry(["_default.posts"])],
             replicator_type=ReplicatorType.PUSH_AND_PULL,
             continuous=True,
             authenticator=ReplicatorBasicAuthenticator("user2", "pass2"),
-            pinned_server_cert=cloud.sync_gateway.tls_cert(),
+            pinned_server_cert=sync_gateway.tls_cert(),
         )
         await replicator2.start()
 
@@ -971,10 +975,10 @@ class TestReplicationFunctional(CBLTestClass):
         )
 
         self.mark_test_step("Verify documents in Sync Gateway have the latest updates.")
-        sgw_doc1 = await cloud.sync_gateway.get_document(
+        sgw_doc1 = await sync_gateway.get_document(
             "posts", "shared_doc1", "_default", "posts"
         )
-        sgw_doc2 = await cloud.sync_gateway.get_document(
+        sgw_doc2 = await sync_gateway.get_document(
             "posts", "shared_doc2", "_default", "posts"
         )
         assert sgw_doc1 is not None, "Document shared_doc1 not found in SGW"

--- a/tests/QE/test_replicator_encryption_hook.py
+++ b/tests/QE/test_replicator_encryption_hook.py
@@ -29,6 +29,7 @@ class TestReplicatorEncryptionHook(CBLTestClass):
 
         self.mark_test_step("Reset SG and load `posts` dataset")
         cloud = cblpytest.simple_cloud()
+        sync_gateway = cloud.sync_gateways[0]
         await cloud.configure_dataset(dataset_path, "posts")
 
         self.mark_test_step("Reset local database, and load `posts` dataset.")
@@ -47,10 +48,10 @@ class TestReplicatorEncryptionHook(CBLTestClass):
         """)
         replicator = Replicator(
             db,
-            cloud.sync_gateway.replication_url("posts"),
+            sync_gateway.replication_url("posts"),
             collections=[ReplicatorCollectionEntry(["_default.posts"])],
             authenticator=ReplicatorBasicAuthenticator("user1", "pass"),
-            pinned_server_cert=cloud.sync_gateway.tls_cert(),
+            pinned_server_cert=sync_gateway.tls_cert(),
             enable_document_listener=True,
         )
         await replicator.start()
@@ -68,7 +69,7 @@ class TestReplicatorEncryptionHook(CBLTestClass):
         )
         await compare_local_and_remote(
             db,
-            cloud.sync_gateway,
+            sync_gateway,
             ReplicatorType.PUSH_AND_PULL,
             "posts",
             ["_default.posts"],
@@ -154,9 +155,7 @@ class TestReplicatorEncryptionHook(CBLTestClass):
                 * Verify the innermost field is properly encrypted.
                 * Validate nested structure is preserved.
         """)
-        doc = await cloud.sync_gateway.get_document(
-            "posts", "post_1000", collection="posts"
-        )
+        doc = await sync_gateway.get_document("posts", "post_1000", collection="posts")
         assert doc is not None, "Document should exist in SGW"
         nest1 = doc.body.get("nest_1")
         assert nest1 is not None, "Parent field should be present"
@@ -208,6 +207,7 @@ class TestReplicatorEncryptionHook(CBLTestClass):
             "Reset SG and load `travel` dataset with delta sync enabled"
         )
         cloud = cblpytest.simple_cloud()
+        sync_gateway = cloud.sync_gateways[0]
         await cloud.configure_dataset(dataset_path, "travel", ["delta_sync"])
 
         self.mark_test_step("Reset local database, and load `travel` dataset.")
@@ -226,11 +226,11 @@ class TestReplicatorEncryptionHook(CBLTestClass):
         """)
         replicator = Replicator(
             db,
-            cloud.sync_gateway.replication_url("travel"),
+            sync_gateway.replication_url("travel"),
             collections=[ReplicatorCollectionEntry(["travel.hotels"])],
             replicator_type=ReplicatorType.PULL,
             authenticator=ReplicatorBasicAuthenticator("user1", "pass"),
-            pinned_server_cert=cloud.sync_gateway.tls_cert(),
+            pinned_server_cert=sync_gateway.tls_cert(),
             enable_document_listener=True,
         )
         await replicator.start()
@@ -248,23 +248,23 @@ class TestReplicatorEncryptionHook(CBLTestClass):
         )
         await compare_local_and_remote(
             db,
-            cloud.sync_gateway,
+            sync_gateway,
             ReplicatorType.PULL,
             "travel",
             ["travel.hotels"],
         )
 
         self.mark_test_step("Record baseline bytes before update")
-        _, bytes_written_before = await cloud.sync_gateway.bytes_transferred("travel")
+        _, bytes_written_before = await sync_gateway.bytes_transferred("travel")
 
         self.mark_test_step("Get existing document for encryption test")
-        original_doc = await cloud.sync_gateway.get_document(
+        original_doc = await sync_gateway.get_document(
             "travel", "hotel_400", "travel", "hotels"
         )
         assert original_doc is not None, "Document hotel_400 should exist"
 
         self.mark_test_step("Update existing document in SGW with encryption")
-        await cloud.sync_gateway.upsert_documents(
+        await sync_gateway.upsert_documents(
             "travel",
             [
                 DocumentUpdateEntry(
@@ -288,10 +288,10 @@ class TestReplicatorEncryptionHook(CBLTestClass):
         )
 
         self.mark_test_step("Record the bytes transferred after delta sync.")
-        _, bytes_written_after = await cloud.sync_gateway.bytes_transferred("travel")
+        _, bytes_written_after = await sync_gateway.bytes_transferred("travel")
 
         self.mark_test_step("Verify delta sync worked with encryption.")
-        sgw_doc = await cloud.sync_gateway.get_document(
+        sgw_doc = await sync_gateway.get_document(
             "travel", "hotel_400", "travel", "hotels"
         )
         assert sgw_doc is not None, "Document should exist in SGW"

--- a/tests/QE/test_system_multipeer.py
+++ b/tests/QE/test_system_multipeer.py
@@ -322,12 +322,12 @@ class TestSystemMultipeer(CBLTestClass):
 
         self.mark_test_step("Reset SG and load `names` dataset")
         cloud_1 = CouchbaseCloud(
-            cblpytest.sync_gateways[0], cblpytest.couchbase_servers[0]
+            [cblpytest.sync_gateways[0]], cblpytest.couchbase_servers[0]
         )
         await cloud_1.configure_dataset(dataset_path, "names")
 
         cloud_2 = CouchbaseCloud(
-            cblpytest.sync_gateways[1], cblpytest.couchbase_servers[1]
+            [cblpytest.sync_gateways[1]], cblpytest.couchbase_servers[1]
         )
         await cloud_2.configure_dataset(dataset_path, "names")
 

--- a/tests/dev_e2e/test_basic_replication.py
+++ b/tests/dev_e2e/test_basic_replication.py
@@ -31,6 +31,7 @@ class TestBasicReplication(CBLTestClass):
     ) -> None:
         self.mark_test_step("Reset SG and load `names` dataset")
         cloud = cblpytest.simple_cloud()
+        sync_gateway = cloud.sync_gateways[0]
         await cloud.configure_dataset(dataset_path, "names")
 
         self.mark_test_step("Reset local database, and load `travel` dataset")
@@ -49,11 +50,11 @@ class TestBasicReplication(CBLTestClass):
         """)
         replicator = Replicator(
             db,
-            cloud.sync_gateway.replication_url("names"),
+            sync_gateway.replication_url("names"),
             replicator_type=ReplicatorType.PUSH,
             collections=[ReplicatorCollectionEntry(["travel.airlines"])],
             authenticator=ReplicatorBasicAuthenticator("user1", "pass"),
-            pinned_server_cert=cloud.sync_gateway.tls_cert(),
+            pinned_server_cert=sync_gateway.tls_cert(),
         )
         await replicator.start()
 
@@ -76,6 +77,7 @@ class TestBasicReplication(CBLTestClass):
     async def test_push(self, cblpytest: CBLPyTest, dataset_path: Path) -> None:
         self.mark_test_step("Reset SG and load `travel` dataset.")
         cloud = cblpytest.simple_cloud()
+        sync_gateway = cloud.sync_gateways[0]
         await cloud.configure_dataset(dataset_path, "travel")
 
         self.mark_test_step("Reset local database, and load `travel` dataset.")
@@ -94,7 +96,7 @@ class TestBasicReplication(CBLTestClass):
         """)
         replicator = Replicator(
             db,
-            cloud.sync_gateway.replication_url("travel"),
+            sync_gateway.replication_url("travel"),
             replicator_type=ReplicatorType.PUSH,
             collections=[
                 ReplicatorCollectionEntry(
@@ -102,7 +104,7 @@ class TestBasicReplication(CBLTestClass):
                 )
             ],
             authenticator=ReplicatorBasicAuthenticator("user1", "pass"),
-            pinned_server_cert=cloud.sync_gateway.tls_cert(),
+            pinned_server_cert=sync_gateway.tls_cert(),
         )
         await replicator.start()
 
@@ -115,7 +117,7 @@ class TestBasicReplication(CBLTestClass):
         self.mark_test_step("Check that all docs are replicated correctly.")
         await compare_local_and_remote(
             db,
-            cloud.sync_gateway,
+            sync_gateway,
             ReplicatorType.PUSH,
             "travel",
             ["travel.airlines", "travel.airports", "travel.hotels"],
@@ -127,6 +129,7 @@ class TestBasicReplication(CBLTestClass):
     async def test_pull(self, cblpytest: CBLPyTest, dataset_path: Path):
         self.mark_test_step("Reset SG and load `travel` dataset.")
         cloud = cblpytest.simple_cloud()
+        sync_gateway = cloud.sync_gateways[0]
         await cloud.configure_dataset(dataset_path, "travel")
 
         self.mark_test_step("Reset local database, and load `travel` dataset.")
@@ -145,7 +148,7 @@ class TestBasicReplication(CBLTestClass):
         """)
         replicator = Replicator(
             db,
-            cloud.sync_gateway.replication_url("travel"),
+            sync_gateway.replication_url("travel"),
             replicator_type=ReplicatorType.PULL,
             collections=[
                 ReplicatorCollectionEntry(
@@ -153,7 +156,7 @@ class TestBasicReplication(CBLTestClass):
                 )
             ],
             authenticator=ReplicatorBasicAuthenticator("user1", "pass"),
-            pinned_server_cert=cloud.sync_gateway.tls_cert(),
+            pinned_server_cert=sync_gateway.tls_cert(),
         )
         await replicator.start()
 
@@ -166,7 +169,7 @@ class TestBasicReplication(CBLTestClass):
         self.mark_test_step("Check that all docs are replicated correctly.")
         await compare_local_and_remote(
             db,
-            cloud.sync_gateway,
+            sync_gateway,
             ReplicatorType.PULL,
             "travel",
             ["travel.routes", "travel.landmarks", "travel.hotels"],
@@ -178,6 +181,7 @@ class TestBasicReplication(CBLTestClass):
     async def test_push_and_pull(self, cblpytest: CBLPyTest, dataset_path: Path):
         self.mark_test_step("Reset SG and load `travel` dataset.")
         cloud = cblpytest.simple_cloud()
+        sync_gateway = cloud.sync_gateways[0]
         await cloud.configure_dataset(dataset_path, "travel")
 
         self.mark_test_step("Reset local database, and load `travel` dataset.")
@@ -196,7 +200,7 @@ class TestBasicReplication(CBLTestClass):
         """)
         replicator = Replicator(
             db,
-            cloud.sync_gateway.replication_url("travel"),
+            sync_gateway.replication_url("travel"),
             replicator_type=ReplicatorType.PUSH_AND_PULL,
             collections=[
                 ReplicatorCollectionEntry(
@@ -210,7 +214,7 @@ class TestBasicReplication(CBLTestClass):
                 )
             ],
             authenticator=ReplicatorBasicAuthenticator("user1", "pass"),
-            pinned_server_cert=cloud.sync_gateway.tls_cert(),
+            pinned_server_cert=sync_gateway.tls_cert(),
         )
         await replicator.start()
 
@@ -225,7 +229,7 @@ class TestBasicReplication(CBLTestClass):
         self.mark_test_step("Check that all docs are replicated correctly.")
         await compare_local_and_remote(
             db,
-            cloud.sync_gateway,
+            sync_gateway,
             ReplicatorType.PUSH_AND_PULL,
             "travel",
             [
@@ -245,6 +249,7 @@ class TestBasicReplication(CBLTestClass):
     ) -> None:
         self.mark_test_step("Reset SG and load `travel` dataset.")
         cloud = cblpytest.simple_cloud()
+        sync_gateway = cloud.sync_gateways[0]
         await cloud.configure_dataset(dataset_path, "travel")
 
         self.mark_test_step("Reset local database, and load `travel` dataset.")
@@ -264,7 +269,7 @@ class TestBasicReplication(CBLTestClass):
         """)
         replicator = Replicator(
             db,
-            cloud.sync_gateway.replication_url("travel"),
+            sync_gateway.replication_url("travel"),
             collections=[
                 ReplicatorCollectionEntry(
                     ["travel.airlines", "travel.airports", "travel.hotels"]
@@ -274,7 +279,7 @@ class TestBasicReplication(CBLTestClass):
             continuous=True,
             enable_document_listener=True,
             authenticator=ReplicatorBasicAuthenticator("user1", "pass"),
-            pinned_server_cert=cloud.sync_gateway.tls_cert(),
+            pinned_server_cert=sync_gateway.tls_cert(),
         )
         await replicator.start()
 
@@ -287,7 +292,7 @@ class TestBasicReplication(CBLTestClass):
         self.mark_test_step("Check that all docs are replicated correctly.")
         await compare_local_and_remote(
             db,
-            cloud.sync_gateway,
+            sync_gateway,
             ReplicatorType.PUSH,
             "travel",
             ["travel.airlines", "travel.airports", "travel.hotels"],
@@ -367,7 +372,7 @@ class TestBasicReplication(CBLTestClass):
         self.mark_test_step("Check that all updates are replicated correctly.")
         await compare_local_and_remote(
             db,
-            cloud.sync_gateway,
+            sync_gateway,
             ReplicatorType.PUSH,
             "travel",
             ["travel.airlines", "travel.airports", "travel.hotels"],
@@ -379,6 +384,7 @@ class TestBasicReplication(CBLTestClass):
     async def test_continuous_pull(self, cblpytest: CBLPyTest, dataset_path: Path):
         self.mark_test_step("Reset SG and load `travel` dataset.")
         cloud = cblpytest.simple_cloud()
+        sync_gateway = cloud.sync_gateways[0]
         await cloud.configure_dataset(dataset_path, "travel")
 
         self.mark_test_step("Reset local database, and load `travel` dataset.")
@@ -398,7 +404,7 @@ class TestBasicReplication(CBLTestClass):
         """)
         replicator = Replicator(
             db,
-            cloud.sync_gateway.replication_url("travel"),
+            sync_gateway.replication_url("travel"),
             collections=[
                 ReplicatorCollectionEntry(
                     ["travel.routes", "travel.landmarks", "travel.hotels"]
@@ -408,7 +414,7 @@ class TestBasicReplication(CBLTestClass):
             continuous=True,
             enable_document_listener=True,
             authenticator=ReplicatorBasicAuthenticator("user1", "pass"),
-            pinned_server_cert=cloud.sync_gateway.tls_cert(),
+            pinned_server_cert=sync_gateway.tls_cert(),
         )
         await replicator.start()
 
@@ -421,7 +427,7 @@ class TestBasicReplication(CBLTestClass):
         self.mark_test_step("Check that all docs are replicated correctly.")
         await compare_local_and_remote(
             db,
-            cloud.sync_gateway,
+            sync_gateway,
             ReplicatorType.PULL,
             "travel",
             ["travel.routes", "travel.landmarks", "travel.hotels"],
@@ -461,13 +467,13 @@ class TestBasicReplication(CBLTestClass):
                 },
             ),
         ]
-        await cloud.sync_gateway.update_documents(
+        await sync_gateway.update_documents(
             "travel", routes_updates, "travel", "routes"
         )
 
         # Update 2 landmarks in `travel.landmarks`
         landmarks_updates: list[DocumentUpdateEntry] = []
-        landmarks_all_docs = await cloud.sync_gateway.get_all_documents(
+        landmarks_all_docs = await sync_gateway.get_all_documents(
             "travel", "travel", "landmarks"
         )
         for doc in landmarks_all_docs.rows:
@@ -501,18 +507,18 @@ class TestBasicReplication(CBLTestClass):
                         },
                     )
                 )
-        await cloud.sync_gateway.update_documents(
+        await sync_gateway.update_documents(
             "travel", landmarks_updates, "travel", "landmarks"
         )
 
         # Remove 2 hotels in `travel.hotels`
-        hotels_all_docs = await cloud.sync_gateway.get_all_documents(
+        hotels_all_docs = await sync_gateway.get_all_documents(
             "travel", "travel", "hotels"
         )
         for doc in hotels_all_docs.rows:
             if doc.id == "hotel_400" or doc.id == "hotel_500":
                 revid = assert_not_null(doc.revid, f"Missing revid on {doc.id}")
-                await cloud.sync_gateway.delete_document(
+                await sync_gateway.delete_document(
                     doc.id, revid, "travel", "travel", "hotels"
                 )
 
@@ -561,7 +567,7 @@ class TestBasicReplication(CBLTestClass):
         self.mark_test_step("Check that all updates are replicated correctly.")
         await compare_local_and_remote(
             db,
-            cloud.sync_gateway,
+            sync_gateway,
             ReplicatorType.PULL,
             "travel",
             ["travel.routes", "travel.landmarks", "travel.hotels"],
@@ -575,6 +581,7 @@ class TestBasicReplication(CBLTestClass):
     ) -> None:
         self.mark_test_step("Reset SG and load `travel` dataset.")
         cloud = cblpytest.simple_cloud()
+        sync_gateway = cloud.sync_gateways[0]
         await cloud.configure_dataset(dataset_path, "travel")
 
         self.mark_test_step("Reset local database, and load `travel` dataset.")
@@ -594,7 +601,7 @@ class TestBasicReplication(CBLTestClass):
         """)
         replicator = Replicator(
             db,
-            cloud.sync_gateway.replication_url("travel"),
+            sync_gateway.replication_url("travel"),
             collections=[
                 ReplicatorCollectionEntry(
                     [
@@ -610,7 +617,7 @@ class TestBasicReplication(CBLTestClass):
             continuous=True,
             enable_document_listener=True,
             authenticator=ReplicatorBasicAuthenticator("user1", "pass"),
-            pinned_server_cert=cloud.sync_gateway.tls_cert(),
+            pinned_server_cert=sync_gateway.tls_cert(),
         )
         await replicator.start()
 
@@ -625,7 +632,7 @@ class TestBasicReplication(CBLTestClass):
         self.mark_test_step("Check that all docs are replicated correctly.")
         await compare_local_and_remote(
             db,
-            cloud.sync_gateway,
+            sync_gateway,
             ReplicatorType.PUSH_AND_PULL,
             "travel",
             [
@@ -705,13 +712,13 @@ class TestBasicReplication(CBLTestClass):
                 },
             ),
         ]
-        await cloud.sync_gateway.update_documents(
+        await sync_gateway.update_documents(
             "travel", routes_updates, "travel", "routes"
         )
 
         # Update 2 SG landmarks in `travel.landmarks`
         landmarks_updates: list[DocumentUpdateEntry] = []
-        landmarks_all_docs = await cloud.sync_gateway.get_all_documents(
+        landmarks_all_docs = await sync_gateway.get_all_documents(
             "travel", "travel", "landmarks"
         )
         for doc in landmarks_all_docs.rows:
@@ -745,13 +752,13 @@ class TestBasicReplication(CBLTestClass):
                         },
                     )
                 )
-        await cloud.sync_gateway.update_documents(
+        await sync_gateway.update_documents(
             "travel", landmarks_updates, "travel", "landmarks"
         )
 
         # Update 2 CBL hotels in `travel.landmarks`
         hotels_updates: list[DocumentUpdateEntry] = []
-        hotels_all_docs = await cloud.sync_gateway.get_all_documents(
+        hotels_all_docs = await sync_gateway.get_all_documents(
             "travel", "travel", "hotels"
         )
         for doc in hotels_all_docs.rows:
@@ -797,12 +804,12 @@ class TestBasicReplication(CBLTestClass):
                         },
                     )
                 )
-        await cloud.sync_gateway.update_documents(
+        await sync_gateway.update_documents(
             "travel", hotels_updates, "travel", "hotels"
         )
 
         # Remove 2 SG and 2 CBL hotels in `travel.hotels`
-        hotels_all_docs = await cloud.sync_gateway.get_all_documents(
+        hotels_all_docs = await sync_gateway.get_all_documents(
             "travel", "travel", "hotels"
         )
         for doc in hotels_all_docs.rows:
@@ -813,7 +820,7 @@ class TestBasicReplication(CBLTestClass):
                 or doc.id == "hotel_500"
             ):
                 revid = assert_not_null(doc.revid, f"Missing revid on {doc.id}")
-                await cloud.sync_gateway.delete_document(
+                await sync_gateway.delete_document(
                     doc.id, revid, "travel", "travel", "hotels"
                 )
 
@@ -947,7 +954,7 @@ class TestBasicReplication(CBLTestClass):
         self.mark_test_step("Check that all updates are replicated correctly.")
         await compare_local_and_remote(
             db,
-            cloud.sync_gateway,
+            sync_gateway,
             ReplicatorType.PUSH_AND_PULL,
             "travel",
             [
@@ -967,6 +974,7 @@ class TestBasicReplication(CBLTestClass):
     ) -> None:
         self.mark_test_step("Reset SG and load `names` dataset.")
         cloud = cblpytest.simple_cloud()
+        sync_gateway = cloud.sync_gateways[0]
         await cloud.configure_dataset(dataset_path, "names")
 
         self.mark_test_step("Reset local database, and load `names` dataset.")
@@ -984,11 +992,11 @@ class TestBasicReplication(CBLTestClass):
         """)
         replicator = Replicator(
             db,
-            cloud.sync_gateway.replication_url("names"),
+            sync_gateway.replication_url("names"),
             replicator_type=ReplicatorType.PUSH,
             collections=[ReplicatorCollectionEntry(["_default._default"])],
             authenticator=ReplicatorBasicAuthenticator("user1", "pass"),
-            pinned_server_cert=cloud.sync_gateway.tls_cert(),
+            pinned_server_cert=sync_gateway.tls_cert(),
         )
         await replicator.start()
 
@@ -1001,7 +1009,7 @@ class TestBasicReplication(CBLTestClass):
         self.mark_test_step("Check that all docs are replicated correctly.")
         await compare_local_and_remote(
             db,
-            cloud.sync_gateway,
+            sync_gateway,
             ReplicatorType.PUSH,
             "names",
             ["_default._default"],
@@ -1015,6 +1023,7 @@ class TestBasicReplication(CBLTestClass):
     ):
         self.mark_test_step("Reset SG and load `names` dataset.")
         cloud = cblpytest.simple_cloud()
+        sync_gateway = cloud.sync_gateways[0]
         await cloud.configure_dataset(dataset_path, "names")
 
         self.mark_test_step("Reset local database, and load `names` dataset.")
@@ -1032,11 +1041,11 @@ class TestBasicReplication(CBLTestClass):
         """)
         replicator = Replicator(
             db,
-            cloud.sync_gateway.replication_url("names"),
+            sync_gateway.replication_url("names"),
             replicator_type=ReplicatorType.PULL,
             collections=[ReplicatorCollectionEntry(["_default._default"])],
             authenticator=ReplicatorBasicAuthenticator("user1", "pass"),
-            pinned_server_cert=cloud.sync_gateway.tls_cert(),
+            pinned_server_cert=sync_gateway.tls_cert(),
         )
         await replicator.start()
 
@@ -1049,7 +1058,7 @@ class TestBasicReplication(CBLTestClass):
         self.mark_test_step("Check that all docs are replicated correctly.")
         await compare_local_and_remote(
             db,
-            cloud.sync_gateway,
+            sync_gateway,
             ReplicatorType.PULL,
             "names",
             ["_default._default"],
@@ -1063,6 +1072,7 @@ class TestBasicReplication(CBLTestClass):
     ):
         self.mark_test_step("Reset SG and load `names` dataset.")
         cloud = cblpytest.simple_cloud()
+        sync_gateway = cloud.sync_gateways[0]
         await cloud.configure_dataset(dataset_path, "names")
 
         self.mark_test_step("Reset local database, and load `names` dataset.")
@@ -1080,11 +1090,11 @@ class TestBasicReplication(CBLTestClass):
         """)
         replicator = Replicator(
             db,
-            cloud.sync_gateway.replication_url("names"),
+            sync_gateway.replication_url("names"),
             replicator_type=ReplicatorType.PUSH_AND_PULL,
             collections=[ReplicatorCollectionEntry(["_default._default"])],
             authenticator=ReplicatorBasicAuthenticator("user1", "pass"),
-            pinned_server_cert=cloud.sync_gateway.tls_cert(),
+            pinned_server_cert=sync_gateway.tls_cert(),
         )
         await replicator.start()
 
@@ -1097,7 +1107,7 @@ class TestBasicReplication(CBLTestClass):
         self.mark_test_step("Check that all docs are replicated correctly.")
         await compare_local_and_remote(
             db,
-            cloud.sync_gateway,
+            sync_gateway,
             ReplicatorType.PUSH_AND_PULL,
             "names",
             ["_default._default"],
@@ -1111,6 +1121,7 @@ class TestBasicReplication(CBLTestClass):
     ):
         self.mark_test_step("Reset SG and load `travel` dataset.")
         cloud = cblpytest.simple_cloud()
+        sync_gateway = cloud.sync_gateways[0]
         await cloud.configure_dataset(dataset_path, "travel")
 
         self.mark_test_step("Reset local database, and load `travel` dataset.")
@@ -1129,11 +1140,11 @@ class TestBasicReplication(CBLTestClass):
         """)
         replicator = Replicator(
             db,
-            cloud.sync_gateway.replication_url("travel"),
+            sync_gateway.replication_url("travel"),
             collections=[ReplicatorCollectionEntry(["travel.airlines"])],
             replicator_type=ReplicatorType.PUSH,
             authenticator=ReplicatorBasicAuthenticator("user1", "pass"),
-            pinned_server_cert=cloud.sync_gateway.tls_cert(),
+            pinned_server_cert=sync_gateway.tls_cert(),
         )
         await replicator.start()
 
@@ -1146,7 +1157,7 @@ class TestBasicReplication(CBLTestClass):
         self.mark_test_step("Check that all docs are replicated correctly.")
         await compare_local_and_remote(
             db,
-            cloud.sync_gateway,
+            sync_gateway,
             ReplicatorType.PUSH,
             "travel",
             ["travel.airlines"],
@@ -1154,7 +1165,7 @@ class TestBasicReplication(CBLTestClass):
 
         self.mark_test_step("Purge an airline doc from `travel.airlines` on SG.")
         sg_purged_doc_id = "airline_10"
-        await cloud.sync_gateway.purge_document(
+        await sync_gateway.purge_document(
             sg_purged_doc_id, "travel", "travel", "airlines"
         )
 
@@ -1168,7 +1179,7 @@ class TestBasicReplication(CBLTestClass):
         )
 
         self.mark_test_step("Check that the purged airline doc doesn't exist on SG.")
-        sg_all_docs = await cloud.sync_gateway.get_all_documents(
+        sg_all_docs = await sync_gateway.get_all_documents(
             "travel", "travel", "airlines"
         )
         for doc in sg_all_docs.rows:
@@ -1181,13 +1192,13 @@ class TestBasicReplication(CBLTestClass):
         )
         replicator = Replicator(
             db,
-            cloud.sync_gateway.replication_url("travel"),
+            sync_gateway.replication_url("travel"),
             collections=[ReplicatorCollectionEntry(["travel.airlines"])],
             replicator_type=ReplicatorType.PUSH,
             authenticator=ReplicatorBasicAuthenticator("user1", "pass"),
             reset=True,
             enable_document_listener=True,
-            pinned_server_cert=cloud.sync_gateway.tls_cert(),
+            pinned_server_cert=sync_gateway.tls_cert(),
         )
         await replicator.start()
 
@@ -1218,6 +1229,7 @@ class TestBasicReplication(CBLTestClass):
     ):
         self.mark_test_step("Reset SG and load `travel` dataset.")
         cloud = cblpytest.simple_cloud()
+        sync_gateway = cloud.sync_gateways[0]
         await cloud.configure_dataset(dataset_path, "travel")
 
         self.mark_test_step("Reset local database, and load `travel` dataset.")
@@ -1236,11 +1248,11 @@ class TestBasicReplication(CBLTestClass):
         """)
         replicator = Replicator(
             db,
-            cloud.sync_gateway.replication_url("travel"),
+            sync_gateway.replication_url("travel"),
             collections=[ReplicatorCollectionEntry(["travel.airports"])],
             replicator_type=ReplicatorType.PULL,
             authenticator=ReplicatorBasicAuthenticator("user1", "pass"),
-            pinned_server_cert=cloud.sync_gateway.tls_cert(),
+            pinned_server_cert=sync_gateway.tls_cert(),
         )
         await replicator.start()
 
@@ -1253,7 +1265,7 @@ class TestBasicReplication(CBLTestClass):
         self.mark_test_step("Check that all docs are replicated correctly.")
         await compare_local_and_remote(
             db,
-            cloud.sync_gateway,
+            sync_gateway,
             ReplicatorType.PULL,
             "travel",
             ["travel.airports"],
@@ -1289,13 +1301,13 @@ class TestBasicReplication(CBLTestClass):
         )
         replicator = Replicator(
             db,
-            cloud.sync_gateway.replication_url("travel"),
+            sync_gateway.replication_url("travel"),
             collections=[ReplicatorCollectionEntry(["travel.airports"])],
             replicator_type=ReplicatorType.PULL,
             authenticator=ReplicatorBasicAuthenticator("user1", "pass"),
             reset=True,
             enable_document_listener=True,
-            pinned_server_cert=cloud.sync_gateway.tls_cert(),
+            pinned_server_cert=sync_gateway.tls_cert(),
         )
         await replicator.start()
 

--- a/tests/dev_e2e/test_custom_conflict.py
+++ b/tests/dev_e2e/test_custom_conflict.py
@@ -30,6 +30,7 @@ class TestCustomConflict(CBLTestClass):
     ):
         self.mark_test_step("Reset SG and load `names` dataset")
         cloud = cblpytest.simple_cloud()
+        sync_gateway = cloud.sync_gateways[0]
         await cloud.configure_dataset(dataset_path, "names")
 
         self.mark_test_step("Reset empty local database")
@@ -46,11 +47,11 @@ class TestCustomConflict(CBLTestClass):
         """)
         replicator = Replicator(
             db,
-            cloud.sync_gateway.replication_url("names"),
+            sync_gateway.replication_url("names"),
             replicator_type=ReplicatorType.PULL,
             collections=[ReplicatorCollectionEntry(["_default._default"])],
             authenticator=ReplicatorBasicAuthenticator("user1", "pass"),
-            pinned_server_cert=cloud.sync_gateway.tls_cert(),
+            pinned_server_cert=sync_gateway.tls_cert(),
         )
         await replicator.start()
 
@@ -63,7 +64,7 @@ class TestCustomConflict(CBLTestClass):
         self.mark_test_step("Check that all docs are replicated correctly.")
         await compare_local_and_remote(
             db,
-            cloud.sync_gateway,
+            sync_gateway,
             ReplicatorType.PULL,
             "names",
             ["_default._default"],
@@ -82,11 +83,11 @@ class TestCustomConflict(CBLTestClass):
             b.upsert_document(update_coll, update_id, [{"name.last": "Smith"}])
 
         self.mark_test_step("Modify the remote name_101 document `name.last` = 'Jones'")
-        existing = await cloud.sync_gateway.get_document("names", "name_101")
+        existing = await sync_gateway.get_document("names", "name_101")
         assert existing is not None, "Missing name_101 on remote"
         newBody = existing.body
         newBody["name"]["last"] = "Jones"
-        await cloud.sync_gateway.update_documents(
+        await sync_gateway.update_documents(
             "names", [DocumentUpdateEntry("name_101", existing.revid, newBody)]
         )
 
@@ -106,7 +107,7 @@ class TestCustomConflict(CBLTestClass):
         """)
         replicator = Replicator(
             db,
-            cloud.sync_gateway.replication_url("names"),
+            sync_gateway.replication_url("names"),
             replicator_type=ReplicatorType.PULL,
             collections=[
                 ReplicatorCollectionEntry(
@@ -114,7 +115,7 @@ class TestCustomConflict(CBLTestClass):
                 )
             ],
             authenticator=ReplicatorBasicAuthenticator("user1", "pass"),
-            pinned_server_cert=cloud.sync_gateway.tls_cert(),
+            pinned_server_cert=sync_gateway.tls_cert(),
         )
         await replicator.start()
 
@@ -136,6 +137,7 @@ class TestCustomConflict(CBLTestClass):
     ):
         self.mark_test_step("Reset SG and load `names` dataset")
         cloud = cblpytest.simple_cloud()
+        sync_gateway = cloud.sync_gateways[0]
         await cloud.configure_dataset(dataset_path, "names")
 
         self.mark_test_step("Reset empty local database")
@@ -152,11 +154,11 @@ class TestCustomConflict(CBLTestClass):
         """)
         replicator = Replicator(
             db,
-            cloud.sync_gateway.replication_url("names"),
+            sync_gateway.replication_url("names"),
             replicator_type=ReplicatorType.PULL,
             collections=[ReplicatorCollectionEntry(["_default._default"])],
             authenticator=ReplicatorBasicAuthenticator("user1", "pass"),
-            pinned_server_cert=cloud.sync_gateway.tls_cert(),
+            pinned_server_cert=sync_gateway.tls_cert(),
         )
         await replicator.start()
 
@@ -169,7 +171,7 @@ class TestCustomConflict(CBLTestClass):
         self.mark_test_step("Check that all docs are replicated correctly.")
         await compare_local_and_remote(
             db,
-            cloud.sync_gateway,
+            sync_gateway,
             ReplicatorType.PULL,
             "names",
             ["_default._default"],
@@ -204,7 +206,7 @@ class TestCustomConflict(CBLTestClass):
         sgw_updates: list[DocumentUpdateEntry] = []
         for suffix in range(101, 104):
             existing_id = f"name_{suffix}"
-            existing = await cloud.sync_gateway.get_document("names", existing_id)
+            existing = await sync_gateway.get_document("names", existing_id)
             assert existing is not None, f"Missing {existing_id} on remote"
             newBody = existing.body
             newBody["name"]["last"] = "Jones"
@@ -212,7 +214,7 @@ class TestCustomConflict(CBLTestClass):
                 DocumentUpdateEntry(existing_id, existing.revid, newBody)
             )
 
-        await cloud.sync_gateway.update_documents("names", sgw_updates)
+        await sync_gateway.update_documents("names", sgw_updates)
 
         self.mark_test_step("""
             Start a replicator:
@@ -225,7 +227,7 @@ class TestCustomConflict(CBLTestClass):
         """)
         replicator = Replicator(
             db,
-            cloud.sync_gateway.replication_url("names"),
+            sync_gateway.replication_url("names"),
             replicator_type=ReplicatorType.PULL,
             collections=[
                 ReplicatorCollectionEntry(
@@ -234,7 +236,7 @@ class TestCustomConflict(CBLTestClass):
                 )
             ],
             authenticator=ReplicatorBasicAuthenticator("user1", "pass"),
-            pinned_server_cert=cloud.sync_gateway.tls_cert(),
+            pinned_server_cert=sync_gateway.tls_cert(),
         )
         await replicator.start()
 
@@ -263,7 +265,7 @@ class TestCustomConflict(CBLTestClass):
         """)
         replicator = Replicator(
             db,
-            cloud.sync_gateway.replication_url("names"),
+            sync_gateway.replication_url("names"),
             replicator_type=ReplicatorType.PUSH,
             collections=[
                 ReplicatorCollectionEntry(
@@ -272,7 +274,7 @@ class TestCustomConflict(CBLTestClass):
                 )
             ],
             authenticator=ReplicatorBasicAuthenticator("user1", "pass"),
-            pinned_server_cert=cloud.sync_gateway.tls_cert(),
+            pinned_server_cert=sync_gateway.tls_cert(),
         )
         await replicator.start()
 
@@ -285,7 +287,7 @@ class TestCustomConflict(CBLTestClass):
         self.mark_test_step("Check that all docs are replicated correctly.")
         await compare_local_and_remote(
             db,
-            cloud.sync_gateway,
+            sync_gateway,
             ReplicatorType.PUSH,
             "names",
             ["_default._default"],
@@ -294,11 +296,11 @@ class TestCustomConflict(CBLTestClass):
         self.mark_test_step(
             "Update name_101 document with `name.last` = 'Jackson' in SG"
         )
-        name_101_sg = await cloud.sync_gateway.get_document("names", "name_101")
+        name_101_sg = await sync_gateway.get_document("names", "name_101")
         assert name_101_sg is not None, "Missing name_101 on remote"
         newBody = name_101_sg.body
         newBody["name"]["last"] = "Jackson"
-        await cloud.sync_gateway.update_documents(
+        await sync_gateway.update_documents(
             "names", [DocumentUpdateEntry("name_101", name_101_sg.revid, newBody)]
         )
 
@@ -325,7 +327,7 @@ class TestCustomConflict(CBLTestClass):
         """)
         replicator = Replicator(
             db,
-            cloud.sync_gateway.replication_url("names"),
+            sync_gateway.replication_url("names"),
             replicator_type=ReplicatorType.PUSH_AND_PULL,
             reset=True,
             collections=[
@@ -335,7 +337,7 @@ class TestCustomConflict(CBLTestClass):
                 )
             ],
             authenticator=ReplicatorBasicAuthenticator("user1", "pass"),
-            pinned_server_cert=cloud.sync_gateway.tls_cert(),
+            pinned_server_cert=sync_gateway.tls_cert(),
         )
         await replicator.start()
 
@@ -348,7 +350,7 @@ class TestCustomConflict(CBLTestClass):
         self.mark_test_step("Check that all docs are replicated correctly.")
         await compare_local_and_remote(
             db,
-            cloud.sync_gateway,
+            sync_gateway,
             ReplicatorType.PUSH_AND_PULL,
             "names",
             ["_default._default"],

--- a/tests/dev_e2e/test_encrypted_properties.py
+++ b/tests/dev_e2e/test_encrypted_properties.py
@@ -25,6 +25,7 @@ class TestEncryptedProperties(CBLTestClass):
 
         self.mark_test_step("Reset SG and load `names` dataset")
         cloud = cblpytest.simple_cloud()
+        sync_gateway = cloud.sync_gateways[0]
         await cloud.configure_dataset(dataset_path, "names")
 
         self.mark_test_step("Reset empty local database")
@@ -48,7 +49,7 @@ class TestEncryptedProperties(CBLTestClass):
         """)
         replicator = Replicator(
             db,
-            cloud.sync_gateway.replication_url("names"),
+            sync_gateway.replication_url("names"),
             replicator_type=ReplicatorType.PUSH,
             collections=[
                 ReplicatorCollectionEntry(
@@ -56,7 +57,7 @@ class TestEncryptedProperties(CBLTestClass):
                 )
             ],
             authenticator=ReplicatorBasicAuthenticator("user1", "pass"),
-            pinned_server_cert=cloud.sync_gateway.tls_cert(),
+            pinned_server_cert=sync_gateway.tls_cert(),
         )
         await replicator.start()
 
@@ -67,7 +68,7 @@ class TestEncryptedProperties(CBLTestClass):
         )
 
         self.mark_test_step("Check that the document in SG is not in plaintext")
-        pushed_doc = await cloud.sync_gateway.get_document("names", "secret")
+        pushed_doc = await sync_gateway.get_document("names", "secret")
         assert pushed_doc is not None, "Document not found in SG"
         assert "password" not in pushed_doc.body, (
             "The document was pushed without encryption"

--- a/tests/dev_e2e/test_fest.py
+++ b/tests/dev_e2e/test_fest.py
@@ -20,6 +20,7 @@ class TestFest(CBLTestClass):
     async def setup_test_fest_cloud(
         self, cloud: CouchbaseCloud, dataset_path: Path, roles: dict[str, list[str]]
     ) -> CouchbaseCloud:
+        sync_gateway = cloud.sync_gateways[0]
         self.mark_test_step("Reset SG and load todo dataset")
         await cloud.configure_dataset(dataset_path, "todo")
 
@@ -28,7 +29,7 @@ class TestFest(CBLTestClass):
                 f"Assign roles '{', '.join(user_roles)}' to the user '{user}'"
             )
             for role in user_roles:
-                await cloud.sync_gateway.add_role(
+                await sync_gateway.add_role(
                     "todo",
                     role,
                     {
@@ -39,7 +40,7 @@ class TestFest(CBLTestClass):
                         }
                     },
                 )
-            await cloud.sync_gateway.add_user("todo", user, admin_roles=user_roles)
+            await sync_gateway.add_user("todo", user, admin_roles=user_roles)
 
         return cloud
 
@@ -55,6 +56,7 @@ class TestFest(CBLTestClass):
         dbs: tuple[Database, Database],
         users: tuple[str, str] = ("user1", "user1"),
     ) -> tuple[Replicator, Replicator]:
+        sync_gateway = cloud.sync_gateways[0]
         self.mark_test_step(f"""
                 Create a replicator
                     * endpoint: /todo
@@ -67,7 +69,7 @@ class TestFest(CBLTestClass):
             """)
         repl1 = Replicator(
             dbs[0],
-            cloud.sync_gateway.replication_url("todo"),
+            sync_gateway.replication_url("todo"),
             replicator_type=ReplicatorType.PUSH_AND_PULL,
             continuous=True,
             collections=[
@@ -77,7 +79,7 @@ class TestFest(CBLTestClass):
             ],
             authenticator=ReplicatorBasicAuthenticator(users[0], "pass"),
             enable_document_listener=True,
-            pinned_server_cert=cloud.sync_gateway.tls_cert(),
+            pinned_server_cert=sync_gateway.tls_cert(),
         )
 
         self.mark_test_step(f"""
@@ -92,7 +94,7 @@ class TestFest(CBLTestClass):
             """)
         repl2 = Replicator(
             dbs[1],
-            cloud.sync_gateway.replication_url("todo"),
+            sync_gateway.replication_url("todo"),
             replicator_type=ReplicatorType.PUSH_AND_PULL,
             continuous=True,
             collections=[
@@ -102,7 +104,7 @@ class TestFest(CBLTestClass):
             ],
             authenticator=ReplicatorBasicAuthenticator(users[1], "pass"),
             enable_document_listener=True,
-            pinned_server_cert=cloud.sync_gateway.tls_cert(),
+            pinned_server_cert=sync_gateway.tls_cert(),
         )
 
         return repl1, repl2

--- a/tests/dev_e2e/test_query_consistency.py
+++ b/tests/dev_e2e/test_query_consistency.py
@@ -32,6 +32,7 @@ class TestQueryConsistency(CBLTestClass):
         # These tests do not modify the data in the bucket, so set it up here to avoid
         # needless teardown and re-setup
         cloud = cblpytest.simple_cloud()
+        sync_gateway = cloud.sync_gateways[0]
         await cloud.configure_dataset(dataset_path, "travel")
 
         dbs = await cblpytest.test_servers[0].create_and_reset_db(
@@ -39,7 +40,7 @@ class TestQueryConsistency(CBLTestClass):
         )
         replicator = Replicator(
             dbs[0],
-            cloud.sync_gateway.replication_url("travel"),
+            sync_gateway.replication_url("travel"),
             collections=[
                 ReplicatorCollectionEntry(
                     [
@@ -53,7 +54,7 @@ class TestQueryConsistency(CBLTestClass):
             ],
             replicator_type=ReplicatorType.PUSH_AND_PULL,
             authenticator=ReplicatorBasicAuthenticator("user1", "pass"),
-            pinned_server_cert=cloud.sync_gateway.tls_cert(),
+            pinned_server_cert=sync_gateway.tls_cert(),
         )
         await replicator.start()
 

--- a/tests/dev_e2e/test_replication_auto_purge.py
+++ b/tests/dev_e2e/test_replication_auto_purge.py
@@ -27,6 +27,7 @@ class TestReplicationAutoPurge(CBLTestClass):
     ) -> None:
         self.mark_test_step("Reset SG and load `posts` dataset")
         cloud = cblpytest.simple_cloud()
+        sync_gateway = cloud.sync_gateways[0]
         await cloud.configure_dataset(dataset_path, "posts")
 
         self.mark_test_step("Reset local database and load `posts` dataset")
@@ -47,13 +48,13 @@ class TestReplicationAutoPurge(CBLTestClass):
         """)
         replicator = Replicator(
             db,
-            cloud.sync_gateway.replication_url("posts"),
+            sync_gateway.replication_url("posts"),
             collections=[ReplicatorCollectionEntry(["_default.posts"])],
             replicator_type=ReplicatorType.PULL,
             continuous=False,
             enable_auto_purge=True,
             authenticator=ReplicatorBasicAuthenticator("user1", "pass"),
-            pinned_server_cert=cloud.sync_gateway.tls_cert(),
+            pinned_server_cert=sync_gateway.tls_cert(),
         )
         await replicator.start()
 
@@ -97,11 +98,11 @@ class TestReplicationAutoPurge(CBLTestClass):
                     DocumentUpdateEntry(doc.id, doc.rev, {"channels": ["group2"]})
                 )
             elif doc.id == "post_4":
-                await cloud.sync_gateway.delete_document(
+                await sync_gateway.delete_document(
                     "post_4", doc.rev, "posts", collection="posts"
                 )
 
-        await cloud.sync_gateway.update_documents("posts", updates, collection="posts")
+        await sync_gateway.update_documents("posts", updates, collection="posts")
 
         self.mark_test_step("Start another replicator with the same config as above")
         replicator.enable_document_listener = True
@@ -161,6 +162,7 @@ class TestReplicationAutoPurge(CBLTestClass):
     ) -> None:
         self.mark_test_step("Reset SG and load `posts` dataset")
         cloud = cblpytest.simple_cloud()
+        sync_gateway = cloud.sync_gateways[0]
         await cloud.configure_dataset(dataset_path, "posts")
 
         self.mark_test_step("Reset local database and load `posts` dataset")
@@ -181,13 +183,13 @@ class TestReplicationAutoPurge(CBLTestClass):
         """)
         replicator = Replicator(
             db,
-            cloud.sync_gateway.replication_url("posts"),
+            sync_gateway.replication_url("posts"),
             collections=[ReplicatorCollectionEntry(["_default.posts"])],
             replicator_type=ReplicatorType.PULL,
             continuous=False,
             enable_auto_purge=True,
             authenticator=ReplicatorBasicAuthenticator("user1", "pass"),
-            pinned_server_cert=cloud.sync_gateway.tls_cert(),
+            pinned_server_cert=sync_gateway.tls_cert(),
         )
         await replicator.start()
 
@@ -217,9 +219,7 @@ class TestReplicationAutoPurge(CBLTestClass):
         collection_access_dict = cblpytest.sync_gateways[
             0
         ].create_collection_access_dict({"_default.posts": ["group1"]})
-        await cloud.sync_gateway.add_user(
-            "posts", "user1", "pass", collection_access_dict
-        )
+        await sync_gateway.add_user("posts", "user1", "pass", collection_access_dict)
 
         self.mark_test_step("Start another replicator with the same config as above")
         replicator.enable_document_listener = True
@@ -267,9 +267,7 @@ class TestReplicationAutoPurge(CBLTestClass):
         collection_access_dict = cblpytest.sync_gateways[
             0
         ].create_collection_access_dict({"_default.posts": ["group1", "group2"]})
-        await cloud.sync_gateway.add_user(
-            "posts", "user1", "pass", collection_access_dict
-        )
+        await sync_gateway.add_user("posts", "user1", "pass", collection_access_dict)
 
         self.mark_test_step("Start another replicator with the same config as above")
         replicator.clear_document_updates()
@@ -318,6 +316,7 @@ class TestReplicationAutoPurge(CBLTestClass):
     ) -> None:
         self.mark_test_step("Reset SG and load `posts` dataset")
         cloud = cblpytest.simple_cloud()
+        sync_gateway = cloud.sync_gateways[0]
         await cloud.configure_dataset(dataset_path, "posts")
 
         self.mark_test_step("Reset local database and load `posts` dataset")
@@ -338,13 +337,13 @@ class TestReplicationAutoPurge(CBLTestClass):
         """)
         repl1 = Replicator(
             db,
-            cloud.sync_gateway.replication_url("posts"),
+            sync_gateway.replication_url("posts"),
             collections=[ReplicatorCollectionEntry(["_default.posts"])],
             replicator_type=ReplicatorType.PULL,
             continuous=False,
             enable_auto_purge=False,
             authenticator=ReplicatorBasicAuthenticator("user1", "pass"),
-            pinned_server_cert=cloud.sync_gateway.tls_cert(),
+            pinned_server_cert=sync_gateway.tls_cert(),
         )
         await repl1.start()
 
@@ -397,21 +396,21 @@ class TestReplicationAutoPurge(CBLTestClass):
                 updates.append(
                     DocumentUpdateEntry(doc.id, doc.rev, {"channels": ["group2"]})
                 )
-        await cloud.sync_gateway.update_documents("posts", updates, collection="posts")
+        await sync_gateway.update_documents("posts", updates, collection="posts")
 
         self.mark_test_step(
             "Start a continuous replicator with a config similar to the one above"
         )
         repl2 = Replicator(
             db,
-            cloud.sync_gateway.replication_url("posts"),
+            sync_gateway.replication_url("posts"),
             collections=[ReplicatorCollectionEntry(["_default.posts"])],
             replicator_type=ReplicatorType.PULL,
             continuous=True,
             enable_auto_purge=False,
             authenticator=ReplicatorBasicAuthenticator("user1", "pass"),
             enable_document_listener=True,
-            pinned_server_cert=cloud.sync_gateway.tls_cert(),
+            pinned_server_cert=sync_gateway.tls_cert(),
         )
         await repl2.start()
 
@@ -481,6 +480,7 @@ class TestReplicationAutoPurge(CBLTestClass):
     ) -> None:
         self.mark_test_step("Reset SG and load `posts` dataset")
         cloud = cblpytest.simple_cloud()
+        sync_gateway = cloud.sync_gateways[0]
         await cloud.configure_dataset(dataset_path, "posts")
 
         self.mark_test_step("Reset local database and load `posts` dataset")
@@ -501,13 +501,13 @@ class TestReplicationAutoPurge(CBLTestClass):
         """)
         repl1 = Replicator(
             db,
-            cloud.sync_gateway.replication_url("posts"),
+            sync_gateway.replication_url("posts"),
             collections=[ReplicatorCollectionEntry(["_default.posts"])],
             replicator_type=ReplicatorType.PULL,
             continuous=False,
             enable_auto_purge=False,
             authenticator=ReplicatorBasicAuthenticator("user1", "pass"),
-            pinned_server_cert=cloud.sync_gateway.tls_cert(),
+            pinned_server_cert=sync_gateway.tls_cert(),
         )
         await repl1.start()
 
@@ -537,9 +537,7 @@ class TestReplicationAutoPurge(CBLTestClass):
         collection_access_dict = cblpytest.sync_gateways[
             0
         ].create_collection_access_dict({"_default.posts": ["group1"]})
-        await cloud.sync_gateway.add_user(
-            "posts", "user1", "pass", collection_access_dict
-        )
+        await sync_gateway.add_user("posts", "user1", "pass", collection_access_dict)
 
         self.mark_test_step("""
              Start another replicator:
@@ -553,14 +551,14 @@ class TestReplicationAutoPurge(CBLTestClass):
          """)
         repl2 = Replicator(
             db,
-            cloud.sync_gateway.replication_url("posts"),
+            sync_gateway.replication_url("posts"),
             collections=[ReplicatorCollectionEntry(["_default.posts"])],
             replicator_type=ReplicatorType.PULL,
             continuous=True,
             enable_auto_purge=False,
             authenticator=ReplicatorBasicAuthenticator("user1", "pass"),
             enable_document_listener=True,
-            pinned_server_cert=cloud.sync_gateway.tls_cert(),
+            pinned_server_cert=sync_gateway.tls_cert(),
         )
         await repl2.start()
 
@@ -606,6 +604,7 @@ class TestReplicationAutoPurge(CBLTestClass):
     ) -> None:
         self.mark_test_step("Reset SG and load `posts` dataset")
         cloud = cblpytest.simple_cloud()
+        sync_gateway = cloud.sync_gateways[0]
         await cloud.configure_dataset(dataset_path, "posts")
 
         self.mark_test_step("Reset local database and load `posts` dataset")
@@ -626,13 +625,13 @@ class TestReplicationAutoPurge(CBLTestClass):
         """)
         repl1 = Replicator(
             db,
-            cloud.sync_gateway.replication_url("posts"),
+            sync_gateway.replication_url("posts"),
             collections=[ReplicatorCollectionEntry(["_default.posts"])],
             replicator_type=ReplicatorType.PULL,
             continuous=False,
             enable_auto_purge=True,
             authenticator=ReplicatorBasicAuthenticator("user1", "pass"),
-            pinned_server_cert=cloud.sync_gateway.tls_cert(),
+            pinned_server_cert=sync_gateway.tls_cert(),
         )
         await repl1.start()
 
@@ -678,7 +677,7 @@ class TestReplicationAutoPurge(CBLTestClass):
             DocumentUpdateEntry("post_1", rev_ids["post_1"], body={"channels": []}),
             DocumentUpdateEntry("post_2", rev_ids["post_2"], body={"channels": []}),
         ]
-        await cloud.sync_gateway.update_documents(
+        await sync_gateway.update_documents(
             "posts", channel_access_dict, "_default", "posts"
         )
 
@@ -695,7 +694,7 @@ class TestReplicationAutoPurge(CBLTestClass):
          """)
         repl2 = Replicator(
             db,
-            cloud.sync_gateway.replication_url("posts"),
+            sync_gateway.replication_url("posts"),
             collections=[
                 ReplicatorCollectionEntry(
                     ["_default.posts"],
@@ -709,7 +708,7 @@ class TestReplicationAutoPurge(CBLTestClass):
             enable_auto_purge=True,
             authenticator=ReplicatorBasicAuthenticator("user1", "pass"),
             enable_document_listener=True,
-            pinned_server_cert=cloud.sync_gateway.tls_cert(),
+            pinned_server_cert=sync_gateway.tls_cert(),
         )
         await repl2.start()
 
@@ -760,6 +759,7 @@ class TestReplicationAutoPurge(CBLTestClass):
     ) -> None:
         self.mark_test_step("Reset SG and load `posts` dataset")
         cloud = cblpytest.simple_cloud()
+        sync_gateway = cloud.sync_gateways[0]
         await cloud.configure_dataset(dataset_path, "posts")
 
         self.mark_test_step("Reset local database and load `posts` dataset")
@@ -780,13 +780,13 @@ class TestReplicationAutoPurge(CBLTestClass):
         """)
         replicator = Replicator(
             db,
-            cloud.sync_gateway.replication_url("posts"),
+            sync_gateway.replication_url("posts"),
             collections=[ReplicatorCollectionEntry(["_default.posts"])],
             replicator_type=ReplicatorType.PULL,
             continuous=False,
             enable_auto_purge=auto_purge_enabled,
             authenticator=ReplicatorBasicAuthenticator("user1", "pass"),
-            pinned_server_cert=cloud.sync_gateway.tls_cert(),
+            pinned_server_cert=sync_gateway.tls_cert(),
         )
         await replicator.start()
 
@@ -813,7 +813,7 @@ class TestReplicationAutoPurge(CBLTestClass):
         self.mark_test_step(
             "Update user by removing `group2` from the `admin_channels` property."
         )
-        await cloud.sync_gateway.add_user(
+        await sync_gateway.add_user(
             "posts",
             "user1",
             "pass",
@@ -877,6 +877,7 @@ class TestReplicationAutoPurge(CBLTestClass):
     ):
         self.mark_test_step("Reset SG and load `posts` dataset")
         cloud = cblpytest.simple_cloud()
+        sync_gateway = cloud.sync_gateways[0]
         await cloud.configure_dataset(dataset_path, "posts")
 
         self.mark_test_step("Reset local database and load `posts` dataset")
@@ -888,12 +889,12 @@ class TestReplicationAutoPurge(CBLTestClass):
         self.mark_test_step(
             "Add a role on Sync Gateway `role1` with access to channel `group3` in `_default.posts`"
         )
-        await cloud.sync_gateway.add_role(
+        await sync_gateway.add_role(
             "posts", "role1", {"_default": {"posts": {"admin_channels": ["group3"]}}}
         )
 
         self.mark_test_step("Update `user1` to be in `role1`")
-        await cloud.sync_gateway.add_user(
+        await sync_gateway.add_user(
             "posts",
             "user1",
             "pass",
@@ -908,7 +909,7 @@ class TestReplicationAutoPurge(CBLTestClass):
                 * channels: ["group3"]
                 * owner: user2
         """)
-        await cloud.sync_gateway.update_documents(
+        await sync_gateway.update_documents(
             "posts",
             [
                 DocumentUpdateEntry(
@@ -937,13 +938,13 @@ class TestReplicationAutoPurge(CBLTestClass):
         """)
         replicator = Replicator(
             db,
-            cloud.sync_gateway.replication_url("posts"),
+            sync_gateway.replication_url("posts"),
             collections=[ReplicatorCollectionEntry(["_default.posts"])],
             replicator_type=ReplicatorType.PULL,
             continuous=False,
             enable_auto_purge=auto_purge_enabled,
             authenticator=ReplicatorBasicAuthenticator("user1", "pass"),
-            pinned_server_cert=cloud.sync_gateway.tls_cert(),
+            pinned_server_cert=sync_gateway.tls_cert(),
         )
         await replicator.start()
 
@@ -970,7 +971,7 @@ class TestReplicationAutoPurge(CBLTestClass):
         self.mark_test_step(
             "Update `role1` by removing `group3` from the `admin_channels` property."
         )
-        await cloud.sync_gateway.add_role(
+        await sync_gateway.add_role(
             "posts", "role1", {"_default": {"posts": {"collection_access": {}}}}
         )
 
@@ -1029,6 +1030,7 @@ class TestReplicationAutoPurge(CBLTestClass):
     ):
         self.mark_test_step("Reset SG and load `posts` dataset")
         cloud = cblpytest.simple_cloud()
+        sync_gateway = cloud.sync_gateways[0]
         await cloud.configure_dataset(dataset_path, "posts")
 
         self.mark_test_step("Reset local database and load `posts` dataset")
@@ -1049,13 +1051,13 @@ class TestReplicationAutoPurge(CBLTestClass):
         """)
         repl = Replicator(
             db,
-            cloud.sync_gateway.replication_url("posts"),
+            sync_gateway.replication_url("posts"),
             collections=[ReplicatorCollectionEntry(["_default.posts"])],
             replicator_type=ReplicatorType.PULL,
             continuous=False,
             enable_auto_purge=True,
             authenticator=ReplicatorBasicAuthenticator("user1", "pass"),
-            pinned_server_cert=cloud.sync_gateway.tls_cert(),
+            pinned_server_cert=sync_gateway.tls_cert(),
         )
         await repl.start()
 
@@ -1093,13 +1095,13 @@ class TestReplicationAutoPurge(CBLTestClass):
         """)
         repl = Replicator(
             db,
-            cloud.sync_gateway.replication_url("posts"),
+            sync_gateway.replication_url("posts"),
             collections=[ReplicatorCollectionEntry(["_default.posts"])],
             replicator_type=ReplicatorType.PULL,
             continuous=True,
             enable_document_listener=True,
             authenticator=ReplicatorBasicAuthenticator("user1", "pass"),
-            pinned_server_cert=cloud.sync_gateway.tls_cert(),
+            pinned_server_cert=sync_gateway.tls_cert(),
         )
         await repl.start()
 
@@ -1110,7 +1112,7 @@ class TestReplicationAutoPurge(CBLTestClass):
             Update doc in SGW:
                 * Update `post_1` with channels = [] (ACCESS-REMOVED)
         """)
-        await cloud.sync_gateway.update_documents(
+        await sync_gateway.update_documents(
             "posts",
             [DocumentUpdateEntry("post_1", rev_ids["post_1"], {"channels": []})],
             collection="posts",
@@ -1140,11 +1142,11 @@ class TestReplicationAutoPurge(CBLTestClass):
             Update doc in SGW:
                 * Update `post_1` with channels = ["group1"]
         """)
-        remote_doc = await cloud.sync_gateway.get_document(
+        remote_doc = await sync_gateway.get_document(
             "posts", "post_1", collection="posts"
         )
         assert remote_doc is not None, "post_1 vanished from SGW"
-        await cloud.sync_gateway.update_documents(
+        await sync_gateway.update_documents(
             "posts",
             [
                 DocumentUpdateEntry(
@@ -1178,6 +1180,7 @@ class TestReplicationAutoPurge(CBLTestClass):
     ):
         self.mark_test_step("Reset SG and load `posts` dataset")
         cloud = cblpytest.simple_cloud()
+        sync_gateway = cloud.sync_gateways[0]
         await cloud.configure_dataset(dataset_path, "posts")
 
         self.mark_test_step("Reset local database and load `posts` dataset")
@@ -1198,13 +1201,13 @@ class TestReplicationAutoPurge(CBLTestClass):
         """)
         repl = Replicator(
             db,
-            cloud.sync_gateway.replication_url("posts"),
+            sync_gateway.replication_url("posts"),
             collections=[ReplicatorCollectionEntry(["_default.posts"])],
             replicator_type=ReplicatorType.PULL,
             continuous=False,
             enable_auto_purge=True,
             authenticator=ReplicatorBasicAuthenticator("user1", "pass"),
-            pinned_server_cert=cloud.sync_gateway.tls_cert(),
+            pinned_server_cert=sync_gateway.tls_cert(),
         )
         await repl.start()
 
@@ -1242,13 +1245,13 @@ class TestReplicationAutoPurge(CBLTestClass):
         """)
         repl = Replicator(
             db,
-            cloud.sync_gateway.replication_url("posts"),
+            sync_gateway.replication_url("posts"),
             collections=[ReplicatorCollectionEntry(["_default.posts"])],
             replicator_type=ReplicatorType.PUSH,
             continuous=True,
             enable_document_listener=True,
             authenticator=ReplicatorBasicAuthenticator("user1", "pass"),
-            pinned_server_cert=cloud.sync_gateway.tls_cert(),
+            pinned_server_cert=sync_gateway.tls_cert(),
         )
         await repl.start()
 
@@ -1300,7 +1303,7 @@ class TestReplicationAutoPurge(CBLTestClass):
         self.mark_test_step(
             "Check that `post_1` on Sync Gateway has channels = ['fake']"
         )
-        remote_doc = await cloud.sync_gateway.get_document(
+        remote_doc = await sync_gateway.get_document(
             "posts", "post_1", collection="posts"
         )
 
@@ -1316,6 +1319,7 @@ class TestReplicationAutoPurge(CBLTestClass):
     ):
         self.mark_test_step("Reset SG and load `posts` dataset")
         cloud = cblpytest.simple_cloud()
+        sync_gateway = cloud.sync_gateways[0]
         await cloud.configure_dataset(dataset_path, "posts")
 
         self.mark_test_step("Reset local database and load `posts` dataset")
@@ -1336,13 +1340,13 @@ class TestReplicationAutoPurge(CBLTestClass):
         """)
         repl = Replicator(
             db,
-            cloud.sync_gateway.replication_url("posts"),
+            sync_gateway.replication_url("posts"),
             collections=[ReplicatorCollectionEntry(["_default.posts"])],
             replicator_type=ReplicatorType.PULL,
             continuous=False,
             enable_auto_purge=True,
             authenticator=ReplicatorBasicAuthenticator("user1", "pass"),
-            pinned_server_cert=cloud.sync_gateway.tls_cert(),
+            pinned_server_cert=sync_gateway.tls_cert(),
         )
         await repl.start()
 
@@ -1372,16 +1376,14 @@ class TestReplicationAutoPurge(CBLTestClass):
             f"Perform a {remove_type} operation to remove post_1 on SGW"
         )
         if remove_type == "delete":
-            await cloud.sync_gateway.delete_document(
+            await sync_gateway.delete_document(
                 "post_1", rev_ids["post_1"], "posts", collection="posts"
             )
         else:
-            await cloud.sync_gateway.purge_document(
-                "post_1", "posts", collection="posts"
-            )
+            await sync_gateway.purge_document("post_1", "posts", collection="posts")
 
         self.mark_test_step("Recreate post_1 on SGW with channels [group1]")
-        await cloud.sync_gateway.update_documents(
+        await sync_gateway.update_documents(
             "posts",
             [
                 DocumentUpdateEntry(
@@ -1394,7 +1396,7 @@ class TestReplicationAutoPurge(CBLTestClass):
         )
 
         self.mark_test_step("Remove user1 from group1")
-        await cloud.sync_gateway.add_user(
+        await sync_gateway.add_user(
             "posts",
             "user1",
             "pass",

--- a/tests/dev_e2e/test_replication_behavior.py
+++ b/tests/dev_e2e/test_replication_behavior.py
@@ -22,15 +22,16 @@ class TestReplicationBehavior(CBLTestClass):
     ):
         self.mark_test_step("Reset SG and load `names` dataset")
         cloud = cblpytest.simple_cloud()
+        sync_gateway = cloud.sync_gateways[0]
         await cloud.configure_dataset(dataset_path, "names")
 
         self.mark_test_step("Delete name_101 through name_150 on sync gateway")
-        all_docs = await cloud.sync_gateway.get_all_documents("names")
+        all_docs = await sync_gateway.get_all_documents("names")
         for row in all_docs.rows:
             name_number = int(row.id[-3:])
             if name_number <= 150:
                 revid = assert_not_null(row.revid, f"Missing revid on {row.id}")
-                await cloud.sync_gateway.delete_document(row.id, revid, "names")
+                await sync_gateway.delete_document(row.id, revid, "names")
 
         self.mark_test_step("Reset local database, and load `empty` dataset")
         dbs = await cblpytest.test_servers[0].create_and_reset_db(["db1"])
@@ -47,12 +48,12 @@ class TestReplicationBehavior(CBLTestClass):
         """)
         replicator = Replicator(
             db,
-            cloud.sync_gateway.replication_url("names"),
+            sync_gateway.replication_url("names"),
             collections=[ReplicatorCollectionEntry(["_default._default"])],
             replicator_type=ReplicatorType.PULL,
             authenticator=ReplicatorBasicAuthenticator("user1", "pass"),
             enable_document_listener=True,
-            pinned_server_cert=cloud.sync_gateway.tls_cert(),
+            pinned_server_cert=sync_gateway.tls_cert(),
         )
         await replicator.start()
 

--- a/tests/dev_e2e/test_replication_blob.py
+++ b/tests/dev_e2e/test_replication_blob.py
@@ -35,6 +35,7 @@ class TestReplicationBlob(CBLTestClass):
             "Reset SG and load `travel` dataset with delta sync enabled."
         )
         cloud = cblpytest.simple_cloud()
+        sync_gateway = cloud.sync_gateways[0]
         await cloud.configure_dataset(dataset_path, "travel", ["delta_sync"])
 
         self.mark_test_step("Reset local database, and load `travel` dataset.")
@@ -55,11 +56,11 @@ class TestReplicationBlob(CBLTestClass):
         )
         replicator = Replicator(
             db,
-            cloud.sync_gateway.replication_url("travel"),
+            sync_gateway.replication_url("travel"),
             collections=[ReplicatorCollectionEntry(["travel.hotels"])],
             replicator_type=ReplicatorType.PUSH_AND_PULL,
             authenticator=ReplicatorBasicAuthenticator("user1", "pass"),
-            pinned_server_cert=cloud.sync_gateway.tls_cert(),
+            pinned_server_cert=sync_gateway.tls_cert(),
         )
         await replicator.start()
 
@@ -72,7 +73,7 @@ class TestReplicationBlob(CBLTestClass):
         self.mark_test_step("Check that all docs are replicated correctly.")
         await compare_local_and_remote(
             db,
-            cloud.sync_gateway,
+            sync_gateway,
             ReplicatorType.PUSH_AND_PULL,
             "travel",
             ["travel.hotels"],
@@ -80,9 +81,7 @@ class TestReplicationBlob(CBLTestClass):
 
         self.mark_test_step("Update hotel_1 on SG without changing the image key.")
         hotel_1 = assert_not_null(
-            await cloud.sync_gateway.get_document(
-                "travel", "hotel_1", "travel", "hotels"
-            ),
+            await sync_gateway.get_document("travel", "hotel_1", "travel", "hotels"),
             "hotel_1 vanished from SGW",
         )
         hotels_updates: list[DocumentUpdateEntry] = []
@@ -112,7 +111,7 @@ class TestReplicationBlob(CBLTestClass):
                 },
             )
         )
-        await cloud.sync_gateway.update_documents(
+        await sync_gateway.update_documents(
             "travel", hotels_updates, "travel", "hotels"
         )
 
@@ -128,7 +127,7 @@ class TestReplicationBlob(CBLTestClass):
         self.mark_test_step("Check that all docs are replicated correctly.")
         await compare_local_and_remote(
             db,
-            cloud.sync_gateway,
+            sync_gateway,
             ReplicatorType.PUSH_AND_PULL,
             "travel",
             ["travel.hotels"],
@@ -138,9 +137,7 @@ class TestReplicationBlob(CBLTestClass):
             "Update hotel_1 on SG again without changing the image key."
         )
         hotel_1 = assert_not_null(
-            await cloud.sync_gateway.get_document(
-                "travel", "hotel_1", "travel", "hotels"
-            ),
+            await sync_gateway.get_document("travel", "hotel_1", "travel", "hotels"),
             "hotel_1 vanished from SGW",
         )
         hotels_updates = []
@@ -169,7 +166,7 @@ class TestReplicationBlob(CBLTestClass):
                 },
             )
         )
-        await cloud.sync_gateway.update_documents(
+        await sync_gateway.update_documents(
             "travel", hotels_updates, "travel", "hotels"
         )
 
@@ -190,7 +187,7 @@ class TestReplicationBlob(CBLTestClass):
         self.mark_test_step("Check that all docs are replicated correctly.")
         await compare_local_and_remote(
             db,
-            cloud.sync_gateway,
+            sync_gateway,
             ReplicatorType.PUSH_AND_PULL,
             "travel",
             ["travel.hotels"],
@@ -215,6 +212,7 @@ class TestReplicationBlob(CBLTestClass):
     async def test_blob_replication(self, cblpytest: CBLPyTest, dataset_path: Path):
         self.mark_test_step("Reset SG and load `names` dataset.")
         cloud = cblpytest.simple_cloud()
+        sync_gateway = cloud.sync_gateways[0]
         await cloud.configure_dataset(dataset_path, "names")
 
         self.mark_test_step("Reset empty local database")
@@ -239,11 +237,11 @@ class TestReplicationBlob(CBLTestClass):
         """)
         replicator = Replicator(
             db,
-            cloud.sync_gateway.replication_url("names"),
+            sync_gateway.replication_url("names"),
             collections=[ReplicatorCollectionEntry(["_default._default"])],
             replicator_type=ReplicatorType.PUSH,
             authenticator=ReplicatorBasicAuthenticator("user1", "pass"),
-            pinned_server_cert=cloud.sync_gateway.tls_cert(),
+            pinned_server_cert=sync_gateway.tls_cert(),
         )
         await replicator.start()
 
@@ -256,7 +254,7 @@ class TestReplicationBlob(CBLTestClass):
         self.mark_test_step(
             "Check that the document with the ID from step 3 contains a valid `watermelon` property"
         )
-        remote_doc = await cloud.sync_gateway.get_document("names", "fruits")
+        remote_doc = await sync_gateway.get_document("names", "fruits")
         assert remote_doc is not None, "Document `fruits` not found in SGW"
 
         def check_blob_prop(d: dict, prop: str, expected_value: Any):

--- a/tests/dev_e2e/test_replication_filter.py
+++ b/tests/dev_e2e/test_replication_filter.py
@@ -41,6 +41,7 @@ class TestReplicationFilter(CBLTestClass):
     ) -> None:
         self.mark_test_step("Reset SG and load `travel` dataset.")
         cloud = cblpytest.simple_cloud()
+        sync_gateway = cloud.sync_gateways[0]
         await cloud.configure_dataset(dataset_path, "travel")
 
         self.mark_test_step("Reset local database, and load `travel` dataset.")
@@ -65,7 +66,7 @@ class TestReplicationFilter(CBLTestClass):
         )
         replicator = Replicator(
             db,
-            cloud.sync_gateway.replication_url("travel"),
+            sync_gateway.replication_url("travel"),
             replicator_type=ReplicatorType.PUSH,
             collections=[
                 ReplicatorCollectionEntry(
@@ -78,7 +79,7 @@ class TestReplicationFilter(CBLTestClass):
             ],
             authenticator=ReplicatorBasicAuthenticator("user1", "pass"),
             enable_document_listener=True,
-            pinned_server_cert=cloud.sync_gateway.tls_cert(),
+            pinned_server_cert=sync_gateway.tls_cert(),
         )
         await replicator.start()
 
@@ -129,6 +130,7 @@ class TestReplicationFilter(CBLTestClass):
     ) -> None:
         self.mark_test_step("Reset SG and load `travel` dataset.")
         cloud = cblpytest.simple_cloud()
+        sync_gateway = cloud.sync_gateways[0]
         await cloud.configure_dataset(dataset_path, "travel")
 
         self.mark_test_step("Reset local database, and load `travel` dataset.")
@@ -153,7 +155,7 @@ class TestReplicationFilter(CBLTestClass):
         )
         replicator = Replicator(
             db,
-            cloud.sync_gateway.replication_url("travel"),
+            sync_gateway.replication_url("travel"),
             replicator_type=ReplicatorType.PULL,
             collections=[
                 ReplicatorCollectionEntry(
@@ -166,7 +168,7 @@ class TestReplicationFilter(CBLTestClass):
             ],
             authenticator=ReplicatorBasicAuthenticator("user1", "pass"),
             enable_document_listener=True,
-            pinned_server_cert=cloud.sync_gateway.tls_cert(),
+            pinned_server_cert=sync_gateway.tls_cert(),
         )
         await replicator.start()
 
@@ -190,12 +192,12 @@ class TestReplicationFilter(CBLTestClass):
                 * Remove `landmark_10`, in `travel.landmarks`
         """
         )
-        remote_airport_10 = await cloud.sync_gateway.get_document(
+        remote_airport_10 = await sync_gateway.get_document(
             "travel", "airport_10", "travel", "airports"
         )
         assert remote_airport_10 is not None, "Missing airport_10 from sync gateway"
 
-        remote_landmark_10 = await cloud.sync_gateway.get_document(
+        remote_landmark_10 = await sync_gateway.get_document(
             "travel", "landmark_10", "travel", "landmarks"
         )
         assert remote_landmark_10 is not None, "Missing landmark_10 from sync gateway"
@@ -207,10 +209,8 @@ class TestReplicationFilter(CBLTestClass):
             DocumentUpdateEntry("airport_1000", None, {"answer": 42}),
             DocumentUpdateEntry("airport_10", remote_airport_10.revid, {"answer": 42}),
         ]
-        await cloud.sync_gateway.update_documents(
-            "travel", updates, "travel", "airports"
-        )
-        await cloud.sync_gateway.delete_document(
+        await sync_gateway.update_documents("travel", updates, "travel", "airports")
+        await sync_gateway.delete_document(
             "landmark_10", landmark_10_revid, "travel", "travel", "landmarks"
         )
 
@@ -236,6 +236,7 @@ class TestReplicationFilter(CBLTestClass):
     ) -> None:
         self.mark_test_step("Reset SG and load `travel` dataset.")
         cloud = cblpytest.simple_cloud()
+        sync_gateway = cloud.sync_gateways[0]
         await cloud.configure_dataset(dataset_path, "travel")
 
         self.mark_test_step("Reset local database, and load `travel` dataset.")
@@ -260,7 +261,7 @@ class TestReplicationFilter(CBLTestClass):
         )
         replicator = Replicator(
             db,
-            cloud.sync_gateway.replication_url("travel"),
+            sync_gateway.replication_url("travel"),
             replicator_type=ReplicatorType.PULL,
             collections=[
                 ReplicatorCollectionEntry(
@@ -270,7 +271,7 @@ class TestReplicationFilter(CBLTestClass):
             ],
             authenticator=ReplicatorBasicAuthenticator("user1", "pass"),
             enable_document_listener=True,
-            pinned_server_cert=cloud.sync_gateway.tls_cert(),
+            pinned_server_cert=sync_gateway.tls_cert(),
         )
         await replicator.start()
 
@@ -294,22 +295,22 @@ class TestReplicationFilter(CBLTestClass):
                 * Remove `landmark_1` channels = ["United Kingdom"], `landmark_2001` channels = ["France"] in `travel.landmarks`
         """
         )
-        remote_airport_11 = await cloud.sync_gateway.get_document(
+        remote_airport_11 = await sync_gateway.get_document(
             "travel", "airport_11", "travel", "airports"
         )
         assert remote_airport_11 is not None, "Missing airport_11 from sync gateway"
 
-        remote_airport_1 = await cloud.sync_gateway.get_document(
+        remote_airport_1 = await sync_gateway.get_document(
             "travel", "airport_1", "travel", "airports"
         )
         assert remote_airport_1 is not None, "Missing airport_1 from sync gateway"
 
-        remote_airport_17 = await cloud.sync_gateway.get_document(
+        remote_airport_17 = await sync_gateway.get_document(
             "travel", "airport_17", "travel", "airports"
         )
         assert remote_airport_17 is not None, "Missing airport_17 from sync gateway"
 
-        remote_landmark_1 = await cloud.sync_gateway.get_document(
+        remote_landmark_1 = await sync_gateway.get_document(
             "travel", "landmark_1", "travel", "landmarks"
         )
         assert remote_landmark_1 is not None, "Missing landmark_1 from sync gateway"
@@ -317,7 +318,7 @@ class TestReplicationFilter(CBLTestClass):
             remote_landmark_1.revid, "Missing landmark_1 revid"
         )
 
-        remote_landmark_601 = await cloud.sync_gateway.get_document(
+        remote_landmark_601 = await sync_gateway.get_document(
             "travel", "landmark_601", "travel", "landmarks"
         )
         assert remote_landmark_601 is not None, "Missing landmark_601 from sync gateway"
@@ -352,13 +353,11 @@ class TestReplicationFilter(CBLTestClass):
             ),
         ]
 
-        await cloud.sync_gateway.update_documents(
-            "travel", updates, "travel", "airports"
-        )
-        await cloud.sync_gateway.delete_document(
+        await sync_gateway.update_documents("travel", updates, "travel", "airports")
+        await sync_gateway.delete_document(
             "landmark_1", landmark_1_revid, "travel", "travel", "landmarks"
         )
-        await cloud.sync_gateway.delete_document(
+        await sync_gateway.delete_document(
             "landmark_601", landmark_601_revid, "travel", "travel", "landmarks"
         )
 
@@ -390,6 +389,7 @@ class TestReplicationFilter(CBLTestClass):
     ) -> None:
         self.mark_test_step("Reset SG and load `names` dataset.")
         cloud = cblpytest.simple_cloud()
+        sync_gateway = cloud.sync_gateways[0]
         await cloud.configure_dataset(dataset_path, "names")
 
         self.mark_test_step("Reset local database, and load `empty` dataset.")
@@ -408,8 +408,7 @@ class TestReplicationFilter(CBLTestClass):
                 * content: `{"hello": "world"}`
         """
         )
-        sgw = cloud.sync_gateway
-        await sgw.update_documents(
+        await sync_gateway.update_documents(
             "names",
             [
                 DocumentUpdateEntry(
@@ -434,10 +433,10 @@ class TestReplicationFilter(CBLTestClass):
         )
         replicator = Replicator(
             db,
-            sgw.replication_url("names"),
+            sync_gateway.replication_url("names"),
             ReplicatorType.PULL,
             authenticator=ReplicatorBasicAuthenticator("user2", "pass"),
-            pinned_server_cert=sgw.tls_cert(),
+            pinned_server_cert=sync_gateway.tls_cert(),
         )
         replicator.add_default_collection()
         await replicator.start()
@@ -479,10 +478,10 @@ class TestReplicationFilter(CBLTestClass):
         )
         replicator = Replicator(
             db,
-            sgw.replication_url("names"),
+            sync_gateway.replication_url("names"),
             ReplicatorType.PUSH,
             authenticator=ReplicatorBasicAuthenticator("user2", "pass"),
-            pinned_server_cert=sgw.tls_cert(),
+            pinned_server_cert=sync_gateway.tls_cert(),
         )
         replicator.add_default_collection()
         await replicator.start()
@@ -494,7 +493,7 @@ class TestReplicationFilter(CBLTestClass):
         )
 
         self.mark_test_step("Verify that the document on Sync Gateway was updated")
-        sgw_doc = await sgw.get_document("names", "test_public")
+        sgw_doc = await sync_gateway.get_document("names", "test_public")
         assert sgw_doc is not None, "test_public missing from SGW"
         assert "see you later" in sgw_doc.body, (
             "updated key missing from test_public in SGW"
@@ -509,6 +508,7 @@ class TestReplicationFilter(CBLTestClass):
     ) -> None:
         self.mark_test_step("Reset SG and load `names` dataset.")
         cloud = cblpytest.simple_cloud()
+        sync_gateway = cloud.sync_gateways[0]
         await cloud.configure_dataset(dataset_path, "names")
 
         self.mark_test_step("Reset local database, and load `names` dataset.")
@@ -533,7 +533,7 @@ class TestReplicationFilter(CBLTestClass):
         )
         replicator = Replicator(
             db,
-            cloud.sync_gateway.replication_url("names"),
+            sync_gateway.replication_url("names"),
             replicator_type=ReplicatorType.PUSH,
             collections=[
                 ReplicatorCollectionEntry(
@@ -543,7 +543,7 @@ class TestReplicationFilter(CBLTestClass):
             ],
             authenticator=ReplicatorBasicAuthenticator("user1", "pass"),
             enable_document_listener=True,
-            pinned_server_cert=cloud.sync_gateway.tls_cert(),
+            pinned_server_cert=sync_gateway.tls_cert(),
         )
         await replicator.start()
 
@@ -596,6 +596,7 @@ class TestReplicationFilter(CBLTestClass):
 
         self.mark_test_step("Reset SG and load `names` dataset.")
         cloud = cblpytest.simple_cloud()
+        sync_gateway = cloud.sync_gateways[0]
         await cloud.configure_dataset(dataset_path, "names")
 
         self.mark_test_step("Reset local database, and load `names` dataset.")
@@ -620,7 +621,7 @@ class TestReplicationFilter(CBLTestClass):
         )
         replicator = Replicator(
             db,
-            cloud.sync_gateway.replication_url("names"),
+            sync_gateway.replication_url("names"),
             replicator_type=ReplicatorType.PULL,
             collections=[
                 ReplicatorCollectionEntry(
@@ -630,7 +631,7 @@ class TestReplicationFilter(CBLTestClass):
             ],
             authenticator=ReplicatorBasicAuthenticator("user1", "pass"),
             enable_document_listener=True,
-            pinned_server_cert=cloud.sync_gateway.tls_cert(),
+            pinned_server_cert=sync_gateway.tls_cert(),
         )
         await replicator.start()
 
@@ -657,17 +658,17 @@ class TestReplicationFilter(CBLTestClass):
         )
         updates = [DocumentUpdateEntry("name_1000", None, {"answer": 42})]
 
-        remote_name_10 = await cloud.sync_gateway.get_document("names", "name_105")
+        remote_name_10 = await sync_gateway.get_document("names", "name_105")
         assert remote_name_10 is not None, "Missing name_105 from sync gateway"
         name_10_revid = assert_not_null(remote_name_10.revid, "Missing name_105 revid")
 
-        remote_name_20 = await cloud.sync_gateway.get_document("names", "name_193")
+        remote_name_20 = await sync_gateway.get_document("names", "name_193")
         assert remote_name_20 is not None, "Missing name_193 from sync gateway"
         name_20_revid = assert_not_null(remote_name_20.revid, "Missing name_193 revid")
 
-        await cloud.sync_gateway.update_documents("names", updates)
-        await cloud.sync_gateway.delete_document("name_105", name_10_revid, "names")
-        await cloud.sync_gateway.delete_document("name_193", name_20_revid, "names")
+        await sync_gateway.update_documents("names", updates)
+        await sync_gateway.delete_document("name_105", name_10_revid, "names")
+        await sync_gateway.delete_document("name_193", name_20_revid, "names")
 
         self.mark_test_step("Start a replicator with the same config as in step 3.")
         await replicator.start()

--- a/tests/dev_e2e/test_replication_xdcr.py
+++ b/tests/dev_e2e/test_replication_xdcr.py
@@ -46,11 +46,11 @@ class TestReplicationXdcr(CBLTestClass):
 
         self.mark_test_step("Reset SGs in cluster 1 and 2, and load dataset.")
         cloud1 = CouchbaseCloud(
-            cblpytest.sync_gateways[0], cblpytest.couchbase_servers[0]
+            [cblpytest.sync_gateways[0]], cblpytest.couchbase_servers[0]
         )
         await cloud1.configure_dataset(dataset_path, dataset_name)
         cloud2 = CouchbaseCloud(
-            cblpytest.sync_gateways[1], cblpytest.couchbase_servers[1]
+            [cblpytest.sync_gateways[1]], cblpytest.couchbase_servers[1]
         )
         await cloud2.configure_dataset(dataset_path, dataset_name)
 


### PR DESCRIPTION
Having CouchbaseCloud.sync_gateway was the wrong abstraction since there can be multiple Sync Gateways.

Use SyncGatewayCluster.wait_for_db_online to wait for the database on all nodes before continuing.

Stubbed some round_robin_node and random_node functions but they aren't used as part of this API. This is useful for future multiple node coordination tasks, like resync tests. Added here for some demonstration.

Having some abstractions is useful for the creating a database tasks. The workflow is:

1. POST /db on node1 - this operation is synchronous to come online
2. node2 (and others) are on a 10s polling loop to look for a documents in each bucket. When they find a new document or updated document, the database on node2 is uploaded.