### PR TITLE
Add periodic Sync Gateway scheduler that triggers sgw-functional only for new builds

### DIFF
--- a/jenkins/pipelines/QE/sgw-main/Jenkinsfile
+++ b/jenkins/pipelines/QE/sgw-main/Jenkinsfile
@@ -33,7 +33,7 @@ pipeline {
         booleanParam(name: 'FORCE_TRIGGER', defaultValue: false, description: 'Force triggering the SGW test job even if this SGW version+build already ran')
     }
     options {
-        timeout(time: 30, unit: 'MINUTES')
+        timeout(time: 1, unit: 'HOURS')
         disableConcurrentBuilds()
     }
     triggers {

--- a/jenkins/pipelines/QE/sgw-main/Jenkinsfile
+++ b/jenkins/pipelines/QE/sgw-main/Jenkinsfile
@@ -37,7 +37,8 @@ pipeline {
         disableConcurrentBuilds()
     }
     triggers {
-        cron('@daily')
+        cron('''TZ=Asia/Kolkata
+0 4 * * *''')
     }
     stages {
         stage('Resolve and Trigger') {

--- a/jenkins/pipelines/QE/sgw-main/Jenkinsfile
+++ b/jenkins/pipelines/QE/sgw-main/Jenkinsfile
@@ -34,6 +34,7 @@ pipeline {
     }
     options {
         timeout(time: 30, unit: 'MINUTES')
+        disableConcurrentBuilds()
     }
     triggers {
         cron('@daily')

--- a/jenkins/pipelines/QE/sgw-main/Jenkinsfile
+++ b/jenkins/pipelines/QE/sgw-main/Jenkinsfile
@@ -1,0 +1,95 @@
+def SGW_PRODUCT = "sync-gateway"          // dedup key: the thing under test
+def CBL_PRODUCT = "couchbase-lite-ios"    // iOS test-server client, passed through
+
+// A fully-qualified "<version>-<build>" param is used as-is; otherwise the latest
+// build is looked up via ProGet get_version.
+def resolveVersionBuild(proget, String product, String param, String label) {
+    def version = proget.resolveProgetVersion(product, param, label)
+    def buildNo
+    if (version.contains('-')) {
+        def parts = version.split('-', 2)
+        version = parts[0]
+        buildNo = parts[1]
+    } else {
+        def buildUrl = "http://proget.build.couchbase.com:8080/api/get_version?product=${product}&version=${version}"
+        buildNo = sh(
+            script: "curl -sf '${buildUrl}' | python3 -c 'import json,sys; print(json.load(sys.stdin).get(\"BuildNumber\",\"\"))'",
+            returnStdout: true
+        ).trim()
+    }
+    if (!buildNo) { error "Could not resolve build number for ${product} ${version}" }
+    return [version: version, build: buildNo]
+}
+
+pipeline {
+    // Pinned: dedup state lives on this node's filesystem (~/.jenkins_build_info).
+    agent { label 'mac-mini-new' }
+    environment {
+        PATH = "/opt/homebrew/opt/python@3.10/bin:/opt/homebrew/bin:/usr/local/bin:${env.PATH}"
+    }
+    parameters {
+        string(name: 'SGW_VERSION', defaultValue: '', description: 'Sync Gateway version (e.g. 4.2.0). Leave blank to auto-resolve the latest prerelease via ProGet. The build number is resolved automatically.')
+        string(name: 'CBL_VERSION', defaultValue: '', description: 'CBL iOS client version (e.g. 4.2.0). Leave blank to auto-resolve the latest prerelease via ProGet. The build number is resolved automatically.')
+        booleanParam(name: 'FORCE_TRIGGER', defaultValue: false, description: 'Force triggering the SGW test job even if this SGW version+build already ran')
+    }
+    options {
+        timeout(time: 30, unit: 'MINUTES')
+    }
+    triggers {
+        cron('@daily')
+    }
+    stages {
+        stage('Resolve and Trigger') {
+            steps {
+                script {
+                    def proget = load 'jenkins/pipelines/shared/resolveProgetVersion.groovy'
+
+                    def sgw = resolveVersionBuild(proget, SGW_PRODUCT, params.SGW_VERSION, 'SGW_VERSION')
+                    def cbl = resolveVersionBuild(proget, CBL_PRODUCT, params.CBL_VERSION, 'CBL_VERSION')
+                    def sgwFull = "${sgw.version}-${sgw.build}"
+                    def cblFull = "${cbl.version}-${cbl.build}"
+
+                    currentBuild.displayName = "SGW ${sgwFull}  |  CBL ${cblFull}  (#${currentBuild.number})"
+                    echo "SGW: ${sgwFull}"
+                    echo "CBL (client): ${cblFull}"
+                    echo "FORCE: ${params.FORCE_TRIGGER}"
+
+                    // Dedup on the SGW build only; the CBL client is not part of the key.
+                    def triggerTestJob = true
+                    def buildInfo = [:]
+                    def buildInfoFile = "${env.HOME}/.jenkins_build_info/${env.JOB_NAME}/sgw.json"
+                    echo "Build Info File: ${buildInfoFile}"
+
+                    if (!params.FORCE_TRIGGER && fileExists(buildInfoFile)) {
+                        try {
+                            buildInfo = readJSON file: buildInfoFile, returnPojo: true
+                        } catch (Exception e) {
+                            echo "WARN : Error when reading sgw.json : ${e}"
+                        }
+                        if (buildInfo[sgw.version] == sgw.build) {
+                            triggerTestJob = false
+                        }
+                    }
+
+                    if (triggerTestJob) {
+                        echo "Triggering 'sgw-functional' for SGW ${sgwFull} (CBL client ${cblFull})"
+
+                        build job: 'sgw-functional', parameters: [
+                            string(name: "SGW_VERSION", value: sgwFull),
+                            string(name: "CBL_VERSION", value: cblFull)
+                        ], wait: false
+
+                        buildInfo[sgw.version] = sgw.build
+                        try {
+                            writeJSON file: buildInfoFile, json: buildInfo
+                        } catch (Exception e) {
+                            error "Cannot save sgw.json with error: ${e}"
+                        }
+                    } else {
+                        echo "SKIP: SGW ${sgwFull} (already triggered)"
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a periodic scheduler that auto-runs the SGW functional QE pipeline, resolving the latest Sync Gateway build and triggering `sgw-functional` only when that build hasn't run yet.

**Features added:**
- New `jenkins/pipelines/QE/sgw-main/Jenkinsfile` - a scheduler pinned to `mac-mini-new`, running daily at 4 AM IST.
- Resolves the latest SGW version + build (dedup key) and the latest `couchbase-lite-ios` client version + build via Proget, and triggers `sgw-functional` with both pinned as `<version>-<build>`.
- Per-build dedup on the SGW build via `~/.jenkins_build_info/<JOB_NAME>/sgw.json`; `FORCE_TRIGGER` overrides.
- `SGW_VERSION/CBL_VERSION` params for manual runs; build display name shows the resolved versions.

Verified against the job pointed at this branch.