### PR TITLE
Route QE pipeline failure/recovery emails to platform owners

### DIFF
--- a/jenkins/pipelines/QE/android/Jenkinsfile
+++ b/jenkins/pipelines/QE/android/Jenkinsfile
@@ -65,4 +65,12 @@ pipeline {
             }
         }
     }
+    post {
+        failure {
+            mail bcc: '', body: "Project: <a href='${env.BUILD_URL}'>${env.JOB_NAME}</a> has failed!", cc: '', charset: 'UTF-8', from: 'jenkins@couchbase.com', mimeType: 'text/html', replyTo: 'no-reply@couchbase.com', subject: "${env.JOB_NAME} failed", to: "barkha.goyal@couchbase.com";
+        }
+        fixed {
+            mail bcc: '', body: "Project: <a href='${env.BUILD_URL}'>${env.JOB_NAME}</a> is back to normal (fixed).", cc: '', charset: 'UTF-8', from: 'jenkins@couchbase.com', mimeType: 'text/html', replyTo: 'no-reply@couchbase.com', subject: "${env.JOB_NAME} fixed", to: "barkha.goyal@couchbase.com";
+        }
+    }
 }

--- a/jenkins/pipelines/QE/c/Jenkinsfile
+++ b/jenkins/pipelines/QE/c/Jenkinsfile
@@ -81,6 +81,12 @@ pipeline {
                             archiveArtifacts artifacts: 'tests/QE/c_macos/**/*', fingerprint: true, allowEmptyArchive: true
                             echo "=== C macOS Test Teardown Complete"
                         }
+                        failure {
+                            mail bcc: '', body: "Project: <a href='${env.BUILD_URL}'>${env.JOB_NAME}</a> (C macOS) has failed!", cc: '', charset: 'UTF-8', from: 'jenkins@couchbase.com', mimeType: 'text/html', replyTo: 'no-reply@couchbase.com', subject: "${env.JOB_NAME} - C macOS failed", to: "sanjivani.patra@couchbase.com";
+                        }
+                        fixed {
+                            mail bcc: '', body: "Project: <a href='${env.BUILD_URL}'>${env.JOB_NAME}</a> (C macOS) is back to normal (fixed).", cc: '', charset: 'UTF-8', from: 'jenkins@couchbase.com', mimeType: 'text/html', replyTo: 'no-reply@couchbase.com', subject: "${env.JOB_NAME} - C macOS fixed", to: "sanjivani.patra@couchbase.com";
+                        }
                     }
                 }
                 stage('iOS') {
@@ -112,6 +118,12 @@ pipeline {
                             }
                             archiveArtifacts artifacts: 'tests/QE/c_ios/**/*', fingerprint: true, allowEmptyArchive: true
                             echo "=== C iOS Test Teardown Complete"
+                        }
+                        failure {
+                            mail bcc: '', body: "Project: <a href='${env.BUILD_URL}'>${env.JOB_NAME}</a> (C iOS) has failed!", cc: '', charset: 'UTF-8', from: 'jenkins@couchbase.com', mimeType: 'text/html', replyTo: 'no-reply@couchbase.com', subject: "${env.JOB_NAME} - C iOS failed", to: "barkha.goyal@couchbase.com";
+                        }
+                        fixed {
+                            mail bcc: '', body: "Project: <a href='${env.BUILD_URL}'>${env.JOB_NAME}</a> (C iOS) is back to normal (fixed).", cc: '', charset: 'UTF-8', from: 'jenkins@couchbase.com', mimeType: 'text/html', replyTo: 'no-reply@couchbase.com', subject: "${env.JOB_NAME} - C iOS fixed", to: "barkha.goyal@couchbase.com";
                         }
                     }
                 }
@@ -145,6 +157,12 @@ pipeline {
                             archiveArtifacts artifacts: 'tests/QE/c_android/**/*', fingerprint: true, allowEmptyArchive: true
                             echo "=== C Android Test Teardown Complete"
                         }
