### PR TITLE
SyncGatewayUserClient: create contextmanager

### DIFF
--- a/client/src/cbltest/api/syncgateway.py
+++ b/client/src/cbltest/api/syncgateway.py
@@ -2,6 +2,8 @@ import asyncio
 import re
 import ssl
 from abc import ABC, abstractmethod
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from enum import Enum
 from json import dumps, loads
 from pathlib import Path
@@ -2228,25 +2230,21 @@ class SyncGateway(_SyncGatewayBase):
         )
         return import_count
 
-    async def create_user_client(
+    async def reset_user(
         self,
         db_name: str,
         username: str,
         password: str,
         channels: list[str],
-    ) -> "SyncGatewayUserClient":
+    ) -> None:
         """
-        Helper method to create a user with channel access and return a user-specific SG client.
-
-        This is a convenience method for tests that need to verify user-level access control.
+        Helper method to delete a user if they exist and recreate them with specific channel access.
 
         :param db_name: The database name
-        :param username: The username to create
+        :param username: The username to reset
         :param password: The password for the user
         :param channels: List of channels the user should have access to
-        :return: A SyncGatewayUserClient instance authenticated as the user (uses public port)
         """
-        # Clean up user if exists from previous run
         await self.delete_user(db_name, username)
         await self.add_user(
             db_name,
@@ -2255,14 +2253,40 @@ class SyncGateway(_SyncGatewayBase):
             collection_access={"_default": {"_default": {"admin_channels": channels}}},
         )
 
