### PR TITLE
Combined run for all SGW tests - backend

### DIFF
--- a/jenkins/pipelines/QE/sgw/Jenkinsfile
+++ b/jenkins/pipelines/QE/sgw/Jenkinsfile
@@ -24,7 +24,7 @@ pipeline {
             steps {
                 build job: 'prebuild-test-server',
                 parameters: [
-                    string(name: 'TS_PLATFORM', value: 'swift_ios'),
+                    string(name: 'TS_PLATFORM', value: 'c_macos'),
                     string(name: 'CBL_VERSION', value: env.CBL_VERSION),
                 ],
                 wait: true,
@@ -54,8 +54,8 @@ pipeline {
                     // surfaced in Jenkins even if teardown fails.
                     script {
                         try {
-                            junit testResults: 'tests/QE/junit_result.xml', allowEmptyResults: true
-                            archiveArtifacts artifacts: 'tests/QE/junit_result.xml', fingerprint: true, allowEmptyArchive: true
+                            junit testResults: 'tests/junit_result.xml', allowEmptyResults: true
+                            archiveArtifacts artifacts: 'tests/junit_result.xml', fingerprint: true, allowEmptyArchive: true
                         } catch (err) {
                             echo "WARNING: Failed to publish/archive JUnit XML: ${err}"
                         }
@@ -66,8 +66,9 @@ pipeline {
                         sh "jenkins/pipelines/QE/sgw/teardown.sh"
                     }
                     // Archived after teardown because teardown's move_artifacts
-                    // is what populates tests/QE/sgw/.
-                    archiveArtifacts artifacts: 'tests/QE/sgw/**/*', fingerprint: true, allowEmptyArchive: true
+                    // is what populates tests/sgw/ (the whole tests/ tree runs
+                    // in one session, so artifacts live at the tests/ root).
+                    archiveArtifacts artifacts: 'tests/sgw/**/*', fingerprint: true, allowEmptyArchive: true
                     echo "=== SGW Test Teardown Complete"
                 }
             }

--- a/jenkins/pipelines/QE/sgw/Jenkinsfile
+++ b/jenkins/pipelines/QE/sgw/Jenkinsfile
@@ -54,8 +54,8 @@ pipeline {
                     // surfaced in Jenkins even if teardown fails.
                     script {
                         try {
-                            junit testResults: 'tests/junit_result.xml', allowEmptyResults: true
-                            archiveArtifacts artifacts: 'tests/junit_result.xml', fingerprint: true, allowEmptyArchive: true
+                            junit testResults: '*/junit_result.xml', allowEmptyResults: true
+                            archiveArtifacts artifacts: '*/junit_result.xml', fingerprint: true, allowEmptyArchive: true
                         } catch (err) {
                             echo "WARNING: Failed to publish/archive JUnit XML: ${err}"
                         }

--- a/jenkins/pipelines/QE/sgw/teardown.sh
+++ b/jenkins/pipelines/QE/sgw/teardown.sh
@@ -7,7 +7,11 @@ source $SCRIPT_DIR/../../shared/config.sh
 
 export PYTHONPATH=$SCRIPT_DIR/../../../
 pushd $AWS_ENVIRONMENT_DIR
-move_artifacts
+# The tests now run from the tests/ root (both QE and dev_e2e in one session),
+# so session.log / http_log / junit_result.xml land in $TESTS_DIR, not
+# $QE_TESTS_DIR. Pass the source dir explicitly instead of letting
+# move_artifacts infer QE vs dev_e2e from the caller path.
+move_artifacts "$TESTS_DIR"
 
 uv run ./stop_backend.py --topology topology_setup/topology.json
 popd

--- a/jenkins/pipelines/QE/sgw/test.sh
+++ b/jenkins/pipelines/QE/sgw/test.sh
@@ -27,11 +27,11 @@ for arg in "$@"; do
 done
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-source $SCRIPT_DIR/../../shared/config.sh
+source "$SCRIPT_DIR"/../../shared/config.sh
 
 echo "Setup backend..."
-pushd $AWS_ENVIRONMENT_DIR > /dev/null
-uv run $SCRIPT_DIR/setup_test.py $CBL_VERSION $SGW_VERSION
+pushd "$AWS_ENVIRONMENT_DIR" > /dev/null
+uv run "$SCRIPT_DIR"/setup_test.py "$CBL_VERSION" "$SGW_VERSION"
 popd > /dev/null
 
 # Exit early if setup-only mode
@@ -57,7 +57,7 @@ fi
 # and tests/QE/test_multipeer.py share a basename and would otherwise collide
 # at import time (pytest imports every collected module before -m deselection).
 echo "Run tests..."
-pushd $TESTS_DIR > /dev/null
+pushd "$TESTS_DIR" > /dev/null
 uv run pytest -v --no-header -W ignore::DeprecationWarning \
     --config QE/config.json \
     --import-mode=importlib \
@@ -65,4 +65,5 @@ uv run pytest -v --no-header -W ignore::DeprecationWarning \
     --ignore=QE/edge_server \
     --ignore=dev_e2e/edge_server \
     --ignore=dev_e2e/test_replication_xdcr.py \
-    --sgcollect-on-test-failure
+    --sgcollect-on-test-failure \
+    dev_e2e QE

--- a/jenkins/pipelines/QE/sgw/test.sh
+++ b/jenkins/pipelines/QE/sgw/test.sh
@@ -40,30 +40,17 @@ if [ "$SETUP_ONLY" = true ]; then
     exit 0
 fi
 
-# Run Tests :
-# Run the whole tests/ tree (both QE and dev_e2e) in a single session and let
-# markers pick the SGW-relevant tests:
-#   * "sgw"  -> QE tests already tagged for Sync Gateway.
-#   * "nightly" -> every dev_e2e test (auto-tagged in tests/dev_e2e/conftest.py).
-#   * "and min_sync_gateways" -> drop tests that never touch SGW (e.g. the
-#     P2P-only tests/dev_e2e/test_multipeer.py, which has no min_sync_gateways).
-# The edge_server sub-suites are out of scope for the nightly SGW run, so they
-# are excluded explicitly rather than by marker.
 # test_replication_xdcr.py needs two separate Couchbase Server clusters, which
 # this single-cluster topology does not provide; it is deferred until the
-# multi-cluster topology is sorted out (tracked separately) rather than left to
-# fail every night.
+# multi-cluster topology is sorted out rather than left to fail every night.
+
 # --import-mode=importlib is required because tests/dev_e2e/test_multipeer.py
 # and tests/QE/test_multipeer.py share a basename and would otherwise collide
-# at import time (pytest imports every collected module before -m deselection).
+# at import time can be removed after: https://jira.issues.couchbase.com/browse/CBL-8685.
 echo "Run tests..."
 pushd "$TESTS_DIR" > /dev/null
-uv run pytest -v --no-header \
+uv run pytest -v --no-header -m sgw \
     --config QE/config.json \
     --import-mode=importlib \
-    -m "(sgw or nightly) and min_sync_gateways" \
-    --ignore=QE/edge_server \
-    --ignore=dev_e2e/edge_server \
     --ignore=dev_e2e/test_replication_xdcr.py \
-    --sgcollect-on-test-failure \
-    dev_e2e QE
+    --sgcollect-on-test-failure

--- a/jenkins/pipelines/QE/sgw/test.sh
+++ b/jenkins/pipelines/QE/sgw/test.sh
@@ -44,13 +44,13 @@ fi
 # this single-cluster topology does not provide; it is deferred until the
 # multi-cluster topology is sorted out rather than left to fail every night.
 
-# --import-mode=importlib is required because tests/dev_e2e/test_multipeer.py
-# and tests/QE/test_multipeer.py share a basename and would otherwise collide
-# at import time can be removed after: https://jira.issues.couchbase.com/browse/CBL-8685.
+# --import-mode=importlib AND --ignore=dev_e2e/edge_server is required because
+# tests/dev_e2e/test_multipeer.py and tests/QE/test_multipeer.py share
+# a basename and would otherwise collide at import time can be removed after:
+# https://jira.issues.couchbase.com/browse/CBL-8685.
 echo "Run tests..."
 pushd "$TESTS_DIR" > /dev/null
-uv run pytest -v --no-header -m sgw \
-    --config QE/config.json \
-    --import-mode=importlib \
+uv run pytest -v --no-header --config QE/config.json \
+    --import-mode=importlib --ignore=dev_e2e/edge_server \
     --ignore=dev_e2e/test_replication_xdcr.py \
     --sgcollect-on-test-failure

--- a/jenkins/pipelines/QE/sgw/test.sh
+++ b/jenkins/pipelines/QE/sgw/test.sh
@@ -41,7 +41,28 @@ if [ "$SETUP_ONLY" = true ]; then
 fi
 
 # Run Tests :
+# Run the whole tests/ tree (both QE and dev_e2e) in a single session and let
+# markers pick the SGW-relevant tests:
+#   * "sgw"  -> QE tests already tagged for Sync Gateway.
+#   * "nightly" -> every dev_e2e test (auto-tagged in tests/dev_e2e/conftest.py).
+#   * "and min_sync_gateways" -> drop tests that never touch SGW (e.g. the
+#     P2P-only tests/dev_e2e/test_multipeer.py, which has no min_sync_gateways).
+# The edge_server sub-suites are out of scope for the nightly SGW run, so they
+# are excluded explicitly rather than by marker.
+# test_replication_xdcr.py needs two separate Couchbase Server clusters, which
+# this single-cluster topology does not provide; it is deferred until the
+# multi-cluster topology is sorted out (tracked separately) rather than left to
+# fail every night.
+# --import-mode=importlib is required because tests/dev_e2e/test_multipeer.py
+# and tests/QE/test_multipeer.py share a basename and would otherwise collide
+# at import time (pytest imports every collected module before -m deselection).
 echo "Run tests..."
-pushd $QE_TESTS_DIR > /dev/null
-uv run pytest -v --no-header -W ignore::DeprecationWarning --config config.json -m sgw \
+pushd $TESTS_DIR > /dev/null
+uv run pytest -v --no-header -W ignore::DeprecationWarning \
+    --config QE/config.json \
+    --import-mode=importlib \
+    -m "(sgw or nightly) and min_sync_gateways" \
+    --ignore=QE/edge_server \
+    --ignore=dev_e2e/edge_server \
+    --ignore=dev_e2e/test_replication_xdcr.py \
     --sgcollect-on-test-failure

--- a/jenkins/pipelines/QE/sgw/test.sh
+++ b/jenkins/pipelines/QE/sgw/test.sh
@@ -58,7 +58,7 @@ fi
 # at import time (pytest imports every collected module before -m deselection).
 echo "Run tests..."
 pushd "$TESTS_DIR" > /dev/null
-uv run pytest -v --no-header -W ignore::DeprecationWarning \
+uv run pytest -v --no-header \
     --config QE/config.json \
     --import-mode=importlib \
     -m "(sgw or nightly) and min_sync_gateways" \

--- a/jenkins/pipelines/QE/sgw/topology.json
+++ b/jenkins/pipelines/QE/sgw/topology.json
@@ -2,10 +2,9 @@
     "$schema": "../../../../environment/aws/topology_setup/topology_schema.json",
     "test_servers": [
 		{
-			"platform": "swift_ios",
+			"platform": "c_macos",
 			"cbl_version": "{{version}}",
-			"location": "00008101-000E0519020A001E",
-			"ip_hint": "10.100.150.115",
+			"location": "localhost",
 			"download": true
 		}
 	],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,11 @@ root = [".", "client/src", "tests"]
 
 [tool.pytest.ini_options]
 asyncio_default_fixture_loop_scope = "session"
-pythonpath = ["tests"]
+# "tests" puts tests/shared on the path; "tests/dev_e2e" keeps the bare
+# sibling import in test_replication_filter.py (from test_replication_filter_data
+# import ...) working under --import-mode=importlib, which the nightly SGW job
+# uses so the two test_multipeer.py modules don't collide at collection.
+pythonpath = ["tests", "tests/dev_e2e"]
 filterwarnings = [
   "ignore:Class property max_ttl is deprecated.*:couchbase.logic.supportability.CouchbaseDeprecationWarning",
 ]
@@ -65,4 +69,5 @@ markers = [
   "sgw: tests that focus on Sync Gateway functionality",
   "upg_sgw: tests that focus on Sync Gateway upgrade scenario",
   "cbl: tests that focus on Couchbase Lite functionality",
+  "nightly: tests run by the nightly SGW job (auto-applied to all tests/dev_e2e tests via tests/dev_e2e/conftest.py)",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,5 +69,4 @@ markers = [
   "sgw: tests that focus on Sync Gateway functionality",
   "upg_sgw: tests that focus on Sync Gateway upgrade scenario",
   "cbl: tests that focus on Couchbase Lite functionality",
-  "nightly: tests run by the nightly SGW job (auto-applied to all tests/dev_e2e tests via tests/dev_e2e/conftest.py)",
 ]

--- a/tests/QE/edge_server/test_blobs.py
+++ b/tests/QE/edge_server/test_blobs.py
@@ -11,6 +11,8 @@ from cbltest.asyncfile import read_binary_file, read_json_file, write_json_file
 SCRIPT_DIR = str(Path(__file__).parent)
 
 
+@pytest.mark.min_sync_gateways(1)
+@pytest.mark.min_couchbase_servers(1)
 @pytest.mark.min_edge_servers(1)
 class TestBlobs(CBLTestClass):
     @pytest.mark.asyncio(loop_scope="session")

--- a/tests/QE/edge_server/test_changes_feed.py
+++ b/tests/QE/edge_server/test_changes_feed.py
@@ -10,6 +10,8 @@ from cbltest.asyncfile import read_json_file, write_json_file
 SCRIPT_DIR = str(Path(__file__).parent)
 
 
+@pytest.mark.min_sync_gateways(1)
+@pytest.mark.min_couchbase_servers(1)
 @pytest.mark.min_edge_servers(1)
 class TestChangesFeed(CBLTestClass):
     @pytest.mark.asyncio(loop_scope="session")

--- a/tests/QE/edge_server/test_chaos_scenarios.py
+++ b/tests/QE/edge_server/test_chaos_scenarios.py
@@ -12,6 +12,7 @@ SCRIPT_DIR = str(Path(__file__).parent)
 
 
 @pytest.mark.min_edge_servers(1)
+@pytest.mark.min_sync_gateways(1)
 class TestEdgeServerChaos(CBLTestClass):
     @pytest.mark.asyncio(loop_scope="session")
     async def test_kill_sgw_mid_replication(self, cblpytest, dataset_path) -> None:

--- a/tests/QE/edge_server/test_logging.py
+++ b/tests/QE/edge_server/test_logging.py
@@ -71,6 +71,8 @@ AUDIT_CONFIG_APPLIERS: dict[str, Callable[[dict], None]] = {
 }
 
 
+@pytest.mark.min_sync_gateways(1)
+@pytest.mark.min_couchbase_servers(1)
 @pytest.mark.min_edge_servers(1)
 class TestLogging(CBLTestClass):
     @pytest.mark.asyncio(loop_scope="session")

--- a/tests/QE/edge_server/test_replication_edge_server.py
+++ b/tests/QE/edge_server/test_replication_edge_server.py
@@ -10,6 +10,7 @@ SCRIPT_DIR = str(Path(__file__).parent)
 
 
 @pytest.mark.min_edge_servers(1)
+@pytest.mark.min_sync_gateways(1)
 class TestEdgeServerSync(CBLTestClass):
     @pytest.mark.asyncio(loop_scope="session")
     async def test_edge_to_sgw_replication(

--- a/tests/QE/edge_server/test_replication_sanity.py
+++ b/tests/QE/edge_server/test_replication_sanity.py
@@ -15,6 +15,8 @@ from cbltest.asyncfile import read_json_file, write_json_file
 SCRIPT_DIR = str(Path(__file__).parent)
 
 
+@pytest.mark.min_sync_gateways(1)
+@pytest.mark.min_couchbase_servers(1)
 @pytest.mark.min_edge_servers(1)
 class TestReplicationSanity(CBLTestClass):
     @pytest.mark.asyncio(loop_scope="session")

--- a/tests/QE/edge_server/test_system.py
+++ b/tests/QE/edge_server/test_system.py
@@ -33,6 +33,8 @@ def _updated_doc_body(doc_id: str) -> dict[str, Any]:
 
 
 @pytest.mark.min_edge_servers(1)
+@pytest.mark.min_sync_gateways(1)
+@pytest.mark.min_couchbase_servers(1)
 class TestSystem(CBLTestClass):
     async def _setup_system_test(self, cblpytest: CBLPyTest):
         """Create bucket, 10 docs, Sync Gateway db, Edge Server db; verify 10 docs on both.

--- a/tests/QE/test_delta_sync.py
+++ b/tests/QE/test_delta_sync.py
@@ -21,6 +21,8 @@ from cbltest.api.test_functions import compare_local_and_remote
 
 
 @pytest.mark.cbl
+@pytest.mark.min_test_servers(1)
+@pytest.mark.min_sync_gateways(1)
 class TestDeltaSync(CBLTestClass):
     @pytest.mark.asyncio(loop_scope="session")
     async def test_delta_sync_replication(

--- a/tests/QE/test_multiple_servers.py
+++ b/tests/QE/test_multiple_servers.py
@@ -326,7 +326,7 @@ class TestISGRCollectionMapping(CBLTestClass):
     ) -> None:
         sg_cluster = SyncGatewayCluster(cblpytest.sync_gateways)
         cbs = cblpytest.couchbase_servers[0]
-        sg1, sg2, sg3 = sg_cluster.sync_gateways[:2]
+        sg1, sg2, sg3 = sg_cluster.sync_gateways[:3]
         bucket1, bucket2, bucket3 = "isgr-bucket1", "isgr-bucket2", "isgr-bucket3"
         sg_db1, sg_db2, sg_db3 = "db1", "db2", "db3"
         b1_collections = ["collection1", "collection2", "collection3"]

--- a/tests/QE/test_rolling_upgrade_sgw.py
+++ b/tests/QE/test_rolling_upgrade_sgw.py
@@ -38,6 +38,7 @@ SGW_CONFIG = {
 
 
 @pytest.mark.upg_sgw
+@pytest.mark.min_test_servers(1)
 @pytest.mark.min_sync_gateways(3)
 @pytest.mark.min_couchbase_servers(1)
 class TestSgwRollingUpgrade(CBLTestClass):

--- a/tests/QE/test_upg_sgw.py
+++ b/tests/QE/test_upg_sgw.py
@@ -15,6 +15,7 @@ from cbltest.api.syncgateway import DocumentUpdateEntry, PutDatabasePayload
 
 
 @pytest.mark.upg_sgw
+@pytest.mark.min_test_servers(1)
 @pytest.mark.min_sync_gateways(1)
 @pytest.mark.min_couchbase_servers(1)
 class TestSgwUpgrade(CBLTestClass):

--- a/tests/dev_e2e/conftest.py
+++ b/tests/dev_e2e/conftest.py
@@ -4,6 +4,25 @@ from pathlib import Path
 import pytest
 from cbltest.utils import verify_lfs_checkout
 
+_THIS_DIR = Path(__file__).resolve().parent
+
+
+# Auto-tag every test under tests/dev_e2e with the `nightly` marker so the
+# nightly SGW job can select them with `-m "(sgw or nightly) and
+# min_sync_gateways"` without touching each test file. The `and
+# min_sync_gateways` half of that expression is what excludes the P2P-only
+# tests here (e.g. test_multipeer.py), which never talk to Sync Gateway.
+#
+# This hook is registered by every conftest in the collection tree, so it must
+# only mark the items that live under *this* directory — otherwise a combined
+# `tests/`-level run would also tag the QE suite.
+def pytest_collection_modifyitems(
+    config: pytest.Config, items: list[pytest.Item]
+) -> None:
+    for item in items:
+        if _THIS_DIR in Path(str(item.fspath)).resolve().parents:
+            item.add_marker(pytest.mark.nightly)
+
 
 # This is used to inject the full path to the dataset folder
 # into tests that need it.

--- a/tests/dev_e2e/conftest.py
+++ b/tests/dev_e2e/conftest.py
@@ -4,25 +4,6 @@ from pathlib import Path
 import pytest
 from cbltest.utils import verify_lfs_checkout
 
-_THIS_DIR = Path(__file__).resolve().parent
-
-
-# Auto-tag every test under tests/dev_e2e with the `nightly` marker so the
-# nightly SGW job can select them with `-m "(sgw or nightly) and
-# min_sync_gateways"` without touching each test file. The `and
-# min_sync_gateways` half of that expression is what excludes the P2P-only
-# tests here (e.g. test_multipeer.py), which never talk to Sync Gateway.
-#
-# This hook is registered by every conftest in the collection tree, so it must
-# only mark the items that live under *this* directory — otherwise a combined
-# `tests/`-level run would also tag the QE suite.
-def pytest_collection_modifyitems(
-    config: pytest.Config, items: list[pytest.Item]
-) -> None:
-    for item in items:
-        if _THIS_DIR in Path(str(item.fspath)).resolve().parents:
-            item.add_marker(pytest.mark.nightly)
-
 
 # This is used to inject the full path to the dataset folder
 # into tests that need it.

--- a/tests/dev_e2e/edge_server/test_jwt_rotation.py
+++ b/tests/dev_e2e/edge_server/test_jwt_rotation.py
@@ -14,6 +14,9 @@ SCRIPT_DIR = str(Path(__file__).parent)
 JWT_FILE = "/home/ec2-user/cert/jwt.txt"
 
 
+@pytest.mark.min_edge_servers(1)
+@pytest.mark.min_sync_gateways(1)
+@pytest.mark.min_couchbase_servers(1)
 class TestJWTReplication(CBLTestClass):
     """Test Edge Server replication using JWT file-based authentication."""
 

--- a/tests/dev_e2e/edge_server/test_jwt_simple.py
+++ b/tests/dev_e2e/edge_server/test_jwt_simple.py
@@ -25,6 +25,9 @@ SCRIPT_DIR = str(Path(__file__).parent)
 JWT_FILE_PATH = "/home/ec2-user/cert/jwt.txt"
 
 
+@pytest.mark.min_sync_gateways(1)
+@pytest.mark.min_couchbase_servers(1)
+@pytest.mark.min_edge_servers(1)
 class TestJWTSimple(CBLTestClass):
     @pytest.mark.asyncio(loop_scope="session")
     async def test_jwt_replication_reconnect_false(


### PR DESCRIPTION
[CBG-5648](https://jira.issues.couchbase.com/browse/CBG-5648)

### NIGHTLY PR
Implementation : 
- The conftest.py uses a script to mark nightly tests, every test inside /tests/dev_e2e is marked, even Edge Server
- c_macos is used instead of previous swift-ios
- Since the test runs at parent dir level, ie, `/tests/**`, hence the artifacts are stored at parent dir level too

To Be Addressed later : 
- The edge-server tests being marked nightly as well, and hence ignored via the pytest command later
- An XDCR test is currently ignored too since the topology uses a single 2 node CBS cluster, I was looking at a workaround for this, want to file another ticket + PR for that. OUT OF SCOPE for this PR.

Any other issue related to the implementation, eg @torcolvin a workaround to leave edge-server dir out naturally (considering its okay to leave it out of nighly??) can be used.
[Link for the test run for verification](http://jenkins.mobiledev.couchbase.com/view/QE/job/sgw-functional/180/). Ignore the failures, they are because of an old PR **merged to main**, I believe #442, which I will fix soon.

[CBG-5648]: https://couchbasecloud.atlassian.net/browse/CBG-5648?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