+                        failure {
+                            mail bcc: '', body: "Project: <a href='${env.BUILD_URL}'>${env.JOB_NAME}</a> (C Android) has failed!", cc: '', charset: 'UTF-8', from: 'jenkins@couchbase.com', mimeType: 'text/html', replyTo: 'no-reply@couchbase.com', subject: "${env.JOB_NAME} - C Android failed", to: "barkha.goyal@couchbase.com";
+                        }
+                        fixed {
+                            mail bcc: '', body: "Project: <a href='${env.BUILD_URL}'>${env.JOB_NAME}</a> (C Android) is back to normal (fixed).", cc: '', charset: 'UTF-8', from: 'jenkins@couchbase.com', mimeType: 'text/html', replyTo: 'no-reply@couchbase.com', subject: "${env.JOB_NAME} - C Android fixed", to: "barkha.goyal@couchbase.com";
+                        }
                     }
                 }
                 stage('Linux') {
@@ -169,6 +187,12 @@ pipeline {
                             archiveArtifacts artifacts: 'tests/QE/c_linux/**/*', fingerprint: true, allowEmptyArchive: true
                             echo "=== C Linux Test Teardown Complete"
                         }
+                        failure {
+                            mail bcc: '', body: "Project: <a href='${env.BUILD_URL}'>${env.JOB_NAME}</a> (C Linux) has failed!", cc: '', charset: 'UTF-8', from: 'jenkins@couchbase.com', mimeType: 'text/html', replyTo: 'no-reply@couchbase.com', subject: "${env.JOB_NAME} - C Linux failed", to: "sanjivani.patra@couchbase.com";
+                        }
+                        fixed {
+                            mail bcc: '', body: "Project: <a href='${env.BUILD_URL}'>${env.JOB_NAME}</a> (C Linux) is back to normal (fixed).", cc: '', charset: 'UTF-8', from: 'jenkins@couchbase.com', mimeType: 'text/html', replyTo: 'no-reply@couchbase.com', subject: "${env.JOB_NAME} - C Linux fixed", to: "sanjivani.patra@couchbase.com";
+                        }
                     }
                 }
                 stage('Windows') {
@@ -192,6 +216,12 @@ pipeline {
                             }
                             archiveArtifacts artifacts: 'tests\\QE\\c_windows\\**\\*', fingerprint: true, allowEmptyArchive: true
                             echo "=== C Windows Test Teardown Complete"
+                        }
+                        failure {
+                            mail bcc: '', body: "Project: <a href='${env.BUILD_URL}'>${env.JOB_NAME}</a> (C Windows) has failed!", cc: '', charset: 'UTF-8', from: 'jenkins@couchbase.com', mimeType: 'text/html', replyTo: 'no-reply@couchbase.com', subject: "${env.JOB_NAME} - C Windows failed", to: "barkha.goyal@couchbase.com";
+                        }
+                        fixed {
+                            mail bcc: '', body: "Project: <a href='${env.BUILD_URL}'>${env.JOB_NAME}</a> (C Windows) is back to normal (fixed).", cc: '', charset: 'UTF-8', from: 'jenkins@couchbase.com', mimeType: 'text/html', replyTo: 'no-reply@couchbase.com', subject: "${env.JOB_NAME} - C Windows fixed", to: "barkha.goyal@couchbase.com";
                         }
                     }
                 }

