### PR TITLE
TDK - CBS port mapping fix

### DIFF
--- a/client/src/cbltest/api/couchbaseserver.py
+++ b/client/src/cbltest/api/couchbaseserver.py
@@ -874,7 +874,17 @@ class CouchbaseServer:
                 try:
                     self.__http_session.put(
                         f"http://{node_to_add.__hostname}:8091/node/controller/setupAlternateAddresses/external",
-                        data={"hostname": node_to_add.__hostname, "mgmt": "8091"},
+                        data={
+                            "hostname": node_to_add.__hostname,
+                            "kv": "11210",
+                            "kvSSL": "11207",
+                            "mgmt": "8091",
+                            "mgmtSSL": "18091",
+                            "capi": "8092",
+                            "capiSSL": "18092",
+                            "n1ql": "8093",
+                            "n1qlSSL": "18093",
+                        },
                     ).raise_for_status()
                     span.add_event(
                         "alternate_address_set",

--- a/client/src/cbltest/api/couchbaseserver.py
+++ b/client/src/cbltest/api/couchbaseserver.py
@@ -874,17 +874,7 @@ class CouchbaseServer:
                 try:
                     self.__http_session.put(
                         f"http://{node_to_add.__hostname}:8091/node/controller/setupAlternateAddresses/external",
-                        data={
-                            "hostname": node_to_add.__hostname,
-                            "kv": "11210",
-                            "kvSSL": "11207",
-                            "mgmt": "8091",
-                            "mgmtSSL": "18091",
-                            "capi": "8092",
-                            "capiSSL": "18092",
-                            "n1ql": "8093",
-                            "n1qlSSL": "18093",
-                        },
+                        data={"hostname": node_to_add.__hostname, "mgmt": "8091"},
                     ).raise_for_status()
                     span.add_event(
                         "alternate_address_set",

--- a/spec/tests/QE/test_multiple_servers.md
+++ b/spec/tests/QE/test_multiple_servers.md
@@ -41,26 +41,25 @@ Test that Sync Gateway continues to function when a Couchbase Server node fails 
 
 Test Inter-Sync Gateway Replication (ISGR) with explicit collection mapping between different buckets.
 
-1. Clean up any leftover state from all Sync Gateways
-2. Create 3 buckets on single CBS cluster (isgr_bucket1, isgr_bucket2, isgr_bucket3)
-3. Create collections in _default scope for each bucket:
+1. Create 3 buckets on single CBS cluster (isgr_bucket1, isgr_bucket2, isgr_bucket3)
+2. Create collections in _default scope for each bucket:
    - bucket1: collection1, collection2, collection3
    - bucket2: collection4, collection5
    - bucket3: collection6, collection7, collection8, collection9
-4. Configure SG1 with bucket1 (db1), SG2 with bucket2 (db2), SG3 with bucket3 (db3)
-5. Upload 3 docs to each collection in SG1 (collection1, collection2, collection3)
-6. Start one-shot push ISGR from SG1 to SG2 with collection remapping:
+3. Configure SG1 with bucket1 (db1), SG2 with bucket2 (db2), SG3 with bucket3 (db3)
+4. Upload 3 docs to each collection in SG1 (collection1, collection2, collection3)
+5. Start one-shot push ISGR from SG1 to SG2 with collection remapping:
    - _default.collection1 -> _default.collection4
    - _default.collection2 -> _default.collection5
-7. Start one-shot pull ISGR from SG1 to SG3 with collection remapping:
+6. Start one-shot pull ISGR from SG1 to SG3 with collection remapping:
    - _default.collection1 -> _default.collection6
    - _default.collection2 -> _default.collection7
    - _default.collection3 -> _default.collection8
-8. Wait for both ISGR replications to complete (status: stopped)
-9. Verify docs replicated to SG2:
+7. Wait for both ISGR replications to complete (status: stopped)
+8. Verify docs replicated to SG2:
    - collection4 should have docs from collection1
    - collection5 should have docs from collection2
-10. Verify docs replicated to SG3:
-    - collection6 should have docs from collection1
-    - collection7 should have docs from collection2
-    - collection8 should have docs from collection3
+9. Verify docs replicated to SG3:
+   - collection6 should have docs from collection1
+   - collection7 should have docs from collection2
+   - collection8 should have docs from collection3

--- a/tests/QE/test_multiple_servers.py
+++ b/tests/QE/test_multiple_servers.py
@@ -326,7 +326,7 @@ class TestISGRCollectionMapping(CBLTestClass):
     ) -> None:
         sg_cluster = SyncGatewayCluster(cblpytest.sync_gateways)
         cbs = cblpytest.couchbase_servers[0]
-        sg1, sg2, sg3 = sg_cluster.sync_gateways[:2]
+        sg1, sg2, sg3 = sg_cluster.sync_gateways[:3]
         bucket1, bucket2, bucket3 = "isgr-bucket1", "isgr-bucket2", "isgr-bucket3"
         sg_db1, sg_db2, sg_db3 = "db1", "db2", "db3"
         b1_collections = ["collection1", "collection2", "collection3"]

--- a/tests/QE/test_multiple_servers.py
+++ b/tests/QE/test_multiple_servers.py
@@ -66,39 +66,82 @@ async def _setup_database_and_user(
     return await sg.create_user_client(sg_db, user_name, user_password, channels)
 
 
-def _readvertise_external_addresses(cbs_servers: list) -> None:
+def _snapshot_cluster(cbs_servers: list) -> tuple[dict[str, str], set[str]]:
     """
-    Re-advertise the external alternate address on every CBS node so the external
-    test agent's SDK can reach all services (incl. KV). A node that was
-    ejected/re-added or failed-over/recovered can lose its alternate address,
-    leaving it unreachable from outside the VPC; this restores it. Setting only
-    the hostname makes Couchbase Server auto-map all standard service ports --
-    the same thing provisioning's `couchbase-cli setting-alternate-address` does.
+    Capture, from /pools/default, each CBS node's external alternate address and
+    whether it is currently in the cluster -- both keyed by the node's public
+    hostname -- so the cluster can be restored to this exact state after a
+    topology-mutating test.
+
+    :return: (alternate address per hostname, set of in-cluster hostnames)
     """
     session = requests.Session()
     session.auth = ("Administrator", "password")
-    for cbs_node in cbs_servers:
+    resp = session.get(f"http://{cbs_servers[0].hostname}:8091/pools/default")
+    resp.raise_for_status()
+    nodes = resp.json().get("nodes", [])
+
+    addresses: dict[str, str] = {}
+    in_cluster: set[str] = set()
+    for cbs in cbs_servers:
+        for node in nodes:
+            hostname = node.get("hostname", "").split(":")[0]
+            alt = (
+                node.get("alternateAddresses", {})
+                .get("external", {})
+                .get("hostname", "")
+            )
+            if cbs.hostname in (hostname, alt):
+                in_cluster.add(cbs.hostname)
+                addresses[cbs.hostname] = alt or cbs.hostname
+                break
+    return addresses, in_cluster
+
+
+def _restore_cluster(
+    cbs_servers: list, addresses: dict[str, str], in_cluster: set[str]
+) -> None:
+    """
+    Restore the cluster to a captured snapshot: rejoin any ejected node and
+    recover any failed one (rebalancing back to health via
+    ``ensure_cluster_healthy``), then re-advertise each node's captured external
+    alternate address so the external test agent's SDK can reach every service
+    (incl. KV). Setting the hostname alone makes Couchbase Server auto-map all
+    standard service ports -- what provisioning's
+    ``couchbase-cli setting-alternate-address`` also does.
+    """
+    # Membership first: rejoin/recover any node that left, then rebalance.
+    cbs_servers[0].ensure_cluster_healthy(cbs_servers)
+
+    # Then addressing: put back the external alternate address each node had.
+    session = requests.Session()
+    session.auth = ("Administrator", "password")
+    for cbs in cbs_servers:
+        if cbs.hostname not in in_cluster:
+            continue
         session.put(
-            f"http://{cbs_node.hostname}:8091/node/controller/setupAlternateAddresses/external",
-            data={"hostname": cbs_node.hostname},
+            f"http://{cbs.hostname}:8091/node/controller/setupAlternateAddresses/external",
+            data={"hostname": addresses.get(cbs.hostname, cbs.hostname)},
         )
 
 
 @pytest.fixture
 def restore_cbs_cluster(cblpytest: CBLPyTest):
     """
-    Restore the Couchbase Server cluster after a test that mutates its topology
-    (failover / rebalance / eject). After the test, re-add or recover any
-    missing/failed nodes and rebalance back to health, then re-advertise
-    external addresses on all nodes -- so the churn does not leak into later
-    tests and the suite stays order-independent (verify with pytest-random-order).
+    Snapshot the Couchbase Server cluster's node membership + external addresses
+    before a test that mutates its topology (failover / rebalance / eject), and
+    force-restore that snapshot in teardown -- rejoining ejected nodes, recovering
+    failed ones, and re-advertising each node's alternate address -- so cluster
+    churn does not leak into later tests. Keeps the suite order-independent
+    (verify with the pytest-random-order plugin).
     """
-    yield
     cbs_servers = cblpytest.couchbase_servers
     if len(cbs_servers) < 2:
+        yield
         return
-    cbs_servers[0].ensure_cluster_healthy(cbs_servers)
-    _readvertise_external_addresses(cbs_servers)
+    addresses, in_cluster = _snapshot_cluster(cbs_servers)
+    yield
+    _restore_cluster(cbs_servers, addresses, in_cluster)
 
 
 @pytest.mark.usefixtures("restore_cbs_cluster")

--- a/tests/QE/test_multiple_servers.py
+++ b/tests/QE/test_multiple_servers.py
@@ -38,27 +38,6 @@ def _recover_or_add_node(cbs_one, cbs_two):
     cbs_one.rebalance()
 
 
-def _set_alternate_addresses(cbs_servers: list) -> None:
-    """Set alternate addresses with all service ports for all CBS nodes."""
-    session = requests.Session()
-    session.auth = ("Administrator", "password")
-    for cbs_node in cbs_servers:
-        session.put(
-            f"http://{cbs_node.hostname}:8091/node/controller/setupAlternateAddresses/external",
-            data={
-                "hostname": cbs_node.hostname,
-                "kv": "11210",
-                "kvSSL": "11207",
-                "mgmt": "8091",
-                "mgmtSSL": "18091",
-                "capi": "8092",
-                "capiSSL": "18092",
-                "n1ql": "8093",
-                "n1qlSSL": "18093",
-            },
-        )
-
-
 async def _setup_database_and_user(
     sg,
     cbs,
@@ -333,9 +312,6 @@ class TestISGRCollectionMapping(CBLTestClass):
         b2_collections = ["collection4", "collection5"]
         b3_collections = ["collection6", "collection7", "collection8", "collection9"]
         num_docs = 3
-
-        self.mark_test_step("Clean up and setup test environment")
-        _set_alternate_addresses(cblpytest.couchbase_servers)
 
         self.mark_test_step("Create collections in _default scope for each bucket")
         for bucket, collections in [

--- a/tests/QE/test_multiple_servers.py
+++ b/tests/QE/test_multiple_servers.py
@@ -66,6 +66,42 @@ async def _setup_database_and_user(
     return await sg.create_user_client(sg_db, user_name, user_password, channels)
 
 
+def _readvertise_external_addresses(cbs_servers: list) -> None:
+    """
+    Re-advertise the external alternate address on every CBS node so the external
+    test agent's SDK can reach all services (incl. KV). A node that was
+    ejected/re-added or failed-over/recovered can lose its alternate address,
+    leaving it unreachable from outside the VPC; this restores it. Setting only
+    the hostname makes Couchbase Server auto-map all standard service ports --
+    the same thing provisioning's `couchbase-cli setting-alternate-address` does.
+    """
+    session = requests.Session()
+    session.auth = ("Administrator", "password")
+    for cbs_node in cbs_servers:
+        session.put(
+            f"http://{cbs_node.hostname}:8091/node/controller/setupAlternateAddresses/external",
+            data={"hostname": cbs_node.hostname},
+        )
+
+
+@pytest.fixture
+def restore_cbs_cluster(cblpytest: CBLPyTest):
+    """
+    Restore the Couchbase Server cluster after a test that mutates its topology
+    (failover / rebalance / eject). After the test, re-add or recover any
+    missing/failed nodes and rebalance back to health, then re-advertise
+    external addresses on all nodes -- so the churn does not leak into later
+    tests and the suite stays order-independent (verify with pytest-random-order).
+    """
+    yield
+    cbs_servers = cblpytest.couchbase_servers
+    if len(cbs_servers) < 2:
+        return
+    cbs_servers[0].ensure_cluster_healthy(cbs_servers)
+    _readvertise_external_addresses(cbs_servers)
+
+
+@pytest.mark.usefixtures("restore_cbs_cluster")
 @pytest.mark.sgw
 @pytest.mark.min_sync_gateways(1)
 @pytest.mark.min_couchbase_servers(2)


### PR DESCRIPTION
[CBG-5656](https://jira.issues.couchbase.com/browse/CBG-5656)

Addressing fix for failing SGW tests.
After a lot of "doubting" different reasons, I ran with one change. Seems to have fixed everything. Not sure how this for affecting every next test after this as well. I expected the array un-packing would only make this test fail, and there might be some other issue affecting every next test as well. But seems to be the case that this was affecting everything else coming after this. Ran two test runs, TEST LINKS IN THE TICKET ABOVE.

Update on the description : 
The port mapping was not complete in `couchbasesever.py` and `_set_alternate_address` in the test was a defensive repair of cluster addressing that a prior test (TestMultipleServers via add_node) had broken on purpose. With external KV addressing now guaranteed by provisioning (initial) + fixed add_node (after any re-add), the alternate addresses are complete for the entire run. So by the time ISGR reaches its setup, KV is already reachable — and ISGR does need KV (its cbs.create_collections() does a KV readiness get()), which now just works.

[CBG-5656]: https://couchbasecloud.atlassian.net/browse/CBG-5656?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