### PR TITLE
Add periodic QE scheduler that triggers per-platform jobs only for new builds

### DIFF
--- a/jenkins/pipelines/QE/main/Jenkinsfile
+++ b/jenkins/pipelines/QE/main/Jenkinsfile
@@ -23,7 +23,8 @@ pipeline {
         timeout(time: 30, unit: 'MINUTES')
     }
     triggers {
-        cron('@daily')
+        cron('''TZ=Asia/Kolkata
+0 4 * * *''')
     }
     stages {
         stage('Init') {

--- a/jenkins/pipelines/QE/main/Jenkinsfile
+++ b/jenkins/pipelines/QE/main/Jenkinsfile
@@ -1,8 +1,6 @@
-// Per-platform CBL info. Written once in 'Resolve Versions', then only read.
-//   platform -> [version: "4.2.0", build: "9", dataset: "4.0"]
+// platform -> [version: "4.2.0", build: "9", dataset: "4.0"]
 def resolved = [:]
 
-// All platforms this scheduler knows about; a single-platform run trims this to one.
 def ALL_PLATFORMS = ['c', 'android', 'java', 'ios', 'dotnet']
 
 def progetProductFor(String platform) {
@@ -10,10 +8,9 @@ def progetProductFor(String platform) {
 }
 
 pipeline {
-    // The dedup state lives on this node's filesystem (~/.jenkins_build_info),
+    // Dedup state lives on this node's filesystem (~/.jenkins_build_info).
     agent { label 'qe-mac-india' }
     environment {
-        // Ensure Homebrew's python3 (used by the ProGet version/build lookups) is on PATH.
         PATH = "/opt/homebrew/opt/python@3.10/bin:/opt/homebrew/bin:/usr/local/bin:${env.PATH}"
     }
     parameters {
@@ -45,12 +42,9 @@ pipeline {
                     for (p in platforms) {
                         def product = progetProductFor(p)
                         try {
-                            // Resolve the latest version (auto when CBL_VERSION is blank):
-                            //   .../api/latest_release?product=<product>&prerelease=true
                             def version = proget.resolveProgetVersion(product, params.CBL_VERSION, "CBL_VERSION")
 
-                            // If a full <version>-<build> was supplied, split it; otherwise look up the latest build:
-                            //   .../api/get_version?product=<product>&version=<version>
+                            // Split a supplied <version>-<build>, else look up the latest build.
                             def buildNo
                             if (version.contains('-')) {
                                 def parts = version.split('-', 2)
@@ -65,22 +59,20 @@ pipeline {
                             }
                             if (!buildNo) { error "Could not resolve build number for ${product} ${version}" }
 
-                            // Pick dataset version from CBL version: 4.0+ uses the 4.0 dataset, else 3.2:
                             def majorVersion = version.tokenize('.')[0].toInteger()
                             def datasetVersion = (majorVersion >= 4) ? "4.0" : "3.2"
 
                             resolved[p] = [version: version, build: buildNo, dataset: datasetVersion]
                             echo "${p}: CBL ${version}-${buildNo} (dataset ${datasetVersion})"
                         } catch (Exception e) {
-                            // Don't let one platform's ProGet hiccup block the others.
+                            // One platform's failure must not block the others.
                             echo "WARN: could not resolve ${p} (${product}): ${e.getMessage()}"
                         }
                     }
 
                     if (resolved.isEmpty()) { error "Could not resolve any platform version" }
 
-                    // Build the display name once, honestly. When every platform lands on the
-                    // same build, collapse to one CBL version; otherwise list them per platform.
+                    // Collapse to one CBL version when all platforms match, else list per platform.
                     def sgw = params.SGW_VERSION
                     if (params.CBL_PLATFORM == 'all') {
                         def present = ALL_PLATFORMS.findAll { resolved.containsKey(it) }
@@ -129,7 +121,7 @@ pipeline {
                                 def force = params.FORCE_TRIGGER
                                 def fullVersion = "${version}-${buildNo}"
 
-                                // Check whether the QE test has already been triggered for this CBL build:
+                                // Skip if this CBL build was already triggered.
                                 def triggerTestJob = true
                                 def buildInfo = [:]
                                 def buildInfoFile = "${env.HOME}/.jenkins_build_info/${env.JOB_NAME}/${platform}.json"
@@ -146,7 +138,6 @@ pipeline {
                                     }
                                 }
 
-                                // Trigger the QE test job:
                                 if (triggerTestJob) {
                                     def jobName = "qe-${platform}-pipeline"
                                     echo "Triggering '${jobName}' job for ${platform} v${fullVersion}"
@@ -157,7 +148,6 @@ pipeline {
                                         string(name: "TS_DATASET_VERSION", value: datasetVersion)
                                     ], wait: false
 
-                                    // Save CBL build info:
                                     buildInfo[version] = buildNo
                                     try {
                                         writeJSON file: buildInfoFile, json: buildInfo

--- a/jenkins/pipelines/QE/main/Jenkinsfile
+++ b/jenkins/pipelines/QE/main/Jenkinsfile
@@ -1,6 +1,20 @@
+// Resolved per-platform CBL info, populated by the 'Resolve Versions' stage and read
+// (never written) by the parallel matrix cells — so there is no cross-cell race.
+//   platform -> [version: "4.2.0", build: "9", dataset: "4.0"]
+def resolved = [:]
+
+// All platforms this scheduler knows about; a single-platform run trims this to one.
+def ALL_PLATFORMS = ['c', 'android', 'java', 'ios', 'dotnet']
+
+def progetProductFor(String platform) {
+    return "couchbase-lite-" + ((platform == "dotnet") ? "net" : platform)
+}
+
 pipeline {
+    // The dedup state lives on this node's filesystem (~/.jenkins_build_info),
     agent { label 'qe-mac-india' }
     environment {
+        // Ensure Homebrew's python3 (used by the ProGet version/build lookups) is on PATH.
         PATH = "/opt/homebrew/opt/python@3.10/bin:/opt/homebrew/bin:/usr/local/bin:${env.PATH}"
     }
     parameters {
@@ -23,6 +37,68 @@ pipeline {
                 }
             }
         }
+        stage('Resolve Versions') {
+            steps {
+                script {
+                    def platforms = (params.CBL_PLATFORM == 'all') ? ALL_PLATFORMS : [params.CBL_PLATFORM]
+                    def proget = load 'jenkins/pipelines/shared/resolveProgetVersion.groovy'
+
+                    for (p in platforms) {
+                        def product = progetProductFor(p)
+                        try {
+                            // Resolve the latest version (auto when CBL_VERSION is blank):
+                            //   .../api/latest_release?product=<product>&prerelease=true
+                            def version = proget.resolveProgetVersion(product, params.CBL_VERSION, "CBL_VERSION")
+
+                            // If a full <version>-<build> was supplied, split it; otherwise look up the latest build:
+                            //   .../api/get_version?product=<product>&version=<version>
+                            def buildNo
+                            if (version.contains('-')) {
+                                def parts = version.split('-', 2)
+                                version = parts[0]
+                                buildNo = parts[1]
+                            } else {
+                                def buildUrl = "http://proget.build.couchbase.com:8080/api/get_version?product=${product}&version=${version}"
+                                buildNo = sh(
+                                    script: "curl -sf '${buildUrl}' | python3 -c 'import json,sys; print(json.load(sys.stdin).get(\"BuildNumber\",\"\"))'",
+                                    returnStdout: true
+                                ).trim()
+                            }
+                            if (!buildNo) { error "Could not resolve build number for ${product} ${version}" }
+
+                            // Pick dataset version from CBL version: 4.0+ uses the 4.0 dataset, else 3.2:
+                            def majorVersion = version.tokenize('.')[0].toInteger()
+                            def datasetVersion = (majorVersion >= 4) ? "4.0" : "3.2"
+
+                            resolved[p] = [version: version, build: buildNo, dataset: datasetVersion]
+                            echo "${p}: CBL ${version}-${buildNo} (dataset ${datasetVersion})"
+                        } catch (Exception e) {
+                            // Don't let one platform's ProGet hiccup block the others.
+                            echo "WARN: could not resolve ${p} (${product}): ${e.getMessage()}"
+                        }
+                    }
+
+                    if (resolved.isEmpty()) { error "Could not resolve any platform version" }
+
+                    // Build the display name once, honestly. When every platform lands on the
+                    // same build, collapse to one CBL version; otherwise list them per platform.
+                    def sgw = params.SGW_VERSION
+                    if (params.CBL_PLATFORM == 'all') {
+                        def present = ALL_PLATFORMS.findAll { resolved.containsKey(it) }
+                        def distinct = present.collect { "${resolved[it].version}-${resolved[it].build}" }.unique()
+                        if (distinct.size() == 1) {
+                            currentBuild.displayName = "QE all  |  CBL ${distinct[0]}  |  SGW ${sgw}  (#${currentBuild.number})"
+                        } else {
+                            def parts = present.collect { "${it} ${resolved[it].version}-${resolved[it].build}" }
+                            currentBuild.displayName = "QE all  |  ${parts.join(', ')}  |  SGW ${sgw}  (#${currentBuild.number})"
+                        }
+                    } else {
+                        def p = params.CBL_PLATFORM
+                        currentBuild.displayName = "QE ${p}  |  CBL ${resolved[p].version}-${resolved[p].build}  |  SGW ${sgw}  (#${currentBuild.number})"
+                    }
+                }
+            }
+        }
         stage('Trigger QE Tests') {
             matrix {
                 when {
@@ -42,48 +118,17 @@ pipeline {
                         steps {
                             script {
                                 def platform = env.CBL_PLATFORM
+                                def info = resolved[platform]
+                                if (info == null) {
+                                    echo "SKIP: ${platform} (version could not be resolved)"
+                                    return
+                                }
+                                def version = info.version
+                                def buildNo = info.build
+                                def datasetVersion = info.dataset
                                 def sgwVersion = params.SGW_VERSION
                                 def force = params.FORCE_TRIGGER
-                                def progetProduct = "couchbase-lite-" + ((platform == "dotnet") ? "net" : platform)
-
-                                // Resolve the latest version (auto when CBL_VERSION is blank):
-                                //   http://proget.build.couchbase.com:8080/api/latest_release?product=<product>&prerelease=true
-                                def proget = load 'jenkins/pipelines/shared/resolveProgetVersion.groovy'
-                                def version = proget.resolveProgetVersion(progetProduct, params.CBL_VERSION, "CBL_VERSION")
-
-                                // If a full <version>-<build> was supplied, split it; otherwise look up the latest build:
-                                //   http://proget.build.couchbase.com:8080/api/get_version?product=<product>&version=<version>
-                                def buildNo
-                                if (version.contains('-')) {
-                                    def parts = version.split('-', 2)
-                                    version = parts[0]
-                                    buildNo = parts[1]
-                                } else {
-                                    def buildUrl = "http://proget.build.couchbase.com:8080/api/get_version?product=${progetProduct}&version=${version}"
-                                    buildNo = sh(
-                                        script: "curl -sf '${buildUrl}' | python3 -c 'import json,sys; print(json.load(sys.stdin).get(\"BuildNumber\",\"\"))'",
-                                        returnStdout: true
-                                    ).trim()
-                                }
-                                if (!buildNo) { error "Could not resolve build number for ${progetProduct} ${version}" }
-
                                 def fullVersion = "${version}-${buildNo}"
-
-                                // Pick dataset version from CBL version: 4.0+ uses the 4.0 dataset, else 3.2:
-                                def majorVersion = version.tokenize('.')[0].toInteger()
-                                def datasetVersion = (majorVersion >= 4) ? "4.0" : "3.2"
-
-                                if (params.CBL_PLATFORM == "all") {
-                                    currentBuild.displayName = "${fullVersion}-SGW${sgwVersion} (#${currentBuild.number})"
-                                } else {
-                                    currentBuild.displayName = "${platform}-${fullVersion}-SGW${sgwVersion} (#${currentBuild.number})"
-                                }
-
-                                echo "PLATFORM: ${platform}"
-                                echo "VERSION: ${version}"
-                                echo "BUILD: ${buildNo}"
-                                echo "DATASET_VERSION: ${datasetVersion}"
-                                echo "FORCE: ${force}"
 
                                 // Check whether the QE test has already been triggered for this CBL build:
                                 def triggerTestJob = true

--- a/jenkins/pipelines/QE/main/Jenkinsfile
+++ b/jenkins/pipelines/QE/main/Jenkinsfile
@@ -21,6 +21,7 @@ pipeline {
     }
     options {
         timeout(time: 30, unit: 'MINUTES')
+        disableConcurrentBuilds()
     }
     triggers {
         cron('''TZ=Asia/Kolkata

--- a/jenkins/pipelines/QE/main/Jenkinsfile
+++ b/jenkins/pipelines/QE/main/Jenkinsfile
@@ -1,5 +1,4 @@
-// Resolved per-platform CBL info, populated by the 'Resolve Versions' stage and read
-// (never written) by the parallel matrix cells — so there is no cross-cell race.
+// Per-platform CBL info. Written once in 'Resolve Versions', then only read.
 //   platform -> [version: "4.2.0", build: "9", dataset: "4.0"]
 def resolved = [:]
 

--- a/jenkins/pipelines/QE/main/Jenkinsfile
+++ b/jenkins/pipelines/QE/main/Jenkinsfile
@@ -1,0 +1,133 @@
+pipeline {
+    agent { label 'qe-mac-india' }
+    environment {
+        PATH = "/opt/homebrew/opt/python@3.10/bin:/opt/homebrew/bin:/usr/local/bin:${env.PATH}"
+    }
+    parameters {
+        choice(name: 'CBL_PLATFORM', choices: ['all', 'c', 'android', 'java', 'ios', 'dotnet'], description: 'CBL platform to run QE tests for')
+        string(name: 'CBL_VERSION', defaultValue: '', description: "CBL version (e.g. 4.2.0). Leave blank to auto-resolve each platform's latest prerelease via ProGet. The build number is resolved automatically.")
+        string(name: 'SGW_VERSION', defaultValue: '4.0.0', description: 'The version of Sync Gateway to use')
+        booleanParam(name: 'FORCE_TRIGGER', defaultValue: false, description: 'Force triggering the QE test job(s) even if this version+build already ran')
+    }
+    options {
+        timeout(time: 30, unit: 'MINUTES')
+    }
+    triggers {
+        cron('@daily')
+    }
+    stages {
+        stage('Init') {
+            steps {
+                script {
+                    if (params.SGW_VERSION == '') { error "SGW_VERSION is required" }
+                }
+            }
+        }
+        stage('Trigger QE Tests') {
+            matrix {
+                when {
+                    anyOf {
+                        expression { params.CBL_PLATFORM == 'all' }
+                        expression { params.CBL_PLATFORM == env.CBL_PLATFORM }
+                    }
+                }
+                axes {
+                    axis {
+                        name 'CBL_PLATFORM'
+                        values 'c', 'android', 'java', 'ios', 'dotnet'
+                    }
+                }
+                stages {
+                    stage('Lookup Build and Trigger Test') {
+                        steps {
+                            script {
+                                def platform = env.CBL_PLATFORM
+                                def sgwVersion = params.SGW_VERSION
+                                def force = params.FORCE_TRIGGER
+                                def progetProduct = "couchbase-lite-" + ((platform == "dotnet") ? "net" : platform)
+
+                                // Resolve the latest version (auto when CBL_VERSION is blank):
+                                //   http://proget.build.couchbase.com:8080/api/latest_release?product=<product>&prerelease=true
+                                def proget = load 'jenkins/pipelines/shared/resolveProgetVersion.groovy'
+                                def version = proget.resolveProgetVersion(progetProduct, params.CBL_VERSION, "CBL_VERSION")
+
+                                // If a full <version>-<build> was supplied, split it; otherwise look up the latest build:
+                                //   http://proget.build.couchbase.com:8080/api/get_version?product=<product>&version=<version>
+                                def buildNo
+                                if (version.contains('-')) {
+                                    def parts = version.split('-', 2)
+                                    version = parts[0]
+                                    buildNo = parts[1]
+                                } else {
+                                    def buildUrl = "http://proget.build.couchbase.com:8080/api/get_version?product=${progetProduct}&version=${version}"
+                                    buildNo = sh(
+                                        script: "curl -sf '${buildUrl}' | python3 -c 'import json,sys; print(json.load(sys.stdin).get(\"BuildNumber\",\"\"))'",
+                                        returnStdout: true
+                                    ).trim()
+                                }
+                                if (!buildNo) { error "Could not resolve build number for ${progetProduct} ${version}" }
+
+                                def fullVersion = "${version}-${buildNo}"
+
+                                // Pick dataset version from CBL version: 4.0+ uses the 4.0 dataset, else 3.2:
+                                def majorVersion = version.tokenize('.')[0].toInteger()
+                                def datasetVersion = (majorVersion >= 4) ? "4.0" : "3.2"
+
+                                if (params.CBL_PLATFORM == "all") {
+                                    currentBuild.displayName = "${fullVersion}-SGW${sgwVersion} (#${currentBuild.number})"
+                                } else {
+                                    currentBuild.displayName = "${platform}-${fullVersion}-SGW${sgwVersion} (#${currentBuild.number})"
+                                }
+
+                                echo "PLATFORM: ${platform}"
+                                echo "VERSION: ${version}"
+                                echo "BUILD: ${buildNo}"
+                                echo "DATASET_VERSION: ${datasetVersion}"
+                                echo "FORCE: ${force}"
+
+                                // Check whether the QE test has already been triggered for this CBL build:
+                                def triggerTestJob = true
+                                def buildInfo = [:]
+                                def buildInfoFile = "${env.HOME}/.jenkins_build_info/${env.JOB_NAME}/${platform}.json"
+                                echo "Build Info File: ${buildInfoFile}"
+
+                                if (!force && fileExists(buildInfoFile)) {
+                                    try {
+                                        buildInfo = readJSON file: buildInfoFile, returnPojo: true
+                                    } catch (Exception e) {
+                                        echo "WARN : Error when reading ${platform}.json : ${e}"
+                                    }
+                                    if (buildInfo[version] == buildNo) {
+                                        triggerTestJob = false
+                                    }
+                                }
+
+                                // Trigger the QE test job:
+                                if (triggerTestJob) {
+                                    def jobName = "qe-${platform}-pipeline"
+                                    echo "Triggering '${jobName}' job for ${platform} v${fullVersion}"
+
+                                    build job: jobName, parameters: [
+                                        string(name: "CBL_VERSION", value: fullVersion),
+                                        string(name: "SGW_VERSION", value: sgwVersion),
+                                        string(name: "TS_DATASET_VERSION", value: datasetVersion)
+                                    ], wait: false
+
+                                    // Save CBL build info:
+                                    buildInfo[version] = buildNo
+                                    try {
+                                        writeJSON file: buildInfoFile, json: buildInfo
+                                    } catch (Exception e) {
+                                        error "Cannot save ${platform}.json with error: ${e}"
+                                    }
+                                } else {
+                                    echo "SKIP: ${platform} v${fullVersion} (already triggered)"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a periodic scheduler that auto-runs the QE pipelines, fetching each platform's latest version + build and triggering its QE job only when that build hasn't run yet.

**Features added:**
- New `jenkins/pipelines/QE/main/Jenkinsfile` - a scheduler that fans out over c, android, java, ios, dotnet, running daily at 4 AM IST.
- Resolves each platform's latest version + build via Proget and triggers the corresponding CBL pipeline with `CBL_VERSION=<version>-<build>`, `SGW_VERSION`, and an auto-selected dataset version.
- Per-build dedup via `~/.jenkins_build_info/<JOB_NAME>/<platform>.json` (pinned to `qe-mac-india`); `FORCE_TRIGGER` overrides.
- `CBL_PLATFORM`/`CBL_VERSION`/`SGW_VERSION` params for manual runs; build display name shows the resolved versions.

Verified against the pipeline pointed at this branch.