-        # Return user-specific SG client for public API access
-        return SyncGatewayUserClient(
+    @asynccontextmanager
+    async def create_user_client(
+        self,
+        db_name: str,
+        username: str,
+        password: str,
+        channels: list[str],
+    ) -> AsyncIterator["SyncGatewayUserClient"]:
+        """
+        Helper method to create a user with channel access and return a user-specific SG client
+        as an async context manager.
+
+        This is a convenience method for tests that need to verify user-level access control.
+        Upon exiting the context, the user client session is closed.
+
+        :param db_name: The database name
+        :param username: The username to create
+        :param password: The password for the user
+        :param channels: List of channels the user should have access to
+        :return: An AsyncIterator yielding a SyncGatewayUserClient instance authenticated as the user (uses public port)
+        """
+        await self.reset_user(db_name, username, password, channels)
+
+        client = SyncGatewayUserClient(
             self.hostname,
             username,
             password,
             port=self.__public_port,
             secure=self.secure,
         )
+        try:
+            yield client
+        finally:
+            await client.close()
 
     async def start_isgr(self, db_name: str, payload: ISGRPayload) -> str:
         """

--- a/client/tests/test_syncgateway_helpers.py
+++ b/client/tests/test_syncgateway_helpers.py
@@ -233,3 +233,30 @@ class TestWaitForDbUp:
             await sg._wait_for_db_online("db1", max_retries=2, retry_delay=0)
 
         assert "database not present in /_all_dbs?verbose=true" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_reset_user(self, sync_gateway):
+        sg, specs = sync_gateway
+        specs[:] = [
+            {"status": 200, "json": {"ok": True}},  # delete_user
+            {"status": 201, "json": {"ok": True}},  # add_user
+        ]
+        await sg.reset_user("db1", "test_user", "test_pass", ["channel1"])
+
+    @pytest.mark.asyncio
+    async def test_create_user_client_context_manager(self, sync_gateway):
+        sg, specs = sync_gateway
+        # Specs for delete_user and add_user (via reset_user) during context enter
+        specs[:] = [
+            {"status": 200, "json": {"ok": True}},  # delete_user
+            {"status": 201, "json": {"ok": True}},  # add_user
+        ]
+
+        async with sg.create_user_client(
+            "db1", "test_user", "test_pass", ["channel1"]
+        ) as client:
+            assert client.hostname == sg.hostname
+            assert client.secure == sg.secure
+            assert not client._SyncGatewayBase__session.closed
+
+        assert client._SyncGatewayBase__session.closed

--- a/tests/QE/test_db_gone.py
+++ b/tests/QE/test_db_gone.py
@@ -143,7 +143,7 @@ class TestDbGone(CBLTestClass):
         ]
 
         self.mark_test_step("Create buckets and configure databases")
-        for i, [db_name, bucket_name, channel, username, _] in enumerate(db_configs):
+        for db_name, bucket_name, channel, username in db_configs:
             cbs.create_bucket(bucket_name)
 
             db_config = {
@@ -153,9 +153,7 @@ class TestDbGone(CBLTestClass):
             }
             db_payload = PutDatabasePayload(db_config)
             await sg.put_database(db_name, db_payload)
-            db_configs[i][4] = await sg.create_user_client(
-                db_name, username, "pass", [channel]
-            )
+            await sg.reset_user(db_name, username, "pass", [channel])
 
             self.mark_test_step(f"Create {num_docs} docs via Sync Gateway")
             sg_docs: list[DocumentUpdateEntry] = []
@@ -207,7 +205,3 @@ class TestDbGone(CBLTestClass):
             assert errors_403 == endpoints_tested, (
                 f"{db_name}: Expected all {endpoints_tested} endpoints to return 403, got {errors_403}"
             )
-
-        for [_, _, _, _, user_client] in db_configs:
-            if user_client is not None:
-                await user_client.close()

--- a/tests/QE/test_high_availability.py
+++ b/tests/QE/test_high_availability.py
@@ -49,8 +49,7 @@ class TestHighAvailability(CBLTestClass):
         self.mark_test_step(
             f"Create user '{username}' with access to channels {channels}"
         )
-        await sgs[0].create_user_client(sg_db, username, password, channels)
-
+        await sgs[0].reset_user(sg_db, username, password, channels)
         self.mark_test_step(f"Create user client via load balancer ({lb_url})")
         lb_user = SyncGatewayUserClient(
             lb_url, username, password, port=4984, secure=False

--- a/tests/QE/test_large_doc_workloads.py
+++ b/tests/QE/test_large_doc_workloads.py
@@ -60,8 +60,7 @@ class TestLargeDocWorkloads(CBLTestClass):
         await sg.put_database(sg_db, db_payload)
 
         self.mark_test_step(f"Create user '{username}' with channel access.")
-        await sg.create_user_client(sg_db, username, password, channels)
-
+        await sg.reset_user(sg_db, username, password, channels)
         self.mark_test_step("Reset local database with empty collection.")
         dbs = await ts.create_and_reset_db(["db1"], collections=["_default._default"])
         db = dbs[0]

--- a/tests/QE/test_log_redaction.py
+++ b/tests/QE/test_log_redaction.py
@@ -255,7 +255,7 @@ class TestLogRedaction(CBLTestClass):
                     "No redacted SGCollect zip files found. "
                     "Make sure SGCollect was run with redaction enabled and Caddy has 'browse' enabled."
                 )
-                redacted_zip_filename = sorted(files)[-1]
+                redacted_zip_filename = max(files)
                 self.mark_test_step(f"Found redacted zip: {redacted_zip_filename}")
 
             except Exception as e:

--- a/tests/QE/test_log_redaction.py
+++ b/tests/QE/test_log_redaction.py
@@ -115,69 +115,70 @@ class TestLogRedaction(CBLTestClass):
         await sg.put_database(sg_db, db_payload)
 
         self.mark_test_step(f"Create user '{username}' with access to channels")
-        sg_user = await sg.create_user_client(sg_db, username, password, channels)
-
-        self.mark_test_step(f"Create {num_docs} docs via Sync Gateway")
-        sg_docs: list[DocumentUpdateEntry] = []
-        sg_doc_ids: list[str] = []
-        for i in range(num_docs):
-            doc_id = f"sg_doc_{i}"
-            sg_doc_ids.append(doc_id)
-            sg_docs.append(
-                DocumentUpdateEntry(
-                    doc_id,
-                    None,
-                    body={
-                        "type": "test_doc",
-                        "index": i,
-                        "channels": channels,
-                    },
-                )
-            )
-        await sg.update_documents(sg_db, sg_docs, "_default", "_default")
-
-        self.mark_test_step("Verify docs were created (public API)")
-        all_docs = await sg_user.get_all_documents(sg_db, "_default", "_default")
-        assert len(all_docs.rows) == num_docs, (
-            f"Expected {num_docs} docs, got {len(all_docs.rows)}"
-        )
-
-        self.mark_test_step("Fetch and scan SG logs for redaction violations via Caddy")
-        log_types = ["debug", "info", "warn", "error"]
-        sensitive_patterns = sg_doc_ids + [username]
-
-        all_violations = []
-        has_any_ud_tags = False
-
-        for log_type in log_types:
-            try:
-                log_contents = await sg.fetch_log_file(log_type)
-                violations = scan_logs_for_untagged_sensitive_data(
-                    log_contents, sensitive_patterns
-                )
-                if violations:
-                    all_violations.extend(
-                        [f"sg_{log_type}.log: {v}" for v in violations[:3]]
+        async with sg.create_user_client(
+            sg_db, username, password, channels
+        ) as sg_user:
+            self.mark_test_step(f"Create {num_docs} docs via Sync Gateway")
+            sg_docs: list[DocumentUpdateEntry] = []
+            sg_doc_ids: list[str] = []
+            for i in range(num_docs):
+                doc_id = f"sg_doc_{i}"
+                sg_doc_ids.append(doc_id)
+                sg_docs.append(
+                    DocumentUpdateEntry(
+                        doc_id,
+                        None,
+                        body={
+                            "type": "test_doc",
+                            "index": i,
+                            "channels": channels,
+                        },
                     )
-                if "<ud>" in log_contents:
-                    has_any_ud_tags = True
-            except FileNotFoundError:
-                continue
-            except Exception as e:
-                raise Exception(
-                    f"Failed to fetch sg_{log_type}.log via Caddy: {e}"
-                ) from e
+                )
+            await sg.update_documents(sg_db, sg_docs, "_default", "_default")
 
-        assert len(all_violations) == 0, (
-            f"Found {len(all_violations)} log redaction violations across all logs: Showing first 10:\n"
-            + "\n".join(all_violations[:10])
-        )
+            self.mark_test_step("Verify docs were created (public API)")
+            all_docs = await sg_user.get_all_documents(sg_db, "_default", "_default")
+            assert len(all_docs.rows) == num_docs, (
+                f"Expected {num_docs} docs, got {len(all_docs.rows)}"
+            )
 
-        assert has_any_ud_tags, (
-            "No <ud> tags found in any log files - partial redaction not working"
-        )
+            self.mark_test_step(
+                "Fetch and scan SG logs for redaction violations via Caddy"
+            )
+            log_types = ["debug", "info", "warn", "error"]
+            sensitive_patterns = sg_doc_ids + [username]
 
-        await sg_user.close()
+            all_violations = []
+            has_any_ud_tags = False
+
+            for log_type in log_types:
+                try:
+                    log_contents = await sg.fetch_log_file(log_type)
+                    violations = scan_logs_for_untagged_sensitive_data(
+                        log_contents, sensitive_patterns
+                    )
+                    if violations:
+                        all_violations.extend(
+                            [f"sg_{log_type}.log: {v}" for v in violations[:3]]
+                        )
+                    if "<ud>" in log_contents:
+                        has_any_ud_tags = True
+                except FileNotFoundError:
+                    continue
+                except Exception as e:
+                    raise Exception(
+                        f"Failed to fetch sg_{log_type}.log via Caddy: {e}"
+                    ) from e
+
+            assert len(all_violations) == 0, (
+                f"Found {len(all_violations)} log redaction violations across all logs: Showing first 10:\n"
+                + "\n".join(all_violations[:10])
+            )
+
+            assert has_any_ud_tags, (
+                "No <ud> tags found in any log files - partial redaction not working"
+            )
 
     @pytest.mark.asyncio(loop_scope="session")
     async def test_sgcollect_redacted_files_and_contents(
@@ -205,106 +206,110 @@ class TestLogRedaction(CBLTestClass):
         await sg.put_database(sg_db, db_payload)
 
         self.mark_test_step(f"Create user '{username}' with access to channels")
-        sg_user = await sg.create_user_client(sg_db, username, password, channels)
-
-        self.mark_test_step(f"Create {num_docs} docs via Sync Gateway")
-        sg_docs: list[DocumentUpdateEntry] = []
-        sg_doc_ids: list[str] = []
-        for i in range(num_docs):
-            doc_id = f"sgcollect_doc_{i}"
-            sg_doc_ids.append(doc_id)
-            sg_docs.append(
-                DocumentUpdateEntry(
-                    doc_id,
-                    None,
-                    body={
-                        "type": "test_doc_sgcollect",
-                        "index": i,
-                        "channels": channels,
-                    },
-                )
-            )
-        await sg.update_documents(sg_db, sg_docs, "_default", "_default")
-
-        self.mark_test_step("Verify docs were created")
-        all_docs = await sg_user.get_all_documents(sg_db, "_default", "_default")
-        assert len(all_docs.rows) == num_docs, (
-            f"Expected {num_docs} docs, got {len(all_docs.rows)}"
-        )
-
-        self.mark_test_step("Trigger SGCollect with redaction enabled")
-        sgcollect_resp = await sg.start_sgcollect(
-            redact_level=SGCollectRedactLevel.PARTIAL, output_dir="/home/ec2-user/log"
-        )
-        assert sgcollect_resp.get("status") in ["running", "started"], (
-            f"SGCollect failed to start: {sgcollect_resp}"
-        )
-
-        self.mark_test_step("Wait for SGCollect to complete")
-        await sg.wait_for_sgcollect_to_complete(max_attempts=60, wait_time=5)
-
-        self.mark_test_step("Discover redacted SGCollect zip file via Caddy")
-        try:
-            files = await sg.list_files_via_caddy(pattern=r"sgcollect.*redacted.*\.zip")
-            assert len(files) > 0, (
-                "No redacted SGCollect zip files found. "
-                "Make sure SGCollect was run with redaction enabled and Caddy has 'browse' enabled."
-            )
-            redacted_zip_filename = max(files)
-            self.mark_test_step(f"Found redacted zip: {redacted_zip_filename}")
-
-        except Exception as e:
-            pytest.fail(
-                f"Failed to list files via Caddy directory browsing: {e}. "
-                "Ensure Caddyfile has 'file_server browse' enabled."
-            )
-
-        self.mark_test_step(f"Download redacted zip: {redacted_zip_filename}")
-        with tempfile.TemporaryDirectory() as tmpdir:
-            local_zip_path = Path(tmpdir) / redacted_zip_filename
-            await sg.download_file_via_caddy(redacted_zip_filename, str(local_zip_path))
-
-            assert local_zip_path.exists(), (
-                f"Downloaded zip not found at {local_zip_path}"
-            )
-
-            self.mark_test_step("Extract and verify redacted logs in zip")
-            extract_dir = Path(tmpdir) / "extracted"
-            extract_dir.mkdir()
-
-            with zipfile.ZipFile(local_zip_path, "r") as zf:
-                zf.extractall(extract_dir)
-
-            # Find log files in the extracted content
-            log_files = list(extract_dir.rglob("sg_*.log"))
-            assert len(log_files) > 0, "No log files found in SGCollect zip"
-
-            self.mark_test_step(
-                f"Scanning {len(log_files)} log files for redaction violations"
-            )
-            sensitive_patterns = sg_doc_ids + [username]
-            all_violations = []
-            has_any_ud_tags = False
-
-            for log_file in log_files:
-                log_content = log_file.read_text(errors="replace")
-                violations = scan_logs_for_untagged_sensitive_data(
-                    log_content, sensitive_patterns
-                )
-                if violations:
-                    all_violations.extend(
-                        [f"{log_file.name}: {v}" for v in violations[:3]]
+        async with sg.create_user_client(
+            sg_db, username, password, channels
+        ) as sg_user:
+            self.mark_test_step(f"Create {num_docs} docs via Sync Gateway")
+            sg_docs: list[DocumentUpdateEntry] = []
+            sg_doc_ids: list[str] = []
+            for i in range(num_docs):
+                doc_id = f"sgcollect_doc_{i}"
+                sg_doc_ids.append(doc_id)
+                sg_docs.append(
+                    DocumentUpdateEntry(
+                        doc_id,
+                        None,
+                        body={
+                            "type": "test_doc_sgcollect",
+                            "index": i,
+                            "channels": channels,
+                        },
                     )
-                if "<ud>" in log_content:
-                    has_any_ud_tags = True
+                )
+            await sg.update_documents(sg_db, sg_docs, "_default", "_default")
 
-            assert len(all_violations) == 0, (
-                f"Found {len(all_violations)} log redaction violations in SGCollect zip. Showing first 10:\n"
-                + "\n".join(all_violations[:10])
+            self.mark_test_step("Verify docs were created")
+            all_docs = await sg_user.get_all_documents(sg_db, "_default", "_default")
+            assert len(all_docs.rows) == num_docs, (
+                f"Expected {num_docs} docs, got {len(all_docs.rows)}"
             )
 
-            assert has_any_ud_tags, (
-                "No <ud> tags found in SGCollect log files - partial redaction not working"
+            self.mark_test_step("Trigger SGCollect with redaction enabled")
+            sgcollect_resp = await sg.start_sgcollect(
+                redact_level=SGCollectRedactLevel.PARTIAL,
+                output_dir="/home/ec2-user/log",
+            )
+            assert sgcollect_resp.get("status") in ["running", "started"], (
+                f"SGCollect failed to start: {sgcollect_resp}"
             )
 
-        await sg_user.close()
+            self.mark_test_step("Wait for SGCollect to complete")
+            await sg.wait_for_sgcollect_to_complete(max_attempts=60, wait_time=5)
+
+            self.mark_test_step("Discover redacted SGCollect zip file via Caddy")
+            try:
+                files = await sg.list_files_via_caddy(
+                    pattern=r"sgcollect.*redacted.*\.zip"
+                )
+                assert len(files) > 0, (
+                    "No redacted SGCollect zip files found. "
+                    "Make sure SGCollect was run with redaction enabled and Caddy has 'browse' enabled."
+                )
+                redacted_zip_filename = sorted(files)[-1]
+                self.mark_test_step(f"Found redacted zip: {redacted_zip_filename}")
+
+            except Exception as e:
+                pytest.fail(
+                    f"Failed to list files via Caddy directory browsing: {e}. "
+                    "Ensure Caddyfile has 'file_server browse' enabled."
+                )
+
+            self.mark_test_step(f"Download redacted zip: {redacted_zip_filename}")
+            with tempfile.TemporaryDirectory() as tmpdir:
+                local_zip_path = Path(tmpdir) / redacted_zip_filename
+                await sg.download_file_via_caddy(
+                    redacted_zip_filename, str(local_zip_path)
+                )
+
+                assert local_zip_path.exists(), (
+                    f"Downloaded zip not found at {local_zip_path}"
+                )
+
+                self.mark_test_step("Extract and verify redacted logs in zip")
+                extract_dir = Path(tmpdir) / "extracted"
+                extract_dir.mkdir()
+
+                with zipfile.ZipFile(local_zip_path, "r") as zf:
+                    zf.extractall(extract_dir)
+
+                # Find log files in the extracted content
+                log_files = list(extract_dir.rglob("sg_*.log"))
+                assert len(log_files) > 0, "No log files found in SGCollect zip"
+
+                self.mark_test_step(
+                    f"Scanning {len(log_files)} log files for redaction violations"
+                )
+                sensitive_patterns = sg_doc_ids + [username]
+                all_violations = []
+                has_any_ud_tags = False
+
+                for log_file in log_files:
+                    log_content = log_file.read_text(errors="replace")
+                    violations = scan_logs_for_untagged_sensitive_data(
+                        log_content, sensitive_patterns
+                    )
+                    if violations:
+                        all_violations.extend(
+                            [f"{log_file.name}: {v}" for v in violations[:3]]
+                        )
+                    if "<ud>" in log_content:
+                        has_any_ud_tags = True
+
+                assert len(all_violations) == 0, (
+                    f"Found {len(all_violations)} log redaction violations in SGCollect zip. Showing first 10:\n"
+                    + "\n".join(all_violations[:10])
+                )
+
+                assert has_any_ud_tags, (
+                    "No <ud> tags found in SGCollect log files - partial redaction not working"
+                )

--- a/tests/QE/test_multiple_servers.py
+++ b/tests/QE/test_multiple_servers.py
@@ -1,4 +1,5 @@
 import asyncio
+from contextlib import asynccontextmanager
 from pathlib import Path
 
 import pytest
@@ -59,6 +60,7 @@ def _set_alternate_addresses(cbs_servers: list) -> None:
         )
 
 
+@asynccontextmanager
 async def _setup_database_and_user(
     sg,
     cbs,
@@ -84,7 +86,10 @@ async def _setup_database_and_user(
         password=user_password,
         collection_access={"_default": {"_default": {"admin_channels": channels}}},
     )
-    return await sg.create_user_client(sg_db, user_name, user_password, channels)
+    async with sg.create_user_client(
+        sg_db, user_name, user_password, channels
+    ) as client:
+        yield client
 
 
 @pytest.mark.sgw
@@ -106,136 +111,137 @@ class TestMultipleServers(CBLTestClass):
         channels = ["ABC", "CBS"]
 
         self.mark_test_step("Clean up and setup test environment")
-        sg_user = await _setup_database_and_user(
+        async with _setup_database_and_user(
             sg, cbs_one, sg_db, bucket_name, sg_user_name, sg_user_password, channels
-        )
+        ) as sg_user:
+            self.mark_test_step(f"Add {num_docs} docs to Sync Gateway")
+            docs_to_add = [
+                DocumentUpdateEntry(
+                    id=f"test_doc_{i}",
+                    revid=None,
+                    body={
+                        "type": "test_doc",
+                        "index": i,
+                        "content": f"Document {i}",
+                        "channels": channels,
+                    },
+                )
+                for i in range(num_docs)
+            ]
+            await sg_user.update_documents(sg_db, docs_to_add)
+            await asyncio.sleep(2)
 
-        self.mark_test_step(f"Add {num_docs} docs to Sync Gateway")
-        docs_to_add = [
-            DocumentUpdateEntry(
-                id=f"test_doc_{i}",
-                revid=None,
-                body={
-                    "type": "test_doc",
-                    "index": i,
-                    "content": f"Document {i}",
-                    "channels": channels,
-                },
+            self.mark_test_step(
+                "Verify all docs were created and store original revisions and version vectors"
             )
-            for i in range(num_docs)
-        ]
-        await sg_user.update_documents(sg_db, docs_to_add)
-        await asyncio.sleep(2)
-
-        self.mark_test_step(
-            "Verify all docs were created and store original revisions and version vectors"
-        )
-        all_docs = await sg_user.get_all_documents(sg_db)
-        assert len(all_docs.rows) == num_docs, (
-            f"Expected {num_docs} docs, got {len(all_docs.rows)}"
-        )
-        original_revs = {row.id: row.revision for row in all_docs.rows}
-        original_vvs = {}
-
-        supports_version_vectors = await sg.supports_version_vectors()
-        if supports_version_vectors:
-            changes_initial = await sg_user.get_changes(sg_db, version_type="cv")
-            original_vvs = {
-                entry.id: entry.changes[0] if entry.changes else None
-                for entry in changes_initial.results
-            }
-
-        self.mark_test_step(
-            f"Start concurrent updates ({num_updates} updates per doc) and rebalance CBS cluster"
-        )
-
-        async def update_docs_continuously() -> None:
-            """Continuously update all documents num_updates times"""
-            for update_num in range(num_updates):
-                # Get current revisions for all docs
-                max_retries = 3
-                for attempt in range(max_retries):
-                    try:
-                        current_docs = await sg_user.get_all_documents(sg_db)
-                        rev_map = {row.id: row.revision for row in current_docs.rows}
-
-                        updates = [
-                            DocumentUpdateEntry(
-                                id=f"test_doc_{i}",
-                                revid=rev_map.get(
-                                    f"test_doc_{i}"
-                                ),  # Use current revision
-                                body={
-                                    "type": "test_doc",
-                                    "index": i,
-                                    "content": f"Document {i} - update {update_num + 1}",
-                                    "channels": channels,
-                                },
-                            )
-                            for i in range(num_docs)
-                        ]
-                        await sg_user.update_documents(sg_db, updates)
-                        break  # Success, exit retry loop
-                    except Exception as e:
-                        if attempt < max_retries - 1:
-                            print(
-                                f"Update attempt {attempt + 1} failed: {e}, retrying..."
-                            )
-                            await asyncio.sleep(1)
-                        else:
-                            print(f"Update failed after {max_retries} attempts: {e}")
-                            raise
-
-                # Small delay between update batches to avoid overwhelming SGW
-                await asyncio.sleep(0.1)
-
-        update_task = asyncio.create_task(update_docs_continuously())
-        await asyncio.sleep(2)
-
-        self.mark_test_step("Rebalance OUT cbs_two from cluster")
-        cbs_one.rebalance(eject_node=cbs_two)
-        if not cbs_one.wait_for_cluster_healthy(timeout=120):
-            pytest.fail("Cluster did not become healthy after rebalance out")
-
-        self.mark_test_step("Add cbs_two back to cluster")
-        cbs_one.add_node(cbs_two)
-
-        self.mark_test_step("Rebalance IN cbs_two to cluster")
-        cbs_one.rebalance()
-        if not cbs_one.wait_for_cluster_healthy(timeout=120):
-            pytest.fail("Cluster did not become healthy after rebalance in")
-
-        self.mark_test_step("Wait for all updates to complete")
-        await update_task
-
-        self.mark_test_step(
-            "Verify all docs are present and revisions/version vectors changed"
-        )
-        all_docs_final = await sg_user.get_all_documents(sg_db)
-        assert len(all_docs_final.rows) == num_docs, (
-            f"Expected {num_docs} docs after rebalance, got {len(all_docs_final.rows)}"
-        )
-
-        for row in all_docs_final.rows:
-            original_rev = original_revs.get(row.id)
-            assert original_rev is not None, (
-                f"Document {row.id} not found in original revisions"
+            all_docs = await sg_user.get_all_documents(sg_db)
+            assert len(all_docs.rows) == num_docs, (
+                f"Expected {num_docs} docs, got {len(all_docs.rows)}"
             )
-            assert row.revision != original_rev, (
-                f"Document {row.id} revision should have changed after {num_updates} "
-                f"updates. Original: {original_rev}, Current: {row.revision}"
-            )
+            original_revs = {row.id: row.revision for row in all_docs.rows}
+            original_vvs = {}
+
+            supports_version_vectors = await sg.supports_version_vectors()
             if supports_version_vectors:
-                original_vv = original_vvs.get(row.id)
-                assert original_vv is not None, (
-                    f"Document {row.id} not found in original version vectors"
-                )
-                assert row.cv != original_vv, (
-                    f"Document {row.id} version vector should have changed after "
-                    f"{num_updates} updates. Original: {original_vv}, Current: {row.cv}"
-                )
+                changes_initial = await sg_user.get_changes(sg_db, version_type="cv")
+                original_vvs = {
+                    entry.id: entry.changes[0] if entry.changes else None
+                    for entry in changes_initial.results
+                }
 
-        await sg_user.close()
+            self.mark_test_step(
+                f"Start concurrent updates ({num_updates} updates per doc) and rebalance CBS cluster"
+            )
+
+            async def update_docs_continuously() -> None:
+                """Continuously update all documents num_updates times"""
+                for update_num in range(num_updates):
+                    # Get current revisions for all docs
+                    max_retries = 3
+                    for attempt in range(max_retries):
+                        try:
+                            current_docs = await sg_user.get_all_documents(sg_db)
+                            rev_map = {
+                                row.id: row.revision for row in current_docs.rows
+                            }
+
+                            updates = [
+                                DocumentUpdateEntry(
+                                    id=f"test_doc_{i}",
+                                    revid=rev_map.get(
+                                        f"test_doc_{i}"
+                                    ),  # Use current revision
+                                    body={
+                                        "type": "test_doc",
+                                        "index": i,
+                                        "content": f"Document {i} - update {update_num + 1}",
+                                        "channels": channels,
+                                    },
+                                )
+                                for i in range(num_docs)
+                            ]
+                            await sg_user.update_documents(sg_db, updates)
+                            break  # Success, exit retry loop
+                        except Exception as e:
+                            if attempt < max_retries - 1:
+                                print(
+                                    f"Update attempt {attempt + 1} failed: {e}, retrying..."
+                                )
+                                await asyncio.sleep(1)
+                            else:
+                                print(
+                                    f"Update failed after {max_retries} attempts: {e}"
+                                )
+                                raise
+
+                    # Small delay between update batches to avoid overwhelming SGW
+                    await asyncio.sleep(0.1)
+
+            update_task = asyncio.create_task(update_docs_continuously())
+            await asyncio.sleep(2)
+
+            self.mark_test_step("Rebalance OUT cbs_two from cluster")
+            cbs_one.rebalance(eject_node=cbs_two)
+            if not cbs_one.wait_for_cluster_healthy(timeout=120):
+                pytest.fail("Cluster did not become healthy after rebalance out")
+
+            self.mark_test_step("Add cbs_two back to cluster")
+            cbs_one.add_node(cbs_two)
+
+            self.mark_test_step("Rebalance IN cbs_two to cluster")
+            cbs_one.rebalance()
+            if not cbs_one.wait_for_cluster_healthy(timeout=120):
+                pytest.fail("Cluster did not become healthy after rebalance in")
+
+            self.mark_test_step("Wait for all updates to complete")
+            await update_task
+
+            self.mark_test_step(
+                "Verify all docs are present and revisions/version vectors changed"
+            )
+            all_docs_final = await sg_user.get_all_documents(sg_db)
+            assert len(all_docs_final.rows) == num_docs, (
+                f"Expected {num_docs} docs after rebalance, got {len(all_docs_final.rows)}"
+            )
+
+            for row in all_docs_final.rows:
+                original_rev = original_revs.get(row.id)
+                assert original_rev is not None, (
+                    f"Document {row.id} not found in original revisions"
+                )
+                assert row.revision != original_rev, (
+                    f"Document {row.id} revision should have changed after {num_updates} "
+                    f"updates. Original: {original_rev}, Current: {row.revision}"
+                )
+                if supports_version_vectors:
+                    original_vv = original_vvs.get(row.id)
+                    assert original_vv is not None, (
+                        f"Document {row.id} not found in original version vectors"
+                    )
+                    assert row.cv != original_vv, (
+                        f"Document {row.id} version vector should have changed after "
+                        f"{num_updates} updates. Original: {original_vv}, Current: {row.cv}"
+                    )
 
     @pytest.mark.asyncio(loop_scope="session")
     async def test_server_goes_down_sanity(
@@ -250,70 +256,69 @@ class TestMultipleServers(CBLTestClass):
         num_docs = 50
         sg_user_name, sg_user_password = "vipul", "pass"
         channels = ["ABC", "CBS"]
-        sg_user = await _setup_database_and_user(
+        async with _setup_database_and_user(
             sg, cbs_one, sg_db, bucket_name, sg_user_name, sg_user_password, channels
-        )
-
-        self.mark_test_step(f"Add {num_docs} docs to Sync Gateway before failover")
-        docs_to_add = [
-            DocumentUpdateEntry(
-                id=f"test_doc_{i}",
-                revid=None,
-                body={
-                    "type": "test_doc",
-                    "index": i,
-                    "content": f"Document {i}",
-                    "channels": channels,
-                },
+        ) as sg_user:
+            self.mark_test_step(f"Add {num_docs} docs to Sync Gateway before failover")
+            docs_to_add = [
+                DocumentUpdateEntry(
+                    id=f"test_doc_{i}",
+                    revid=None,
+                    body={
+                        "type": "test_doc",
+                        "index": i,
+                        "content": f"Document {i}",
+                        "channels": channels,
+                    },
+                )
+                for i in range(num_docs)
+            ]
+            await sg_user.update_documents(sg_db, docs_to_add)
+            initial_docs = await sg_user.get_all_documents(sg_db)
+            assert len(initial_docs.rows) == num_docs, (
+                f"Expected {num_docs} docs, got {len(initial_docs.rows)}"
             )
-            for i in range(num_docs)
-        ]
-        await sg_user.update_documents(sg_db, docs_to_add)
-        initial_docs = await sg_user.get_all_documents(sg_db)
-        assert len(initial_docs.rows) == num_docs, (
-            f"Expected {num_docs} docs, got {len(initial_docs.rows)}"
-        )
 
-        self.mark_test_step("Failover CBS node 2 to simulate server failure")
-        cbs_one.failover(cbs_two)
-        cbs_one.rebalance(eject_failed_nodes=False)
-        if not cbs_one.wait_for_cluster_healthy(timeout=120):
-            pytest.fail("Cluster did not become healthy after failover")
+            self.mark_test_step("Failover CBS node 2 to simulate server failure")
+            cbs_one.failover(cbs_two)
+            cbs_one.rebalance(eject_failed_nodes=False)
+            if not cbs_one.wait_for_cluster_healthy(timeout=120):
+                pytest.fail("Cluster did not become healthy after failover")
 
-        self.mark_test_step("Verify original docs accessible with node 2 failed over")
-        changes_after_failover = await sg.get_changes(sg_db, version_type="cv")
-        assert len(changes_after_failover.results) == num_docs
-
-        self.mark_test_step(f"Add {num_docs} NEW docs while node 2 is down")
-        new_docs_during_failover = [
-            DocumentUpdateEntry(
-                id=f"test_doc_during_failover_{i}",
-                revid=None,
-                body={
-                    "type": "test_doc_failover",
-                    "index": i,
-                    "content": f"Document {i} added during failover",
-                    "channels": channels,
-                },
+            self.mark_test_step(
+                "Verify original docs accessible with node 2 failed over"
             )
-            for i in range(num_docs)
-        ]
-        await sg.update_documents(sg_db, new_docs_during_failover)
+            changes_after_failover = await sg.get_changes(sg_db, version_type="cv")
+            assert len(changes_after_failover.results) == num_docs
 
-        self.mark_test_step("Verify new docs added during failover")
-        all_docs_with_new = await sg.get_all_documents(sg_db)
-        assert len(all_docs_with_new.rows) == num_docs * 2
+            self.mark_test_step(f"Add {num_docs} NEW docs while node 2 is down")
+            new_docs_during_failover = [
+                DocumentUpdateEntry(
+                    id=f"test_doc_during_failover_{i}",
+                    revid=None,
+                    body={
+                        "type": "test_doc_failover",
+                        "index": i,
+                        "content": f"Document {i} added during failover",
+                        "channels": channels,
+                    },
+                )
+                for i in range(num_docs)
+            ]
+            await sg.update_documents(sg_db, new_docs_during_failover)
 
-        self.mark_test_step("Recover CBS node 2")
-        _recover_or_add_node(cbs_one, cbs_two)
-        if not cbs_one.wait_for_cluster_healthy(timeout=120):
-            pytest.fail("Cluster did not become healthy after recovery")
+            self.mark_test_step("Verify new docs added during failover")
+            all_docs_with_new = await sg.get_all_documents(sg_db)
+            assert len(all_docs_with_new.rows) == num_docs * 2
 
-        self.mark_test_step("Verify all docs accessible after recovery")
-        changes_final = await sg.get_changes(sg_db, version_type="cv")
-        assert len(changes_final.results) == num_docs * 2
+            self.mark_test_step("Recover CBS node 2")
+            _recover_or_add_node(cbs_one, cbs_two)
+            if not cbs_one.wait_for_cluster_healthy(timeout=120):
+                pytest.fail("Cluster did not become healthy after recovery")
 
-        await sg_user.close()
+            self.mark_test_step("Verify all docs accessible after recovery")
+            changes_final = await sg.get_changes(sg_db, version_type="cv")
+            assert len(changes_final.results) == num_docs * 2
 
 
 @pytest.mark.sgw

--- a/tests/QE/test_ttl.py
+++ b/tests/QE/test_ttl.py
@@ -38,78 +38,79 @@ class TestTTL(CBLTestClass):
         await sg.put_database(sg_db, db_payload)
 
         self.mark_test_step(f"Create user '{username}' with access to {channels}")
-        sg_user = await sg.create_user_client(sg_db, username, password, channels)
+        async with sg.create_user_client(
+            sg_db, username, password, channels
+        ) as sg_user:
+            self.mark_test_step("Create documents with different expiry times")
+            current_time = datetime.now(timezone.utc)
+            expire_5s = int((current_time + timedelta(seconds=5)).timestamp())
+            expire_years = int((current_time + timedelta(days=365)).timestamp())
+            await sg.update_documents(
+                sg_db,
+                [
+                    DocumentUpdateEntry(
+                        "exp_5",
+                        None,
+                        body={
+                            "type": "test_doc",
+                            "channels": channels,
+                            "_exp": str(expire_5s),
+                        },
+                    )
+                ],
+                "_default",
+                "_default",
+            )
+            await sg.update_documents(
+                sg_db,
+                [
+                    DocumentUpdateEntry(
+                        "exp_years",
+                        None,
+                        body={
+                            "type": "test_doc",
+                            "channels": channels,
+                            "_exp": str(expire_years),
+                        },
+                    )
+                ],
+                "_default",
+                "_default",
+            )
 
-        self.mark_test_step("Create documents with different expiry times")
-        current_time = datetime.now(timezone.utc)
-        expire_5s = int((current_time + timedelta(seconds=5)).timestamp())
-        expire_years = int((current_time + timedelta(days=365)).timestamp())
-        await sg.update_documents(
-            sg_db,
-            [
-                DocumentUpdateEntry(
-                    "exp_5",
-                    None,
-                    body={
-                        "type": "test_doc",
-                        "channels": channels,
-                        "_exp": str(expire_5s),
-                    },
-                )
-            ],
-            "_default",
-            "_default",
-        )
-        await sg.update_documents(
-            sg_db,
-            [
-                DocumentUpdateEntry(
-                    "exp_years",
-                    None,
-                    body={
-                        "type": "test_doc",
-                        "channels": channels,
-                        "_exp": str(expire_years),
-                    },
-                )
-            ],
-            "_default",
-            "_default",
-        )
-
-        self.mark_test_step("Verify both documents exist initially")
-        doc_exp_5 = await sg_user.get_document(sg_db, "exp_5", "_default", "_default")
-        doc_exp_years = await sg_user.get_document(
-            sg_db, "exp_years", "_default", "_default"
-        )
-        assert doc_exp_5 is not None, "exp_5 should exist"
-        assert doc_exp_years is not None, "exp_years should exist"
-
-        self.mark_test_step("Wait for exp_5 document to expire")
-        await asyncio.sleep(10)
-
-        self.mark_test_step("Verify exp_5 document is expired (not accessible)")
-        try:
-            expired_doc = await sg_user.get_document(
+            self.mark_test_step("Verify both documents exist initially")
+            doc_exp_5 = await sg_user.get_document(
                 sg_db, "exp_5", "_default", "_default"
             )
-            if expired_doc is not None:
-                pytest.fail("exp_5 should be expired/inaccessible")
-        except CblSyncGatewayBadResponseError as e:
-            assert e.code in [403, 404], (
-                f"Expected 403/404 for expired doc, got {e.code}"
+            doc_exp_years = await sg_user.get_document(
+                sg_db, "exp_years", "_default", "_default"
             )
-        sdk_doc = cbs.get_document(bucket_name, "exp_5", "_default", "_default")
-        assert sdk_doc is None, "exp_5 should be purged"
+            assert doc_exp_5 is not None, "exp_5 should exist"
+            assert doc_exp_years is not None, "exp_years should exist"
 
-        self.mark_test_step("Verify exp_years document is still accessible")
-        doc_still_valid = await sg_user.get_document(
-            sg_db, "exp_years", "_default", "_default"
-        )
-        assert doc_still_valid is not None, "exp_years should still be accessible"
-        assert doc_still_valid.id == "exp_years"
+            self.mark_test_step("Wait for exp_5 document to expire")
+            await asyncio.sleep(10)
 
-        await sg_user.close()
+            self.mark_test_step("Verify exp_5 document is expired (not accessible)")
+            try:
+                expired_doc = await sg_user.get_document(
+                    sg_db, "exp_5", "_default", "_default"
+                )
+                if expired_doc is not None:
+                    pytest.fail("exp_5 should be expired/inaccessible")
+            except CblSyncGatewayBadResponseError as e:
+                assert e.code in [403, 404], (
+                    f"Expected 403/404 for expired doc, got {e.code}"
+                )
+            sdk_doc = cbs.get_document(bucket_name, "exp_5", "_default", "_default")
+            assert sdk_doc is None, "exp_5 should be purged"
+
+            self.mark_test_step("Verify exp_years document is still accessible")
+            doc_still_valid = await sg_user.get_document(
+                sg_db, "exp_years", "_default", "_default"
+            )
+            assert doc_still_valid is not None, "exp_years should still be accessible"
+            assert doc_still_valid.id == "exp_years"
 
     @pytest.mark.asyncio(loop_scope="session")
     async def test_string_expiry_as_iso_8601_date(
@@ -136,76 +137,77 @@ class TestTTL(CBLTestClass):
         await sg.put_database(sg_db, db_payload)
 
         self.mark_test_step(f"Create user '{username}' with access to {channels}")
-        sg_user = await sg.create_user_client(sg_db, username, password, channels)
+        async with sg.create_user_client(
+            sg_db, username, password, channels
+        ) as sg_user:
+            self.mark_test_step("Create documents with ISO-8601 expiry dates")
+            current_time = datetime.now().astimezone()
+            expire_5s_iso = (current_time + timedelta(seconds=5)).isoformat()
+            expire_years_iso = (current_time + timedelta(days=365)).isoformat()
 
-        self.mark_test_step("Create documents with ISO-8601 expiry dates")
-        current_time = datetime.now().astimezone()
-        expire_5s_iso = (current_time + timedelta(seconds=5)).isoformat()
-        expire_years_iso = (current_time + timedelta(days=365)).isoformat()
+            await sg.update_documents(
+                sg_db,
+                [
+                    DocumentUpdateEntry(
+                        "exp_5",
+                        None,
+                        body={
+                            "type": "test_doc",
+                            "channels": channels,
+                            "_exp": expire_5s_iso,
+                        },
+                    )
+                ],
+                "_default",
+                "_default",
+            )
+            await sg.update_documents(
+                sg_db,
+                [
+                    DocumentUpdateEntry(
+                        "exp_years",
+                        None,
+                        body={
+                            "type": "test_doc",
+                            "channels": channels,
+                            "_exp": expire_years_iso,
+                        },
+                    )
+                ],
+                "_default",
+                "_default",
+            )
 
-        await sg.update_documents(
-            sg_db,
-            [
-                DocumentUpdateEntry(
-                    "exp_5",
-                    None,
-                    body={
-                        "type": "test_doc",
-                        "channels": channels,
-                        "_exp": expire_5s_iso,
-                    },
-                )
-            ],
-            "_default",
-            "_default",
-        )
-        await sg.update_documents(
-            sg_db,
-            [
-                DocumentUpdateEntry(
-                    "exp_years",
-                    None,
-                    body={
-                        "type": "test_doc",
-                        "channels": channels,
-                        "_exp": expire_years_iso,
-                    },
-                )
-            ],
-            "_default",
-            "_default",
-        )
-
-        self.mark_test_step("Verify both documents exist initially")
-        doc_exp_5 = await sg_user.get_document(sg_db, "exp_5", "_default", "_default")
-        doc_exp_years = await sg_user.get_document(
-            sg_db, "exp_years", "_default", "_default"
-        )
-        assert doc_exp_5 is not None, "exp_5 should exist"
-        assert doc_exp_years is not None, "exp_years should exist"
-
-        self.mark_test_step("Wait for exp_5 document to expire")
-        await asyncio.sleep(10)
-
-        self.mark_test_step("Verify exp_5 document is expired (not accessible)")
-        try:
-            expired_doc = await sg_user.get_document(
+            self.mark_test_step("Verify both documents exist initially")
+            doc_exp_5 = await sg_user.get_document(
                 sg_db, "exp_5", "_default", "_default"
             )
-            if expired_doc is not None:
-                pytest.fail("exp_5 should be expired/inaccessible")
-        except CblSyncGatewayBadResponseError as e:
-            assert e.code in [403, 404], (
-                f"Expected 403/404 for expired doc, got {e.code}"
+            doc_exp_years = await sg_user.get_document(
+                sg_db, "exp_years", "_default", "_default"
             )
-        sdk_doc = cbs.get_document(bucket_name, "exp_5", "_default", "_default")
-        assert sdk_doc is None, "exp_5 should be purged from bucket"
+            assert doc_exp_5 is not None, "exp_5 should exist"
+            assert doc_exp_years is not None, "exp_years should exist"
 
-        self.mark_test_step("Verify exp_years document is still accessible")
-        doc_still_valid = await sg_user.get_document(
-            sg_db, "exp_years", "_default", "_default"
-        )
-        assert doc_still_valid is not None, "exp_years should still be accessible"
-        assert doc_still_valid.id == "exp_years"
+            self.mark_test_step("Wait for exp_5 document to expire")
+            await asyncio.sleep(10)
 
-        await sg_user.close()
+            self.mark_test_step("Verify exp_5 document is expired (not accessible)")
+            try:
+                expired_doc = await sg_user.get_document(
+                    sg_db, "exp_5", "_default", "_default"
+                )
+                if expired_doc is not None:
+                    pytest.fail("exp_5 should be expired/inaccessible")
+            except CblSyncGatewayBadResponseError as e:
+                assert e.code in [403, 404], (
+                    f"Expected 403/404 for expired doc, got {e.code}"
+                )
+            sdk_doc = cbs.get_document(bucket_name, "exp_5", "_default", "_default")
+            assert sdk_doc is None, "exp_5 should be purged from bucket"
+
+            self.mark_test_step("Verify exp_years document is still accessible")
+            doc_still_valid = await sg_user.get_document(
+                sg_db, "exp_years", "_default", "_default"
+            )
+            assert doc_still_valid is not None, "exp_years should still be accessible"
+            assert doc_still_valid.id == "exp_years"

--- a/tests/QE/test_users_channels.py
+++ b/tests/QE/test_users_channels.py
@@ -47,104 +47,112 @@ class TestUsersChannels(CBLTestClass):
         self.mark_test_step(
             f"Create user '{username}' with access to {channels} (stored in shared bucket)"
         )
-        sg_user = await sgs[0].create_user_client(sg_db, username, password, channels)
-
-        self.mark_test_step(
-            f"Bulk create {total_docs} documents in {num_batches} batches of {batch_size} docs "
-            f"using round-robin across {num_sgs} SGW nodes"
-        )
-        doc_ids: list[str] = []
-        for batch_num in range(num_batches):
-            target_sg = sgs[batch_num % num_sgs]
-            docs: list[DocumentUpdateEntry] = []
-            for i in range(batch_size):
-                doc_id = f"doc_{batch_num}_{i}"
-                doc_ids.append(doc_id)
-                channel = channels[i % len(channels)]
-                docs.append(
-                    DocumentUpdateEntry(
-                        doc_id,
-                        None,
-                        body={
-                            "type": "test_doc",
-                            "batch": batch_num,
-                            "index": i,
-                            "channels": [channel],
-                            "updates": 0,
-                            "created_via_sgw": batch_num % num_sgs,
-                        },
-                    )
-                )
-            await target_sg.update_documents(sg_db, docs, "_default", "_default")
-
-        self.mark_test_step("Wait for documents to propagate across all SGW nodes")
-        await asyncio.sleep(10)
-
-        self.mark_test_step(
-            f"Verify user sees all {total_docs} docs via changes feed from first SGW"
-        )
-        changes = await sg_user.get_changes(sg_db)
-        user_doc_changes = [entry for entry in changes.results if entry.id in doc_ids]
-        assert len(user_doc_changes) == total_docs, (
-            f"Expected {total_docs} docs in changes feed, got {len(user_doc_changes)}"
-        )
-
-        self.mark_test_step("Verify no duplicate documents in changes feed")
-        unique_ids = {entry.id for entry in user_doc_changes}
-        assert len(unique_ids) == total_docs, (
-            f"Duplicate documents found in changes feed. "
-            f"Expected: {total_docs}, Got: {len(unique_ids)}"
-        )
-
-        self.mark_test_step("Verify all expected document IDs are present")
-        expected_ids = set(doc_ids)
-        actual_ids = unique_ids
-        missing_ids = expected_ids - actual_ids
-        unexpected_ids = actual_ids - expected_ids
-        assert len(missing_ids) == 0, f"Missing document IDs: {missing_ids}"
-        assert len(unexpected_ids) == 0, f"Unexpected document IDs: {unexpected_ids}"
-
-        self.mark_test_step(
-            "Verify user can retrieve all documents via _all_docs from one SGW node"
-        )
-        all_docs = await sg_user.wait_for_all_documents(sg_db, total_docs)
-        all_docs_ids = [row.id for row in all_docs.rows if row.id in doc_ids]
-        assert len(all_docs_ids) == total_docs, (
-            f"Expected {total_docs} docs via _all_docs, got {len(all_docs_ids)}"
-        )
-
-        self.mark_test_step("Verify all documents have correct revision format")
-        for row in all_docs.rows:
-            if row.id in doc_ids:
-                assert len(row.revision) > 0, f"Document {row.id} has no revision"
-                assert "-" in row.revision, (
-                    f"Invalid revision format for {row.id}: {row.revision}"
-                )
-
-        supports_version_vectors = await sgs[0].supports_version_vectors()
-        if supports_version_vectors:
+        async with sgs[0].create_user_client(
+            sg_db, username, password, channels
+        ) as sg_user:
             self.mark_test_step(
-                "Verify all documents have correct version vector format (SGW 4.0+)"
+                f"Bulk create {total_docs} documents in {num_batches} batches of {batch_size} docs "
+                f"using round-robin across {num_sgs} SGW nodes"
             )
+            doc_ids: list[str] = []
+            for batch_num in range(num_batches):
+                target_sg = sgs[batch_num % num_sgs]
+                docs: list[DocumentUpdateEntry] = []
+                for i in range(batch_size):
+                    doc_id = f"doc_{batch_num}_{i}"
+                    doc_ids.append(doc_id)
+                    channel = channels[i % len(channels)]
+                    docs.append(
+                        DocumentUpdateEntry(
+                            doc_id,
+                            None,
+                            body={
+                                "type": "test_doc",
+                                "batch": batch_num,
+                                "index": i,
+                                "channels": [channel],
+                                "updates": 0,
+                                "created_via_sgw": batch_num % num_sgs,
+                            },
+                        )
+                    )
+                await target_sg.update_documents(sg_db, docs, "_default", "_default")
+
+            self.mark_test_step("Wait for documents to propagate across all SGW nodes")
+            await asyncio.sleep(10)
+
+            self.mark_test_step(
+                f"Verify user sees all {total_docs} docs via changes feed from first SGW"
+            )
+            changes = await sg_user.get_changes(sg_db)
+            user_doc_changes = [
+                entry for entry in changes.results if entry.id in doc_ids
+            ]
+            assert len(user_doc_changes) == total_docs, (
+                f"Expected {total_docs} docs in changes feed, got {len(user_doc_changes)}"
+            )
+
+            self.mark_test_step("Verify no duplicate documents in changes feed")
+            unique_ids = {entry.id for entry in user_doc_changes}
+            assert len(unique_ids) == total_docs, (
+                f"Duplicate documents found in changes feed. "
+                f"Expected: {total_docs}, Got: {len(unique_ids)}"
+            )
+
+            self.mark_test_step("Verify all expected document IDs are present")
+            expected_ids = set(doc_ids)
+            actual_ids = unique_ids
+            missing_ids = expected_ids - actual_ids
+            unexpected_ids = actual_ids - expected_ids
+            assert len(missing_ids) == 0, f"Missing document IDs: {missing_ids}"
+            assert len(unexpected_ids) == 0, (
+                f"Unexpected document IDs: {unexpected_ids}"
+            )
+
+            self.mark_test_step(
+                "Verify user can retrieve all documents via _all_docs from one SGW node"
+            )
+            all_docs = await sg_user.wait_for_all_documents(sg_db, total_docs)
+            all_docs_ids = [row.id for row in all_docs.rows if row.id in doc_ids]
+            assert len(all_docs_ids) == total_docs, (
+                f"Expected {total_docs} docs via _all_docs, got {len(all_docs_ids)}"
+            )
+
+            self.mark_test_step("Verify all documents have correct revision format")
             for row in all_docs.rows:
                 if row.id in doc_ids:
-                    assert row.cv is not None and len(row.cv) > 0, (
-                        f"Document {row.id} has no version vector"
-                    )
-                    assert "@" in row.cv, (
-                        f"Invalid version vector format for {row.id}: {row.cv}"
+                    assert len(row.revision) > 0, f"Document {row.id} has no revision"
+                    assert "-" in row.revision, (
+                        f"Invalid revision format for {row.id}: {row.revision}"
                     )
 
-        self.mark_test_step(
-            "Verify all documents are accessible from each SGW node independently"
-        )
-        for i, sg in enumerate(sgs):
-            test_user = await sg.create_user_client(sg_db, username, password, channels)
-            node_all_docs = await test_user.wait_for_all_documents(sg_db, total_docs)
-            node_doc_ids = [row.id for row in node_all_docs.rows if row.id in doc_ids]
-            assert len(node_doc_ids) == total_docs, (
-                f"SGW node {i}: Expected {total_docs} docs, got {len(node_doc_ids)}"
+            supports_version_vectors = await sgs[0].supports_version_vectors()
+            if supports_version_vectors:
+                self.mark_test_step(
+                    "Verify all documents have correct version vector format (SGW 4.0+)"
+                )
+                for row in all_docs.rows:
+                    if row.id in doc_ids:
+                        assert row.cv is not None and len(row.cv) > 0, (
+                            f"Document {row.id} has no version vector"
+                        )
+                        assert "@" in row.cv, (
+                            f"Invalid version vector format for {row.id}: {row.cv}"
+                        )
+
+            self.mark_test_step(
+                "Verify all documents are accessible from each SGW node independently"
             )
-            await test_user.close()
-
-        await sg_user.close()
+            for i, sg in enumerate(sgs):
+                async with sg.create_user_client(
+                    sg_db, username, password, channels
+                ) as test_user:
+                    node_all_docs = await test_user.wait_for_all_documents(
+                        sg_db, total_docs
+                    )
+                    node_doc_ids = [
+                        row.id for row in node_all_docs.rows if row.id in doc_ids
+                    ]
+                    assert len(node_doc_ids) == total_docs, (
+                        f"SGW node {i}: Expected {total_docs} docs, got {len(node_doc_ids)}"
+                    )

--- a/tests/QE/test_xattrs.py
+++ b/tests/QE/test_xattrs.py
@@ -43,51 +43,52 @@ class TestXattrs(CBLTestClass):
         self.mark_test_step(
             f"Create user {username} with access to SG and SDK channels"
         )
-        sg_user = await sg.create_user_client(sg_db, username, password, ["SG", "SDK"])
-
-        self.mark_test_step(f"Bulk create {num_docs} docs via Sync Gateway")
-        sg_docs: list[DocumentUpdateEntry] = []
-        sg_doc_ids: list[str] = []
-        for i in range(num_docs):
-            doc_id = f"sg_{i}"
-            sg_doc_ids.append(doc_id)
-            sg_docs.append(
-                DocumentUpdateEntry(
-                    doc_id,
-                    None,  # No revision for new docs
-                    body={
-                        "type": "sg_doc",
-                        "index": i,
-                        "channels": ["SG"],
-                        "created_by": "sync_gateway",
-                    },
+        async with sg.create_user_client(
+            sg_db, username, password, ["SG", "SDK"]
+        ) as sg_user:
+            self.mark_test_step(f"Bulk create {num_docs} docs via Sync Gateway")
+            sg_docs: list[DocumentUpdateEntry] = []
+            sg_doc_ids: list[str] = []
+            for i in range(num_docs):
+                doc_id = f"sg_{i}"
+                sg_doc_ids.append(doc_id)
+                sg_docs.append(
+                    DocumentUpdateEntry(
+                        doc_id,
+                        None,  # No revision for new docs
+                        body={
+                            "type": "sg_doc",
+                            "index": i,
+                            "channels": ["SG"],
+                            "created_by": "sync_gateway",
+                        },
+                    )
                 )
-            )
 
-        batch_size = 500
-        for batch_start in range(0, num_docs, batch_size):
-            batch_end = min(batch_start + batch_size, num_docs)
-            await sg.update_documents(
-                sg_db,
-                sg_docs[batch_start:batch_end],
-                scope="_default",
-                collection="_default",
-            )
+            batch_size = 500
+            for batch_start in range(0, num_docs, batch_size):
+                batch_end = min(batch_start + batch_size, num_docs)
+                await sg.update_documents(
+                    sg_db,
+                    sg_docs[batch_start:batch_end],
+                    scope="_default",
+                    collection="_default",
+                )
 
-        self.mark_test_step(
-            "Verify all SG docs were created successfully and store revisions, versions"
-        )
-        sg_all_docs = await sg_user.get_all_documents(sg_db)
-        sg_created_count = len(
-            [doc for doc in sg_all_docs.rows if doc.id.startswith("sg_")]
-        )
-        assert sg_created_count == num_docs, (
-            f"Expected {num_docs} SG docs, but found {sg_created_count}"
-        )
-        supports_version_vectors = await sg.supports_version_vectors()
-        original_revisions = {row.id: row.revision for row in sg_all_docs.rows}
-        if supports_version_vectors:
-            original_vv = {row.id: row.cv for row in sg_all_docs.rows}
+            self.mark_test_step(
+                "Verify all SG docs were created successfully and store revisions, versions"
+            )
+            sg_all_docs = await sg_user.get_all_documents(sg_db)
+            sg_created_count = len(
+                [doc for doc in sg_all_docs.rows if doc.id.startswith("sg_")]
+            )
+            assert sg_created_count == num_docs, (
+                f"Expected {num_docs} SG docs, but found {sg_created_count}"
+            )
+            supports_version_vectors = await sg.supports_version_vectors()
+            original_revisions = {row.id: row.revision for row in sg_all_docs.rows}
+            if supports_version_vectors:
+                original_vv = {row.id: row.cv for row in sg_all_docs.rows}
 
         self.mark_test_step("Stop Sync Gateway")
         await sg.delete_database(sg_db)
@@ -118,48 +119,49 @@ class TestXattrs(CBLTestClass):
 
         self.mark_test_step("Restart Sync Gateway (recreate database endpoint)")
         await sg.put_database(sg_db, db_payload)
-        sg_user = await sg.create_user_client(sg_db, username, password, ["SG", "SDK"])
-
-        self.mark_test_step("Verify revisions, versions and contents of all documents")
-        sgw_docs_now, sdk_docs_now = 0, 0
-        content_errors = []
-        for doc_id in sg_doc_ids + sdk_doc_ids:
-            doc = await sg.get_document(sg_db, doc_id, "_default", "_default")
-            if doc is None:
-                content_errors.append(f"SG doc {doc_id} not found")
-            elif doc.id.startswith("sg_"):
-                sgw_docs_now += 1
-                if doc.body.get("updated_by_sdk") is not True:
-                    content_errors.append(
-                        f"SG doc {doc_id} missing 'updated_by_sdk' flag"
-                    )
-                if doc.revid == original_revisions.get(doc.id):
-                    content_errors.append(f"SG doc {doc_id} has incorrect revision")
-                if (
-                    supports_version_vectors
-                    and doc.cv is not None
-                    and doc.cv == original_vv.get(doc.id)
-                ):
-                    content_errors.append(
-                        f"SG doc {doc_id} has incorrect version vector"
-                    )
-            elif doc.id.startswith("sdk_"):
-                sdk_docs_now += 1
-                if doc.body.get("created_by") != "sdk":
-                    content_errors.append(
-                        f"SDK doc {doc_id} has incorrect 'created_by' value"
-                    )
-        assert sgw_docs_now == num_docs, (
-            f"Expected {num_docs} SG docs, got {sgw_docs_now}"
-        )
-        assert sdk_docs_now == num_docs, (
-            f"Expected {num_docs} SDK docs, got {sdk_docs_now}"
-        )
-        assert len(content_errors) == 0, (
-            f"{len(content_errors)} documents didn't have correct content: {content_errors}"
-        )
-
-        await sg_user.close()
+        async with sg.create_user_client(
+            sg_db, username, password, ["SG", "SDK"]
+        ) as sg_user:
+            self.mark_test_step(
+                "Verify revisions, versions and contents of all documents"
+            )
+            sgw_docs_now, sdk_docs_now = 0, 0
+            content_errors = []
+            for doc_id in sg_doc_ids + sdk_doc_ids:
+                doc = await sg.get_document(sg_db, doc_id, "_default", "_default")
+                if doc is None:
+                    content_errors.append(f"SG doc {doc_id} not found")
+                elif doc.id.startswith("sg_"):
+                    sgw_docs_now += 1
+                    if doc.body.get("updated_by_sdk") is not True:
+                        content_errors.append(
+                            f"SG doc {doc_id} missing 'updated_by_sdk' flag"
+                        )
+                    if doc.revid == original_revisions.get(doc.id):
+                        content_errors.append(f"SG doc {doc_id} has incorrect revision")
+                    if (
+                        supports_version_vectors
+                        and doc.cv is not None
+                        and doc.cv == original_vv.get(doc.id)
+                    ):
+                        content_errors.append(
+                            f"SG doc {doc_id} has incorrect version vector"
+                        )
+                elif doc.id.startswith("sdk_"):
+                    sdk_docs_now += 1
+                    if doc.body.get("created_by") != "sdk":
+                        content_errors.append(
+                            f"SDK doc {doc_id} has incorrect 'created_by' value"
+                        )
+            assert sgw_docs_now == num_docs, (
+                f"Expected {num_docs} SG docs, got {sgw_docs_now}"
+            )
+            assert sdk_docs_now == num_docs, (
+                f"Expected {num_docs} SDK docs, got {sdk_docs_now}"
+            )
+            assert len(content_errors) == 0, (
+                f"{len(content_errors)} documents didn't have correct content: {content_errors}"
+            )
 
     @pytest.mark.asyncio(loop_scope="session")
     async def test_purge(self, cblpytest: CBLPyTest) -> None:
@@ -187,164 +189,169 @@ class TestXattrs(CBLTestClass):
         await sg.put_database(sg_db, db_payload)
 
         self.mark_test_step(f"Create user {username} with access to channels")
-        sg_user = await sg.create_user_client(sg_db, username, password, channels)
-
-        self.mark_test_step(f"Bulk create {num_docs} docs via Sync Gateway")
-        sg_docs: list[DocumentUpdateEntry] = []
-        sg_doc_ids: list[str] = []
-        for i in range(num_docs):
-            doc_id = f"sg_{i}"
-            sg_doc_ids.append(doc_id)
-            sg_docs.append(
-                DocumentUpdateEntry(
-                    doc_id,
-                    None,
-                    body={
-                        "type": "sg_doc",
-                        "index": i,
-                        "channels": channels,
-                    },
+        async with sg.create_user_client(
+            sg_db, username, password, channels
+        ) as sg_user:
+            self.mark_test_step(f"Bulk create {num_docs} docs via Sync Gateway")
+            sg_docs: list[DocumentUpdateEntry] = []
+            sg_doc_ids: list[str] = []
+            for i in range(num_docs):
+                doc_id = f"sg_{i}"
+                sg_doc_ids.append(doc_id)
+                sg_docs.append(
+                    DocumentUpdateEntry(
+                        doc_id,
+                        None,
+                        body={
+                            "type": "sg_doc",
+                            "index": i,
+                            "channels": channels,
+                        },
+                    )
                 )
-            )
 
-        batch_size = 500
-        for batch_start in range(0, num_docs, batch_size):
-            batch_end = min(batch_start + batch_size, num_docs)
-            await sg.update_documents(
-                sg_db,
-                sg_docs[batch_start:batch_end],
-                scope="_default",
-                collection="_default",
-            )
+            batch_size = 500
+            for batch_start in range(0, num_docs, batch_size):
+                batch_end = min(batch_start + batch_size, num_docs)
+                await sg.update_documents(
+                    sg_db,
+                    sg_docs[batch_start:batch_end],
+                    scope="_default",
+                    collection="_default",
+                )
 
-        self.mark_test_step(f"Bulk create {num_docs} docs via SDK")
-        sdk_doc_ids: list[str] = []
-        for i in range(num_docs):
-            doc_id = f"sdk_{i}"
-            sdk_doc_ids.append(doc_id)
-            doc_body = {
-                "type": "sdk_doc",
-                "index": i,
-                "channels": channels,
+            self.mark_test_step(f"Bulk create {num_docs} docs via SDK")
+            sdk_doc_ids: list[str] = []
+            for i in range(num_docs):
+                doc_id = f"sdk_{i}"
+                sdk_doc_ids.append(doc_id)
+                doc_body = {
+                    "type": "sdk_doc",
+                    "index": i,
+                    "channels": channels,
+                }
+                cbs.upsert_document(
+                    bucket_name, doc_id, doc_body, "_default", "_default"
+                )
+            all_doc_ids = sg_doc_ids + sdk_doc_ids
+
+            self.mark_test_step("Get all docs via Sync Gateway and save revisions")
+            sg_all_docs = await sg_user.wait_for_all_documents(sg_db, num_docs * 2)
+            assert len(sg_all_docs.rows) == num_docs * 2, (
+                f"Expected {num_docs * 2} docs via SG, got {len(sg_all_docs.rows)}"
+            )
+            all_doc_revisions: dict[str, str] = {
+                row.id: row.revision for row in sg_all_docs.rows
             }
-            cbs.upsert_document(bucket_name, doc_id, doc_body, "_default", "_default")
-        all_doc_ids = sg_doc_ids + sdk_doc_ids
 
-        self.mark_test_step("Get all docs via Sync Gateway and save revisions")
-        sg_all_docs = await sg_user.wait_for_all_documents(sg_db, num_docs * 2)
-        assert len(sg_all_docs.rows) == num_docs * 2, (
-            f"Expected {num_docs * 2} docs via SG, got {len(sg_all_docs.rows)}"
-        )
-        all_doc_revisions: dict[str, str] = {
-            row.id: row.revision for row in sg_all_docs.rows
-        }
-
-        supports_version_vectors = await sg.supports_version_vectors()
-        all_doc_version_vectors: dict[str, str | None] = {}
-        if supports_version_vectors:
-            self.mark_test_step("Store original version vectors for SG docs (optional)")
-            all_doc_version_vectors = {row.id: row.cv for row in sg_all_docs.rows}
-
-        self.mark_test_step("Get all docs via SDK and verify count")
-        sdk_visible_count = 0
-        for doc_id in all_doc_ids:
-            sdk_doc = cbs.get_document(bucket_name, doc_id, "_default", "_default")
-            if sdk_doc is not None:
-                sdk_visible_count += 1
-        assert sdk_visible_count == num_docs * 2, (
-            f"Expected {num_docs * 2} docs via SDK, got {sdk_visible_count}"
-        )
-
-        self.mark_test_step("Delete half of the docs randomly via Sync Gateway")
-        random.shuffle(all_doc_ids)
-        docs_to_delete = all_doc_ids[:num_docs]
-        remaining_docs = all_doc_ids[num_docs:]
-
-        for doc_id in docs_to_delete:
-            sg_doc = await sg.get_document(sg_db, doc_id, "_default", "_default")
-            if sg_doc is not None and sg_doc.revid is not None:
-                await sg.delete_document(
-                    doc_id, sg_doc.revid, sg_db, "_default", "_default"
+            supports_version_vectors = await sg.supports_version_vectors()
+            all_doc_version_vectors: dict[str, str | None] = {}
+            if supports_version_vectors:
+                self.mark_test_step(
+                    "Store original version vectors for SG docs (optional)"
                 )
+                all_doc_version_vectors = {row.id: row.cv for row in sg_all_docs.rows}
 
-        self.mark_test_step(
-            "Verify deleted docs visible in changes feed with new revision"
-        )
-        rev_changes = await sg.get_changes(
-            sg_db, "_default", "_default", version_type="rev"
-        )
-        deleted_revisions, remaining_revisions = 0, 0
-        for entry in rev_changes.results:
-            if entry.id in docs_to_delete and entry.deleted:
-                assert entry.changes[0] != all_doc_revisions.get(entry.id), (
-                    f"Deleted doc {entry.id} should have a new revision, got {entry.changes[0]}"
-                )
-                deleted_revisions += 1
-            elif entry.id in remaining_docs:
-                assert entry.changes[0] == all_doc_revisions.get(entry.id), (
-                    f"Non-deleted doc {entry.id} should have the same revision, got {entry.changes[0]}"
-                )
-                remaining_revisions += 1
-        assert deleted_revisions == len(docs_to_delete), (
-            f"Expected to find {len(docs_to_delete)} deleted docs in changes feed, found {deleted_revisions}"
-        )
-        assert remaining_revisions == len(remaining_docs), (
-            f"Expected to find {len(remaining_docs)} non-deleted docs in changes feed, found {remaining_revisions}"
-        )
-
-        self.mark_test_step("Verify non-deleted docs still accessible")
-        for doc_id in remaining_docs:
-            sg_doc = await sg.get_document(sg_db, doc_id, "_default", "_default")
-            assert sg_doc is not None, (
-                f"Non-deleted doc {doc_id} should still be accessible"
+            self.mark_test_step("Get all docs via SDK and verify count")
+            sdk_visible_count = 0
+            for doc_id in all_doc_ids:
+                sdk_doc = cbs.get_document(bucket_name, doc_id, "_default", "_default")
+                if sdk_doc is not None:
+                    sdk_visible_count += 1
+            assert sdk_visible_count == num_docs * 2, (
+                f"Expected {num_docs * 2} docs via SDK, got {sdk_visible_count}"
             )
 
-        if supports_version_vectors:
-            self.mark_test_step(
-                "Verify new version vectors for deleted docs (optional)"
-            )
-            cv_changes = await sg.get_changes(
-                sg_db, "_default", "_default", version_type="cv"
-            )
-            for entry in cv_changes.results:
-                if entry.id in docs_to_delete and entry.deleted and entry.changes:
-                    assert entry.changes[0] != all_doc_version_vectors.get(entry.id), (
-                        f"Deleted doc {entry.id} should have different version vector. "
-                        f"Original: {all_doc_version_vectors.get(entry.id)}, Current: {entry.changes[0]}"
+            self.mark_test_step("Delete half of the docs randomly via Sync Gateway")
+            random.shuffle(all_doc_ids)
+            docs_to_delete = all_doc_ids[:num_docs]
+            remaining_docs = all_doc_ids[num_docs:]
+
+            for doc_id in docs_to_delete:
+                sg_doc = await sg.get_document(sg_db, doc_id, "_default", "_default")
+                if sg_doc is not None and sg_doc.revid is not None:
+                    await sg.delete_document(
+                        doc_id, sg_doc.revid, sg_db, "_default", "_default"
                     )
 
-        self.mark_test_step("Purge all docs via Sync Gateway")
-        for doc_id in all_doc_ids:
-            await sg.purge_document(doc_id, sg_db, "_default", "_default")
+            self.mark_test_step(
+                "Verify deleted docs visible in changes feed with new revision"
+            )
+            rev_changes = await sg.get_changes(
+                sg_db, "_default", "_default", version_type="rev"
+            )
+            deleted_revisions, remaining_revisions = 0, 0
+            for entry in rev_changes.results:
+                if entry.id in docs_to_delete and entry.deleted:
+                    assert entry.changes[0] != all_doc_revisions.get(entry.id), (
+                        f"Deleted doc {entry.id} should have a new revision, got {entry.changes[0]}"
+                    )
+                    deleted_revisions += 1
+                elif entry.id in remaining_docs:
+                    assert entry.changes[0] == all_doc_revisions.get(entry.id), (
+                        f"Non-deleted doc {entry.id} should have the same revision, got {entry.changes[0]}"
+                    )
+                    remaining_revisions += 1
+            assert deleted_revisions == len(docs_to_delete), (
+                f"Expected to find {len(docs_to_delete)} deleted docs in changes feed, found {deleted_revisions}"
+            )
+            assert remaining_revisions == len(remaining_docs), (
+                f"Expected to find {len(remaining_docs)} non-deleted docs in changes feed, found {remaining_revisions}"
+            )
 
-        self.mark_test_step("Verify SG can't see any docs after purge")
-        sg_docs_after_purge = await sg_user.get_all_documents(sg_db)
-        assert len(sg_docs_after_purge.rows) == 0, (
-            f"Expected 0 docs after purge, got {len(sg_docs_after_purge.rows)}"
-        )
+            self.mark_test_step("Verify non-deleted docs still accessible")
+            for doc_id in remaining_docs:
+                sg_doc = await sg.get_document(sg_db, doc_id, "_default", "_default")
+                assert sg_doc is not None, (
+                    f"Non-deleted doc {doc_id} should still be accessible"
+                )
 
-        self.mark_test_step("Verify XATTRS are gone using changes feed")
-        changes_after_purge = await sg.get_changes(
-            sg_db, "_default", "_default", version_type="rev"
-        )
-        purged_doc_count = sum(
-            1 for entry in changes_after_purge.results if entry.id in all_doc_ids
-        )
-        assert purged_doc_count == 0, (
-            f"Expected 0 docs in changes feed after purge, found {purged_doc_count} (verifies _sync XATTR is removed)"
-        )
+            if supports_version_vectors:
+                self.mark_test_step(
+                    "Verify new version vectors for deleted docs (optional)"
+                )
+                cv_changes = await sg.get_changes(
+                    sg_db, "_default", "_default", version_type="cv"
+                )
+                for entry in cv_changes.results:
+                    if entry.id in docs_to_delete and entry.deleted and entry.changes:
+                        assert entry.changes[0] != all_doc_version_vectors.get(
+                            entry.id
+                        ), (
+                            f"Deleted doc {entry.id} should have different version vector. "
+                            f"Original: {all_doc_version_vectors.get(entry.id)}, Current: {entry.changes[0]}"
+                        )
 
-        self.mark_test_step("Verify SDK can't see any docs after purge")
-        sdk_visible_after_purge = 0
-        for doc_id in all_doc_ids:
-            doc = cbs.get_document(bucket_name, doc_id, "_default", "_default")
-            if doc is not None:
-                sdk_visible_after_purge += 1
-        assert sdk_visible_after_purge == 0, (
-            f"Expected 0 docs visible via SDK after purge, got {sdk_visible_after_purge}"
-        )
+            self.mark_test_step("Purge all docs via Sync Gateway")
+            for doc_id in all_doc_ids:
+                await sg.purge_document(doc_id, sg_db, "_default", "_default")
 
-        await sg_user.close()
+            self.mark_test_step("Verify SG can't see any docs after purge")
+            sg_docs_after_purge = await sg_user.get_all_documents(sg_db)
+            assert len(sg_docs_after_purge.rows) == 0, (
+                f"Expected 0 docs after purge, got {len(sg_docs_after_purge.rows)}"
+            )
+
+            self.mark_test_step("Verify XATTRS are gone using changes feed")
+            changes_after_purge = await sg.get_changes(
+                sg_db, "_default", "_default", version_type="rev"
+            )
+            purged_doc_count = sum(
+                1 for entry in changes_after_purge.results if entry.id in all_doc_ids
+            )
+            assert purged_doc_count == 0, (
+                f"Expected 0 docs in changes feed after purge, found {purged_doc_count} (verifies _sync XATTR is removed)"
+            )
+
+            self.mark_test_step("Verify SDK can't see any docs after purge")
+            sdk_visible_after_purge = 0
+            for doc_id in all_doc_ids:
+                doc = cbs.get_document(bucket_name, doc_id, "_default", "_default")
+                if doc is not None:
+                    sdk_visible_after_purge += 1
+            assert sdk_visible_after_purge == 0, (
+                f"Expected 0 docs visible via SDK after purge, got {sdk_visible_after_purge}"
+            )
 
     @pytest.mark.asyncio(loop_scope="session")
     async def test_sg_sdk_interop_unique_docs(self, cblpytest: CBLPyTest) -> None:
@@ -373,137 +380,158 @@ class TestXattrs(CBLTestClass):
         self.mark_test_step(
             f"Create user '{username}' with access to SDK and SG channels"
         )
-        sg_user = await sg.create_user_client(sg_db, username, password, ["sdk", "sg"])
-
-        self.mark_test_step(f"Bulk create {num_docs} docs via SDK")
-        sdk_doc_ids: list[str] = []
-        for i in range(num_docs):
-            doc_id = f"sdk_{i}"
-            sdk_doc_ids.append(doc_id)
-            doc_body = {"content": {"foo": "bar", "updates": 1}, "channels": ["sdk"]}
-            cbs.upsert_document(bucket_name, doc_id, doc_body, "_default", "_default")
-
-        self.mark_test_step(f"Bulk create {num_docs} docs via Sync Gateway")
-        sg_docs: list[DocumentUpdateEntry] = []
-        sg_doc_ids: list[str] = []
-        for i in range(num_docs):
-            doc_id = f"sg_{i}"
-            sg_doc_ids.append(doc_id)
-            sg_docs.append(
-                DocumentUpdateEntry(
-                    doc_id,
-                    None,
-                    body={"content": {"foo": "bar", "updates": 1}, "channels": ["sg"]},
+        async with sg.create_user_client(
+            sg_db, username, password, ["sdk", "sg"]
+        ) as sg_user:
+            self.mark_test_step(f"Bulk create {num_docs} docs via SDK")
+            sdk_doc_ids: list[str] = []
+            for i in range(num_docs):
+                doc_id = f"sdk_{i}"
+                sdk_doc_ids.append(doc_id)
+                doc_body = {
+                    "content": {"foo": "bar", "updates": 1},
+                    "channels": ["sdk"],
+                }
+                cbs.upsert_document(
+                    bucket_name, doc_id, doc_body, "_default", "_default"
                 )
-            )
-        await sg.update_documents(sg_db, sg_docs, "_default", "_default")
-        all_doc_ids = sdk_doc_ids + sg_doc_ids
 
-        self.mark_test_step("Verify SDK sees all docs")
-        sdk_visible_count = 0
-        for doc_id in all_doc_ids:
-            sdk_doc = cbs.get_document(bucket_name, doc_id, "_default", "_default")
-            if sdk_doc is not None:
-                sdk_visible_count += 1
-        assert sdk_visible_count == num_docs * 2, (
-            f"Expected {num_docs * 2} docs via SDK, got {sdk_visible_count}"
-        )
+            self.mark_test_step(f"Bulk create {num_docs} docs via Sync Gateway")
+            sg_docs: list[DocumentUpdateEntry] = []
+            sg_doc_ids: list[str] = []
+            for i in range(num_docs):
+                doc_id = f"sg_{i}"
+                sg_doc_ids.append(doc_id)
+                sg_docs.append(
+                    DocumentUpdateEntry(
+                        doc_id,
+                        None,
+                        body={
+                            "content": {"foo": "bar", "updates": 1},
+                            "channels": ["sg"],
+                        },
+                    )
+                )
+            await sg.update_documents(sg_db, sg_docs, "_default", "_default")
+            all_doc_ids = sdk_doc_ids + sg_doc_ids
 
-        self.mark_test_step(
-            f"Verify user '{username}' sees all docs via _changes (public API)"
-        )
-        user_changes = await sg_user.get_changes(sg_db)
-        unique_docs = {e.id for e in user_changes.results if e.id in all_doc_ids}
-        assert len(unique_docs) == num_docs * 2, (
-            f"User should see {num_docs * 2} docs via public API, got {len(unique_docs)}"
-        )
-
-        self.mark_test_step(f"Bulk update sdk docs {num_updates} times via SDK")
-        for _ in range(num_updates):
-            for doc_id in sdk_doc_ids:
+            self.mark_test_step("Verify SDK sees all docs")
+            sdk_visible_count = 0
+            for doc_id in all_doc_ids:
                 sdk_doc = cbs.get_document(bucket_name, doc_id, "_default", "_default")
                 if sdk_doc is not None:
-                    sdk_doc["content"]["updates"] += 1
-                    cbs.upsert_document(
-                        bucket_name, doc_id, sdk_doc, "_default", "_default"
+                    sdk_visible_count += 1
+            assert sdk_visible_count == num_docs * 2, (
+                f"Expected {num_docs * 2} docs via SDK, got {sdk_visible_count}"
+            )
+
+            self.mark_test_step(
+                f"Verify user '{username}' sees all docs via _changes (public API)"
+            )
+            user_changes = await sg_user.get_changes(sg_db)
+            unique_docs = {e.id for e in user_changes.results if e.id in all_doc_ids}
+            assert len(unique_docs) == num_docs * 2, (
+                f"User should see {num_docs * 2} docs via public API, got {len(unique_docs)}"
+            )
+
+            self.mark_test_step(f"Bulk update sdk docs {num_updates} times via SDK")
+            for _ in range(num_updates):
+                for doc_id in sdk_doc_ids:
+                    sdk_doc = cbs.get_document(
+                        bucket_name, doc_id, "_default", "_default"
+                    )
+                    if sdk_doc is not None:
+                        sdk_doc["content"]["updates"] += 1
+                        cbs.upsert_document(
+                            bucket_name, doc_id, sdk_doc, "_default", "_default"
+                        )
+
+            self.mark_test_step("Verify SDK docs don't contain _sync metadata")
+            for doc_id in sdk_doc_ids[:5]:
+                sdk_doc = cbs.get_document(bucket_name, doc_id, "_default", "_default")
+                if sdk_doc is not None:
+                    assert "_sync" not in sdk_doc, f"SDK doc {doc_id} contains _sync"
+
+            self.mark_test_step(
+                f"Bulk update sg docs {num_updates} times via Sync Gateway"
+            )
+            for _ in range(num_updates):
+                sg_docs_to_update: list[DocumentUpdateEntry] = []
+                for doc_id in sg_doc_ids:
+                    sg_doc = await sg.get_document(
+                        sg_db, doc_id, "_default", "_default"
+                    )
+                    if sg_doc is not None:
+                        updated_body = sg_doc.body.copy()
+                        updated_body["content"]["updates"] += 1
+                        sg_docs_to_update.append(
+                            DocumentUpdateEntry(doc_id, sg_doc.revid, updated_body)
+                        )
+                await sg.update_documents(
+                    sg_db, sg_docs_to_update, "_default", "_default"
+                )
+
+            self.mark_test_step("Verify SDK sees all doc updates")
+            for doc_id in all_doc_ids:
+                sdk_doc = cbs.get_document(bucket_name, doc_id, "_default", "_default")
+                if sdk_doc is not None:
+                    assert sdk_doc["content"]["updates"] == num_updates + 1, (
+                        f"SDK doc {doc_id} should have {num_updates + 1} updates, got {sdk_doc['content']['updates']}"
                     )
 
-        self.mark_test_step("Verify SDK docs don't contain _sync metadata")
-        for doc_id in sdk_doc_ids[:5]:
-            sdk_doc = cbs.get_document(bucket_name, doc_id, "_default", "_default")
-            if sdk_doc is not None:
-                assert "_sync" not in sdk_doc, f"SDK doc {doc_id} contains _sync"
+            self.mark_test_step(
+                f"Verify '{username}' sees all doc updates via _all_docs (public API)"
+            )
+            all_docs_updated = await sg_user.get_all_documents(sg_db)
+            for row in all_docs_updated.rows:
+                sg_doc = await sg.get_document(sg_db, row.id, "_default", "_default")
+                if sg_doc is not None:
+                    assert sg_doc.body["content"]["updates"] == num_updates + 1, (
+                        f"SG doc {sg_doc.id} should have {num_updates + 1} updates, got {sg_doc.body['content']['updates']}"
+                    )
 
-        self.mark_test_step(f"Bulk update sg docs {num_updates} times via Sync Gateway")
-        for _ in range(num_updates):
-            sg_docs_to_update: list[DocumentUpdateEntry] = []
+            self.mark_test_step(
+                "Verify SDK docs still don't contain _sync after updates"
+            )
+            for doc_id in sdk_doc_ids:
+                sdk_doc = cbs.get_document(bucket_name, doc_id, "_default", "_default")
+                assert sdk_doc is not None, f"SDK doc {doc_id} should not be None"
+                assert "_sync" not in sdk_doc, (
+                    f"SDK doc {doc_id} should not contain _sync"
+                )
+
+            self.mark_test_step("Bulk delete sdk docs via SDK")
+            for doc_id in sdk_doc_ids:
+                cbs.delete_document(bucket_name, doc_id, "_default", "_default")
+
+            self.mark_test_step("Bulk delete sg docs via Sync Gateway")
             for doc_id in sg_doc_ids:
                 sg_doc = await sg.get_document(sg_db, doc_id, "_default", "_default")
-                if sg_doc is not None:
-                    updated_body = sg_doc.body.copy()
-                    updated_body["content"]["updates"] += 1
-                    sg_docs_to_update.append(
-                        DocumentUpdateEntry(doc_id, sg_doc.revid, updated_body)
+                if sg_doc is not None and sg_doc.revid is not None:
+                    await sg.delete_document(
+                        doc_id, sg_doc.revid, sg_db, "_default", "_default"
                     )
-            await sg.update_documents(sg_db, sg_docs_to_update, "_default", "_default")
 
-        self.mark_test_step("Verify SDK sees all doc updates")
-        for doc_id in all_doc_ids:
-            sdk_doc = cbs.get_document(bucket_name, doc_id, "_default", "_default")
-            if sdk_doc is not None:
-                assert sdk_doc["content"]["updates"] == num_updates + 1, (
-                    f"SDK doc {doc_id} should have {num_updates + 1} updates, got {sdk_doc['content']['updates']}"
-                )
+            self.mark_test_step("Verify SDK sees all docs as deleted")
+            sdk_deleted_count = 0
+            for doc_id in all_doc_ids:
+                sdk_doc = cbs.get_document(bucket_name, doc_id, "_default", "_default")
+                if sdk_doc is None or len(sdk_doc) == 0:
+                    sdk_deleted_count += 1
+            assert sdk_deleted_count == num_docs * 2, (
+                f"Expected {num_docs * 2} docs to be deleted via SDK, got {sdk_deleted_count}"
+            )
 
-        self.mark_test_step(
-            f"Verify '{username}' sees all doc updates via _all_docs (public API)"
-        )
-        all_docs_updated = await sg_user.get_all_documents(sg_db)
-        for row in all_docs_updated.rows:
-            sg_doc = await sg.get_document(sg_db, row.id, "_default", "_default")
-            if sg_doc is not None:
-                assert sg_doc.body["content"]["updates"] == num_updates + 1, (
-                    f"SG doc {sg_doc.id} should have {num_updates + 1} updates, got {sg_doc.body['content']['updates']}"
-                )
-
-        self.mark_test_step("Verify SDK docs still don't contain _sync after updates")
-        for doc_id in sdk_doc_ids:
-            sdk_doc = cbs.get_document(bucket_name, doc_id, "_default", "_default")
-            assert sdk_doc is not None, f"SDK doc {doc_id} should not be None"
-            assert "_sync" not in sdk_doc, f"SDK doc {doc_id} should not contain _sync"
-
-        self.mark_test_step("Bulk delete sdk docs via SDK")
-        for doc_id in sdk_doc_ids:
-            cbs.delete_document(bucket_name, doc_id, "_default", "_default")
-
-        self.mark_test_step("Bulk delete sg docs via Sync Gateway")
-        for doc_id in sg_doc_ids:
-            sg_doc = await sg.get_document(sg_db, doc_id, "_default", "_default")
-            if sg_doc is not None and sg_doc.revid is not None:
-                await sg.delete_document(
-                    doc_id, sg_doc.revid, sg_db, "_default", "_default"
-                )
-
-        self.mark_test_step("Verify SDK sees all docs as deleted")
-        sdk_deleted_count = 0
-        for doc_id in all_doc_ids:
-            sdk_doc = cbs.get_document(bucket_name, doc_id, "_default", "_default")
-            if sdk_doc is None or len(sdk_doc) == 0:
-                sdk_deleted_count += 1
-        assert sdk_deleted_count == num_docs * 2, (
-            f"Expected {num_docs * 2} docs to be deleted via SDK, got {sdk_deleted_count}"
-        )
-
-        self.mark_test_step(
-            f"Verify '{username}' sees all docs as deleted via _changes (public API)"
-        )
-        changes_deleted = await sg_user.get_changes(sg_db)
-        sg_deleted_count = sum(1 for entry in changes_deleted.results if entry.deleted)
-        assert sg_deleted_count == num_docs * 2, (
-            f"Expected {num_docs * 2} docs to be deleted via SG, got {sg_deleted_count}"
-        )
-
-        await sg_user.close()
+            self.mark_test_step(
+                f"Verify '{username}' sees all docs as deleted via _changes (public API)"
+            )
+            changes_deleted = await sg_user.get_changes(sg_db)
+            sg_deleted_count = sum(
+                1 for entry in changes_deleted.results if entry.deleted
+            )
+            assert sg_deleted_count == num_docs * 2, (
+                f"Expected {num_docs * 2} docs to be deleted via SG, got {sg_deleted_count}"
+            )
 
     @pytest.mark.asyncio(loop_scope="session")
     async def test_sg_sdk_interop_shared_docs(self, cblpytest: CBLPyTest) -> None:
@@ -529,217 +557,226 @@ class TestXattrs(CBLTestClass):
         await sg.put_database(sg_db, db_payload)
 
         self.mark_test_step(f"Create user '{username}' with access to shared channel")
-        sg_user = await sg.create_user_client(sg_db, username, password, ["shared"])
-
-        self.mark_test_step(
-            f"Bulk create {num_docs} docs via SDK with tracking properties"
-        )
-        sdk_doc_ids: list[str] = []
-        for i in range(num_docs):
-            doc_id = f"doc_set_one_{i}"
-            sdk_doc_ids.append(doc_id)
-            doc_body = {
-                "updates": 0,
-                "sg_updates": 0,
-                "sdk_updates": 0,
-                "channels": ["shared"],
-            }
-            cbs.upsert_document(bucket_name, doc_id, doc_body, "_default", "_default")
-
-        self.mark_test_step(
-            f"Bulk create {num_docs} docs via SG with tracking properties"
-        )
-        sg_docs: list[DocumentUpdateEntry] = []
-        sg_doc_ids: list[str] = []
-        for i in range(num_docs):
-            doc_id = f"doc_set_two_{i}"
-            sg_doc_ids.append(doc_id)
-            sg_docs.append(
-                DocumentUpdateEntry(
-                    doc_id,
-                    None,
-                    body={
-                        "updates": 0,
-                        "sg_updates": 0,
-                        "sdk_updates": 0,
-                        "channels": ["shared"],
-                    },
-                )
+        async with sg.create_user_client(
+            sg_db, username, password, ["shared"]
+        ) as sg_user:
+            self.mark_test_step(
+                f"Bulk create {num_docs} docs via SDK with tracking properties"
             )
-        await sg.update_documents(sg_db, sg_docs, "_default", "_default")
-        all_doc_ids = sdk_doc_ids + sg_doc_ids
+            sdk_doc_ids: list[str] = []
+            for i in range(num_docs):
+                doc_id = f"doc_set_one_{i}"
+                sdk_doc_ids.append(doc_id)
+                doc_body = {
+                    "updates": 0,
+                    "sg_updates": 0,
+                    "sdk_updates": 0,
+                    "channels": ["shared"],
+                }
+                cbs.upsert_document(
+                    bucket_name, doc_id, doc_body, "_default", "_default"
+                )
 
-        self.mark_test_step("Verify SDK sees all docs")
-        sdk_visible_count = 0
-        for doc_id in all_doc_ids:
-            sdk_doc = cbs.get_document(bucket_name, doc_id, "_default", "_default")
-            if sdk_doc is not None:
-                sdk_visible_count += 1
-        assert sdk_visible_count == num_docs * 2, (
-            f"Expected {num_docs * 2} docs via SDK, got {sdk_visible_count}"
-        )
+            self.mark_test_step(
+                f"Bulk create {num_docs} docs via SG with tracking properties"
+            )
+            sg_docs: list[DocumentUpdateEntry] = []
+            sg_doc_ids: list[str] = []
+            for i in range(num_docs):
+                doc_id = f"doc_set_two_{i}"
+                sg_doc_ids.append(doc_id)
+                sg_docs.append(
+                    DocumentUpdateEntry(
+                        doc_id,
+                        None,
+                        body={
+                            "updates": 0,
+                            "sg_updates": 0,
+                            "sdk_updates": 0,
+                            "channels": ["shared"],
+                        },
+                    )
+                )
+            await sg.update_documents(sg_db, sg_docs, "_default", "_default")
+            all_doc_ids = sdk_doc_ids + sg_doc_ids
 
-        self.mark_test_step(
-            f"Verify '{username}' sees all docs via _all_docs (public API)"
-        )
-        sg_all_docs = await sg_user.get_all_documents(sg_db)
-        assert len(sg_all_docs.rows) == num_docs * 2, (
-            f"Expected {num_docs * 2} docs, got {len(sg_all_docs.rows)}"
-        )
+            self.mark_test_step("Verify SDK sees all docs")
+            sdk_visible_count = 0
+            for doc_id in all_doc_ids:
+                sdk_doc = cbs.get_document(bucket_name, doc_id, "_default", "_default")
+                if sdk_doc is not None:
+                    sdk_visible_count += 1
+            assert sdk_visible_count == num_docs * 2, (
+                f"Expected {num_docs * 2} docs via SDK, got {sdk_visible_count}"
+            )
 
-        self.mark_test_step(
-            f"Perform concurrent updates ({num_updates} per doc) from SDK and SG"
-        )
+            self.mark_test_step(
+                f"Verify '{username}' sees all docs via _all_docs (public API)"
+            )
+            sg_all_docs = await sg_user.get_all_documents(sg_db)
+            assert len(sg_all_docs.rows) == num_docs * 2, (
+                f"Expected {num_docs * 2} docs, got {len(sg_all_docs.rows)}"
+            )
 
-        async def update_from_sg() -> None:
-            """Update documents from Sync Gateway side with conflict handling"""
-            docs_remaining = list(all_doc_ids)
-            while docs_remaining:
-                doc_id = random.choice(docs_remaining)
-                try:
-                    sg_doc = await sg.get_document(sg_db, doc_id)
-                    if (
-                        sg_doc is None
-                        or sg_doc.body.get("sg_updates", 0) >= num_updates
-                    ):
+            self.mark_test_step(
+                f"Perform concurrent updates ({num_updates} per doc) from SDK and SG"
+            )
+
+            async def update_from_sg() -> None:
+                """Update documents from Sync Gateway side with conflict handling"""
+                docs_remaining = list(all_doc_ids)
+                while docs_remaining:
+                    doc_id = random.choice(docs_remaining)
+                    try:
+                        sg_doc = await sg.get_document(sg_db, doc_id)
+                        if (
+                            sg_doc is None
+                            or sg_doc.body.get("sg_updates", 0) >= num_updates
+                        ):
+                            docs_remaining.remove(doc_id)
+                            continue
+
+                        updated_body = sg_doc.body.copy()
+                        updated_body["sg_updates"] = (
+                            updated_body.get("sg_updates", 0) + 1
+                        )
+                        updated_body["updates"] = updated_body.get("updates", 0) + 1
+                        await sg.update_documents(
+                            sg_db,
+                            [DocumentUpdateEntry(doc_id, sg_doc.revid, updated_body)],
+                        )
+                    except CblSyncGatewayBadResponseError as e:
+                        if e.code == 409:  # Conflict
+                            continue  # Retry
+                        raise
+                    await asyncio.sleep(0.01)  # Small delay to normalize rate
+
+            def update_from_sdk() -> None:
+                """Update documents from SDK side with CAS"""
+                docs_remaining = list(all_doc_ids)
+                while docs_remaining:
+                    doc_id = random.choice(docs_remaining)
+                    sdk_doc = cbs.get_document(bucket_name, doc_id)
+                    if sdk_doc is None or sdk_doc.get("sdk_updates", 0) >= num_updates:
                         docs_remaining.remove(doc_id)
                         continue
 
-                    updated_body = sg_doc.body.copy()
-                    updated_body["sg_updates"] = updated_body.get("sg_updates", 0) + 1
-                    updated_body["updates"] = updated_body.get("updates", 0) + 1
-                    await sg.update_documents(
-                        sg_db,
-                        [DocumentUpdateEntry(doc_id, sg_doc.revid, updated_body)],
-                    )
-                except CblSyncGatewayBadResponseError as e:
-                    if e.code == 409:  # Conflict
-                        continue  # Retry
-                    raise
-                await asyncio.sleep(0.01)  # Small delay to normalize rate
+                    # Ensure no _sync metadata in SDK docs
+                    assert "_sync" not in sdk_doc, f"SDK doc {doc_id} contains _sync"
+                    try:
+                        sdk_doc["sdk_updates"] = sdk_doc.get("sdk_updates", 0) + 1
+                        sdk_doc["updates"] = sdk_doc.get("updates", 0) + 1
+                        cbs.upsert_document(bucket_name, doc_id, sdk_doc)
+                    except Exception:
+                        # CAS mismatch or other error, retry
+                        continue
 
-        def update_from_sdk() -> None:
-            """Update documents from SDK side with CAS"""
-            docs_remaining = list(all_doc_ids)
-            while docs_remaining:
-                doc_id = random.choice(docs_remaining)
+            # Run concurrent updates
+            await asyncio.gather(update_from_sg(), asyncio.to_thread(update_from_sdk))
+
+            self.mark_test_step("Verify all documents have correct update counts")
+            for doc_id in all_doc_ids:
+                # Verify from SDK side
                 sdk_doc = cbs.get_document(bucket_name, doc_id)
-                if sdk_doc is None or sdk_doc.get("sdk_updates", 0) >= num_updates:
-                    docs_remaining.remove(doc_id)
-                    continue
+                assert sdk_doc is not None, f"Doc {doc_id} should exist in SDK"
+                assert (
+                    sdk_doc["updates"] == num_updates * 2
+                    and sdk_doc["sg_updates"] == num_updates
+                    and sdk_doc["sdk_updates"] == num_updates
+                ), (
+                    f"Doc {doc_id} should have {num_updates * 2} total updates via SDK, got {sdk_doc['updates']}, ie, SG: {sdk_doc['sg_updates']}, SDK: {sdk_doc['sdk_updates']}"
+                )
 
-                # Ensure no _sync metadata in SDK docs
-                assert "_sync" not in sdk_doc, f"SDK doc {doc_id} contains _sync"
-                try:
-                    sdk_doc["sdk_updates"] = sdk_doc.get("sdk_updates", 0) + 1
-                    sdk_doc["updates"] = sdk_doc.get("updates", 0) + 1
-                    cbs.upsert_document(bucket_name, doc_id, sdk_doc)
-                except Exception:
-                    # CAS mismatch or other error, retry
-                    continue
+                # Verify from SG side
+                sg_doc = await sg.get_document(sg_db, doc_id)
+                assert sg_doc is not None, f"Doc {doc_id} should exist in SG"
+                assert (
+                    sg_doc.body["updates"] == num_updates * 2
+                    and sg_doc.body["sdk_updates"] == num_updates
+                    and sg_doc.body["sg_updates"] == num_updates
+                ), (
+                    f"Doc {doc_id} should have {num_updates * 2} total updates via SG, got {sg_doc.body['updates']}, ie, SDK: {sg_doc.body['sdk_updates']}, SG: {sg_doc.body['sg_updates']}"
+                )
 
-        # Run concurrent updates
-        await asyncio.gather(update_from_sg(), asyncio.to_thread(update_from_sdk))
+            self.mark_test_step("Perform concurrent deletes from SDK and SG")
 
-        self.mark_test_step("Verify all documents have correct update counts")
-        for doc_id in all_doc_ids:
-            # Verify from SDK side
-            sdk_doc = cbs.get_document(bucket_name, doc_id)
-            assert sdk_doc is not None, f"Doc {doc_id} should exist in SDK"
-            assert (
-                sdk_doc["updates"] == num_updates * 2
-                and sdk_doc["sg_updates"] == num_updates
-                and sdk_doc["sdk_updates"] == num_updates
-            ), (
-                f"Doc {doc_id} should have {num_updates * 2} total updates via SDK, got {sdk_doc['updates']}, ie, SG: {sdk_doc['sg_updates']}, SDK: {sdk_doc['sdk_updates']}"
-            )
+            async def delete_from_sg() -> int:
+                """Delete documents from Sync Gateway with conflict handling"""
+                deleted_count = 0
+                docs_to_delete = list(all_doc_ids)
 
-            # Verify from SG side
-            sg_doc = await sg.get_document(sg_db, doc_id)
-            assert sg_doc is not None, f"Doc {doc_id} should exist in SG"
-            assert (
-                sg_doc.body["updates"] == num_updates * 2
-                and sg_doc.body["sdk_updates"] == num_updates
-                and sg_doc.body["sg_updates"] == num_updates
-            ), (
-                f"Doc {doc_id} should have {num_updates * 2} total updates via SG, got {sg_doc.body['updates']}, ie, SDK: {sg_doc.body['sdk_updates']}, SG: {sg_doc.body['sg_updates']}"
-            )
+                while docs_to_delete:
+                    doc_id = random.choice(docs_to_delete)
+                    try:
+                        sg_doc = await sg.get_document(sg_db, doc_id)
+                        if sg_doc is None:
+                            docs_to_delete.remove(doc_id)
+                            continue
 
-        self.mark_test_step("Perform concurrent deletes from SDK and SG")
-
-        async def delete_from_sg() -> int:
-            """Delete documents from Sync Gateway with conflict handling"""
-            deleted_count = 0
-            docs_to_delete = list(all_doc_ids)
-
-            while docs_to_delete:
-                doc_id = random.choice(docs_to_delete)
-                try:
-                    sg_doc = await sg.get_document(sg_db, doc_id)
-                    if sg_doc is None:
+                        if sg_doc.revid is not None:
+                            await sg.delete_document(doc_id, sg_doc.revid, sg_db)
+                            deleted_count += 1
                         docs_to_delete.remove(doc_id)
-                        continue
+                    except CblSyncGatewayBadResponseError as e:
+                        if e.code in [
+                            403,
+                            404,
+                            409,
+                        ]:  # Forbidden, Not Found, or Conflict
+                            docs_to_delete.remove(doc_id)
+                            continue
+                        raise
+                    await asyncio.sleep(0.01)
+                return deleted_count
 
-                    if sg_doc.revid is not None:
-                        await sg.delete_document(doc_id, sg_doc.revid, sg_db)
+            async def delete_from_sdk() -> int:
+                """Delete documents from SDK"""
+                deleted_count = 0
+                docs_to_delete = list(all_doc_ids)
+                while docs_to_delete:
+                    doc_id = random.choice(docs_to_delete)
+                    try:
+                        cbs.delete_document(bucket_name, doc_id)
                         deleted_count += 1
-                    docs_to_delete.remove(doc_id)
-                except CblSyncGatewayBadResponseError as e:
-                    if e.code in [403, 404, 409]:  # Forbidden, Not Found, or Conflict
+                        docs_to_delete.remove(doc_id)
+                    except Exception:
+                        # Document not found, must have been deleted by SG
                         docs_to_delete.remove(doc_id)
                         continue
-                    raise
-                await asyncio.sleep(0.01)
-            return deleted_count
+                    await asyncio.sleep(0.01)
+                return deleted_count
 
-        async def delete_from_sdk() -> int:
-            """Delete documents from SDK"""
-            deleted_count = 0
-            docs_to_delete = list(all_doc_ids)
-            while docs_to_delete:
-                doc_id = random.choice(docs_to_delete)
-                try:
-                    cbs.delete_document(bucket_name, doc_id)
-                    deleted_count += 1
-                    docs_to_delete.remove(doc_id)
-                except Exception:
-                    # Document not found, must have been deleted by SG
-                    docs_to_delete.remove(doc_id)
-                    continue
-                await asyncio.sleep(0.01)
-            return deleted_count
+            sg_deleted, sdk_deleted = await asyncio.gather(
+                delete_from_sg(), delete_from_sdk()
+            )
 
-        sg_deleted, sdk_deleted = await asyncio.gather(
-            delete_from_sg(), delete_from_sdk()
-        )
+            assert sg_deleted > 0, (
+                f"SG should have deleted at least some documents, got {sg_deleted}"
+            )
+            assert sdk_deleted > 0, (
+                f"SDK should have deleted at least some documents, got {sdk_deleted}"
+            )
 
-        assert sg_deleted > 0, (
-            f"SG should have deleted at least some documents, got {sg_deleted}"
-        )
-        assert sdk_deleted > 0, (
-            f"SDK should have deleted at least some documents, got {sdk_deleted}"
-        )
+            self.mark_test_step("Verify all docs deleted from SDK side")
+            sdk_deleted_count = 0
+            for doc_id in all_doc_ids:
+                sdk_doc = cbs.get_document(bucket_name, doc_id)
+                if sdk_doc is None or len(sdk_doc) == 0:
+                    sdk_deleted_count += 1
+            assert sdk_deleted_count == num_docs * 2, (
+                f"Expected {num_docs * 2} docs deleted via SDK, got {sdk_deleted_count}"
+            )
 
-        self.mark_test_step("Verify all docs deleted from SDK side")
-        sdk_deleted_count = 0
-        for doc_id in all_doc_ids:
-            sdk_doc = cbs.get_document(bucket_name, doc_id)
-            if sdk_doc is None or len(sdk_doc) == 0:
-                sdk_deleted_count += 1
-        assert sdk_deleted_count == num_docs * 2, (
-            f"Expected {num_docs * 2} docs deleted via SDK, got {sdk_deleted_count}"
-        )
-
-        self.mark_test_step(
-            f"Verify '{username}' sees all docs as deleted via _changes (public API)"
-        )
-        changes_deleted = await sg_user.get_changes(sg_db)
-        sg_deleted_count = sum(1 for entry in changes_deleted.results if entry.deleted)
-        assert sg_deleted_count == num_docs * 2, (
-            f"Expected {num_docs * 2} docs deleted via SG, got {sg_deleted_count}"
-        )
-
-        await sg_user.close()
+            self.mark_test_step(
+                f"Verify '{username}' sees all docs as deleted via _changes (public API)"
+            )
+            changes_deleted = await sg_user.get_changes(sg_db)
+            sg_deleted_count = sum(
+                1 for entry in changes_deleted.results if entry.deleted
+            )
+            assert sg_deleted_count == num_docs * 2, (
+                f"Expected {num_docs * 2} docs deleted via SG, got {sg_deleted_count}"
+            )
 
     @pytest.mark.asyncio(loop_scope="session")
     async def test_sync_xattrs_update_concurrently(self, cblpytest: CBLPyTest) -> None:
@@ -788,110 +825,114 @@ class TestXattrs(CBLTestClass):
         self.mark_test_step(
             f"Create users '{username1}', '{username2}' with access to '{sg_channel1}', '{sg_channel2}'"
         )
-        sg_user1 = await sg.create_user_client(
-            sg_db, username1, password, [sg_channel1]
-        )
-        sg_user2 = await sg.create_user_client(
-            sg_db, username2, password, [sg_channel2]
-        )
-
-        self.mark_test_step(
-            f"Create {num_docs} docs via SDK with xattr '{user_custom_channel_xattr}={sg_channel1}'"
-        )
-        sdk_doc_ids: list[str] = []
-        for i in range(num_docs):
-            doc_id = f"sdk_{i}"
-            sdk_doc_ids.append(doc_id)
-            doc_body = {
-                "type": "sdk_doc",
-                "index": i,
-            }
-            cbs.upsert_document(bucket_name, doc_id, doc_body, "_default", "_default")
-            cbs.upsert_document_xattr(
-                bucket_name,
-                doc_id,
-                user_custom_channel_xattr,
-                sg_channel1,
-                "_default",
-                "_default",
+        async with (
+            sg.create_user_client(
+                sg_db, username1, password, [sg_channel1]
+            ) as sg_user1,
+            sg.create_user_client(
+                sg_db, username2, password, [sg_channel2]
+            ) as sg_user2,
+        ):
+            self.mark_test_step(
+                f"Create {num_docs} docs via SDK with xattr '{user_custom_channel_xattr}={sg_channel1}'"
             )
-
-        self.mark_test_step("Wait for SG to import all docs (as admin)")
-        sg_all_docs = await sg.wait_for_all_documents(sg_db, num_docs)
-        assert len(sg_all_docs.rows) >= num_docs, (
-            f"Expected at least {num_docs} docs to be imported, got {len(sg_all_docs.rows)}"
-        )
-
-        self.mark_test_step(
-            f"Verify user '{username1}' can see all docs in channel '{sg_channel1}'"
-        )
-        await asyncio.sleep(10)
-        user1_changes = await sg_user1.get_changes(sg_db)
-        unique_user1_docs = {e.id for e in user1_changes.results if e.id in sdk_doc_ids}
-        user1_doc_count = len(unique_user1_docs)
-        assert user1_doc_count == num_docs, (
-            f"User '{username1}' should see {num_docs} docs in channel '{sg_channel1}', got {user1_doc_count}"
-        )
-
-        self.mark_test_step(
-            f"Concurrently update xattrs to '{sg_channel2}' while querying docs"
-        )
-
-        async def update_xattrs_and_docs() -> None:
-            """Update xattrs to change channel assignment, then trigger import"""
-            for doc_id in sdk_doc_ids:
+            sdk_doc_ids: list[str] = []
+            for i in range(num_docs):
+                doc_id = f"sdk_{i}"
+                sdk_doc_ids.append(doc_id)
+                doc_body = {
+                    "type": "sdk_doc",
+                    "index": i,
+                }
+                cbs.upsert_document(
+                    bucket_name, doc_id, doc_body, "_default", "_default"
+                )
                 cbs.upsert_document_xattr(
                     bucket_name,
                     doc_id,
                     user_custom_channel_xattr,
-                    sg_channel2,
+                    sg_channel1,
                     "_default",
                     "_default",
                 )
 
-        async def query_as_user2() -> None:
-            """Repeatedly query as user2 to trigger sync function processing"""
-            for _ in range(20):
-                await sg_user2.get_changes(sg_db)
-                await asyncio.sleep(0.1)
-
-        await asyncio.gather(update_xattrs_and_docs(), query_as_user2())
-
-        self.mark_test_step("Delete _sync xattrs to force complete re-processing")
-        for doc_id in sdk_doc_ids:
-            cbs.delete_document_xattr(
-                bucket_name, doc_id, "_sync", "_default", "_default"
+            self.mark_test_step("Wait for SG to import all docs (as admin)")
+            sg_all_docs = await sg.wait_for_all_documents(sg_db, num_docs)
+            assert len(sg_all_docs.rows) >= num_docs, (
+                f"Expected at least {num_docs} docs to be imported, got {len(sg_all_docs.rows)}"
             )
 
-        self.mark_test_step(
-            "Restart Sync Gateway to force re-import with updated xattrs"
-        )
-        await sg.delete_database(sg_db)
-        await sg.put_database(sg_db, db_payload)
+            self.mark_test_step(
+                f"Verify user '{username1}' can see all docs in channel '{sg_channel1}'"
+            )
+            await asyncio.sleep(10)
+            user1_changes = await sg_user1.get_changes(sg_db)
+            unique_user1_docs = {
+                e.id for e in user1_changes.results if e.id in sdk_doc_ids
+            }
+            user1_doc_count = len(unique_user1_docs)
+            assert user1_doc_count == num_docs, (
+                f"User '{username1}' should see {num_docs} docs in channel '{sg_channel1}', got {user1_doc_count}"
+            )
 
-        # Recreate users after database restart
-        await sg.create_user_client(sg_db, username1, password, [sg_channel1])
-        await sg.create_user_client(sg_db, username2, password, [sg_channel2])
+            self.mark_test_step(
+                f"Concurrently update xattrs to '{sg_channel2}' while querying docs"
+            )
 
-        self.mark_test_step(f"Verify user '{username2}' can now see all docs")
-        user2_changes = await sg_user2.get_changes(sg_db)
-        unique_user2_docs = {e.id for e in user2_changes.results if e.id in sdk_doc_ids}
-        user2_count = len(unique_user2_docs)
-        assert user2_count == num_docs, (
-            f"User '{username2}' should see {num_docs} docs after xattr change to channel '{sg_channel2}', "
-            f"got {user2_count}"
-        )
+            async def update_xattrs_and_docs() -> None:
+                """Update xattrs to change channel assignment, then trigger import"""
+                for doc_id in sdk_doc_ids:
+                    cbs.upsert_document_xattr(
+                        bucket_name,
+                        doc_id,
+                        user_custom_channel_xattr,
+                        sg_channel2,
+                        "_default",
+                        "_default",
+                    )
 
-        self.mark_test_step(f"Verify user '{username1}' can no longer see any docs")
-        user1_changes_after = await sg_user1.get_changes(sg_db)
-        unique_user1_after = {
-            e.id for e in user1_changes_after.results if e.id in sdk_doc_ids
-        }
-        user1_count_after = len(unique_user1_after)
-        assert user1_count_after == 0, (
-            f"User '{username1}' should see 0 docs after xattr change to channel '{sg_channel2}', "
-            f"got {user1_count_after}"
-        )
+            async def query_as_user2() -> None:
+                """Repeatedly query as user2 to trigger sync function processing"""
+                for _ in range(20):
+                    await sg_user2.get_changes(sg_db)
+                    await asyncio.sleep(0.1)
 
-        await sg_user1.close()
-        await sg_user2.close()
+            await asyncio.gather(update_xattrs_and_docs(), query_as_user2())
+
+            self.mark_test_step("Delete _sync xattrs to force complete re-processing")
+            for doc_id in sdk_doc_ids:
+                cbs.delete_document_xattr(
+                    bucket_name, doc_id, "_sync", "_default", "_default"
+                )
+
+            self.mark_test_step(
+                "Restart Sync Gateway to force re-import with updated xattrs"
+            )
+            await sg.delete_database(sg_db)
+            await sg.put_database(sg_db, db_payload)
+
+            # Recreate users after database restart
+            await sg.reset_user(sg_db, username1, password, [sg_channel1])
+            await sg.reset_user(sg_db, username2, password, [sg_channel2])
+
+            self.mark_test_step(f"Verify user '{username2}' can now see all docs")
+            user2_changes = await sg_user2.get_changes(sg_db)
+            unique_user2_docs = {
+                e.id for e in user2_changes.results if e.id in sdk_doc_ids
+            }
+            user2_count = len(unique_user2_docs)
+            assert user2_count == num_docs, (
+                f"User '{username2}' should see {num_docs} docs after xattr change to channel '{sg_channel2}', "
+                f"got {user2_count}"
+            )
+
+            self.mark_test_step(f"Verify user '{username1}' can no longer see any docs")
+            user1_changes_after = await sg_user1.get_changes(sg_db)
+            unique_user1_after = {
+                e.id for e in user1_changes_after.results if e.id in sdk_doc_ids
+            }
+            user1_count_after = len(unique_user1_after)
+            assert user1_count_after == 0, (
+                f"User '{username1}' should see 0 docs after xattr change to channel '{sg_channel2}', "
+                f"got {user1_count_after}"
+            )


### PR DESCRIPTION
Turn SyncGatewayUserClient into a context manager so that an explicit close is not required.

When reviewing, make sure to turn whitespace changes off.