--- a/jenkins/pipelines/QE/dotnet/Jenkinsfile
+++ b/jenkins/pipelines/QE/dotnet/Jenkinsfile
@@ -178,11 +178,11 @@ pipeline {
         }
     }
     post {
-        success {
-            mail bcc: '', body: "Project: <a href='${env.BUILD_URL}'>${env.JOB_NAME}</a> succeeded.", cc: '', charset: 'UTF-8', from: 'jenkins@couchbase.com', mimeType: 'text/html', replyTo: 'no-reply@couchbase.com', subject: "${env.JOB_NAME} succeeded", to: "sanjivani.patra@couchbase.com";
+        failure {
+            mail bcc: '', body: "Project: <a href='${env.BUILD_URL}'>${env.JOB_NAME}</a> has failed!", cc: '', charset: 'UTF-8', from: 'jenkins@couchbase.com', mimeType: 'text/html', replyTo: 'no-reply@couchbase.com', subject: "${env.JOB_NAME} failed", to: "sanjivani.patra@couchbase.com";
         }
-        regression {
-            mail bcc: '', body: "Project: <a href='${env.BUILD_URL}'>${env.JOB_NAME}</a> regressed (first failure after success).", cc: '', charset: 'UTF-8', from: 'jenkins@couchbase.com', mimeType: 'text/html', replyTo: 'no-reply@couchbase.com', subject: "${env.JOB_NAME} regressed", to: "sanjivani.patra@couchbase.com";
+        fixed {
+            mail bcc: '', body: "Project: <a href='${env.BUILD_URL}'>${env.JOB_NAME}</a> is back to normal (fixed).", cc: '', charset: 'UTF-8', from: 'jenkins@couchbase.com', mimeType: 'text/html', replyTo: 'no-reply@couchbase.com', subject: "${env.JOB_NAME} fixed", to: "sanjivani.patra@couchbase.com";
         }
     }
 }

--- a/jenkins/pipelines/QE/ios/Jenkinsfile
+++ b/jenkins/pipelines/QE/ios/Jenkinsfile
@@ -59,11 +59,11 @@ pipeline {
         }
     }
     post {
-        success {
-            mail bcc: '', body: "Project: <a href='${env.BUILD_URL}'>${env.JOB_NAME}</a> succeeded.", cc: '', charset: 'UTF-8', from: 'jenkins@couchbase.com', mimeType: 'text/html', replyTo: 'no-reply@couchbase.com', subject: "${env.JOB_NAME} succeeded", to: "sanjivani.patra@couchbase.com";
+        failure {
+            mail bcc: '', body: "Project: <a href='${env.BUILD_URL}'>${env.JOB_NAME}</a> has failed!", cc: '', charset: 'UTF-8', from: 'jenkins@couchbase.com', mimeType: 'text/html', replyTo: 'no-reply@couchbase.com', subject: "${env.JOB_NAME} failed", to: "sanjivani.patra@couchbase.com";
         }
-        regression {
-            mail bcc: '', body: "Project: <a href='${env.BUILD_URL}'>${env.JOB_NAME}</a> regressed (first failure after success).", cc: '', charset: 'UTF-8', from: 'jenkins@couchbase.com', mimeType: 'text/html', replyTo: 'no-reply@couchbase.com', subject: "${env.JOB_NAME} regressed", to: "sanjivani.patra@couchbase.com";
+        fixed {
+            mail bcc: '', body: "Project: <a href='${env.BUILD_URL}'>${env.JOB_NAME}</a> is back to normal (fixed).", cc: '', charset: 'UTF-8', from: 'jenkins@couchbase.com', mimeType: 'text/html', replyTo: 'no-reply@couchbase.com', subject: "${env.JOB_NAME} fixed", to: "sanjivani.patra@couchbase.com";
         }
     }
 }

--- a/jenkins/pipelines/QE/java/Jenkinsfile
+++ b/jenkins/pipelines/QE/java/Jenkinsfile
@@ -142,4 +142,12 @@ pipeline {
             }
         }
     }
+    post {
+        failure {
+            mail bcc: '', body: "Project: <a href='${env.BUILD_URL}'>${env.JOB_NAME}</a> has failed!", cc: '', charset: 'UTF-8', from: 'jenkins@couchbase.com', mimeType: 'text/html', replyTo: 'no-reply@couchbase.com', subject: "${env.JOB_NAME} failed", to: "barkha.goyal@couchbase.com";
+        }
+        fixed {
+            mail bcc: '', body: "Project: <a href='${env.BUILD_URL}'>${env.JOB_NAME}</a> is back to normal (fixed).", cc: '', charset: 'UTF-8', from: 'jenkins@couchbase.com', mimeType: 'text/html', replyTo: 'no-reply@couchbase.com', subject: "${env.JOB_NAME} fixed", to: "barkha.goyal@couchbase.com";
+        }
+    }
 }

--- a/jenkins/pipelines/QE/sgw/Jenkinsfile
+++ b/jenkins/pipelines/QE/sgw/Jenkinsfile
@@ -77,5 +77,8 @@ pipeline {
         failure {
             mail bcc: '', body: "Project: <a href='${env.BUILD_URL}'>${env.JOB_NAME}</a> has failed!", cc: '', charset: 'UTF-8', from: 'jenkins@couchbase.com', mimeType: 'text/html', replyTo: 'no-reply@couchbase.com', subject: "${env.JOB_NAME} failed", to: "vipul.bhardwaj@couchbase.com";
         }
+        fixed {
+            mail bcc: '', body: "Project: <a href='${env.BUILD_URL}'>${env.JOB_NAME}</a> is back to normal (fixed).", cc: '', charset: 'UTF-8', from: 'jenkins@couchbase.com', mimeType: 'text/html', replyTo: 'no-reply@couchbase.com', subject: "${env.JOB_NAME} fixed", to: "vipul.bhardwaj@couchbase.com";
+        }
     }
 }


### PR DESCRIPTION
This PR standardises email notifications across the QE Jenkins pipelines to a `failure` + `fixed` model and routes each pipeline to its owner. With `failure` + `fixed`, a break is caught immediately, a persistently-broken job keeps nagging until addressed, and a single "fixed" email confirms recovery - with no noise on green days.